### PR TITLE
Revert "Prepare for Package Release"

### DIFF
--- a/realsense_navigation/CMakeLists.txt
+++ b/realsense_navigation/CMakeLists.txt
@@ -9,18 +9,3 @@ find_package(catkin REQUIRED)
 
 # Declare this project as a catkin package
 catkin_package()
-
-# Install launch files
-install(DIRECTORY launch/
-    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
-)
-
-# Install rviz files
-install(DIRECTORY rviz/
-    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/rviz
-)
-
-# Install config files
-install(DIRECTORY config/
-    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/config
-)

--- a/realsense_navigation/package.xml
+++ b/realsense_navigation/package.xml
@@ -1,27 +1,23 @@
 <?xml version="1.0"?>
-<package format="2">
+<package>
   <name>realsense_navigation</name>
   <version>1.1.0</version>
   <description>RealSense Camera navigation package allowing use of Intel 3D cameras with the navigation stack</description>
 
+  <maintainer email="amit.moran@intel.com">Amit Moran</maintainer>
   <maintainer email="matthew.c.curfman@intel.com">Matt Curfman</maintainer>
-  <maintainer email="mark.d.horn@intel.com">Mark Horn</maintainer>
 
   <license>BSD 3-clause. See license attached</license>
 
   <url type="website">http://www.ros.org/wiki/RealSense</url>
 
   <author email="amit.moran@intel.com">Amit Moran</author>
+  <author email="matthew.c.curfman@intel.com">Matt Curfman</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-
-  <exec_depend>roslaunch</exec_depend>
-  <exec_depend>realsense_camera</exec_depend>
-  <exec_depend>turtlebot_bringup</exec_depend>
-  <exec_depend>turtlebot_navigation</exec_depend>
-  <exec_depend>map_server</exec_depend>
-  <exec_depend>rviz</exec_depend>
-  <exec_depend>rosbag</exec_depend>
-  <exec_depend>amcl</exec_depend>
-  <exec_depend>gmapping</exec_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>rospy</build_depend>
+ 
+  <run_depend>roscpp</run_depend>
+  <run_depend>rospy</run_depend>
 </package>


### PR DESCRIPTION
Reverts intel-ros/realsense#59

Requirement for turtlebot_navigation under Kinetic breaks the build.
