### PR TITLE
[realsense_camera/CMakeLists.txt] fix: finding librealsense library

### DIFF
--- a/realsense_camera/CMakeLists.txt
+++ b/realsense_camera/CMakeLists.txt
@@ -14,10 +14,26 @@ set(CMAKE_EXE_LINKER_FLAGS "-pie -z noexecstack -z relro -z now")
 # Flags shared libraries
 set(CMAKE_SHARED_LINKER_FLAGS "-z noexecstack -z relro -z now")
 
-find_library(REALSENSE_LIB realsense)
-
 # This is optional until the first release of librealsense as a ROS package
-find_package(catkin OPTIONAL_COMPONENTS librealsense)
+find_package(librealsense)
+
+# This should be removed once librealsense is a required component
+if(NOT librealsense_FOUND)
+  find_library(REALSENSE_LIB realsense)
+  if(NOT REALSENSE_LIB)
+    message(FATAL_ERROR "librealsense library not found")
+  endif()
+  find_path(REALSENSE_INCLUDE_DIR
+    NAMES rs rsutil
+    PATHS /usr/include /usr/local/include
+    PATH_SUFFIXES include)
+  if(REALSENSE_INCLUDE_DIR)
+    include_directories(${REALSENSE_INCLUDE_DIR})
+  else()
+    message(FATAL_ERROR "librealsense header files not found")
+  endif()
+endif()
+
 find_package(catkin REQUIRED COMPONENTS
   dynamic_reconfigure
   roscpp


### PR DESCRIPTION
## Issue
- No clear error if library was not found in CMake.
- `find_package(catkin OPTIONAL_COMPONENTS ...)` was always overridden by `find_package(catkin REQUIRED COMPONENTS ...)`. (library path for `librealsense` was always not written in `catkin_LIBRARIES`)
- In current `CMakeLists.txt`, build system at first finds `realsense` (assumed to be installed without catkin), then re-finds `librealsense` (catkin package version). This could occur runtime error (`undefined symbol`) when `realsense` library (which is installed without catkin) is old.
## Solution
- fix: avoid to find_package catkin twice
- find `librealsense` catkin package at first, and if not found then find `realsense` library by manual
