### PR TITLE
[realsense_camera/CMakeLists.txt] fix: testing

### DIFF
--- a/realsense_camera/CMakeLists.txt
+++ b/realsense_camera/CMakeLists.txt
@@ -29,7 +29,6 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
   std_msgs
   sensor_msgs
-  rostest
   pcl_ros
 )
 
@@ -78,22 +77,6 @@ target_link_libraries(${PROJECT_NAME}_nodelet
 add_dependencies(${PROJECT_NAME}_nodelet ${PROJECT_NAME}_generate_messages_cpp ${PROJECT_NAME}_gencfg)
 add_dependencies(${PROJECT_NAME}_nodelet ${catkin_EXPORTED_TARGETS})
 
-add_executable(tests_camera_core test/camera_core.cpp)
-target_link_libraries(tests_camera_core
-  ${catkin_LIBRARIES}
-  ${GTEST_LIBRARIES}
-)
-add_dependencies(tests_camera_core ${PROJECT_NAME}_generate_messages_cpp ${PROJECT_NAME}_gencfg)
-add_dependencies(tests_camera_core ${catkin_EXPORTED_TARGETS})
-
-add_executable(tests_rgbd_topics test/rgbd_topics.cpp)
-target_link_libraries(tests_rgbd_topics
-  ${catkin_LIBRARIES}
-  ${GTEST_LIBRARIES}
-)
-add_dependencies(tests_rgbd_topics ${PROJECT_NAME}_generate_messages_cpp)
-add_dependencies(tests_rgbd_topics ${catkin_EXPORTED_TARGETS})
-
 # Install nodelet library
 install(TARGETS ${PROJECT_NAME}_nodelet LIBRARY
     DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
@@ -118,3 +101,27 @@ install(DIRECTORY rviz/
 install(FILES nodelet_plugins.xml
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+  add_executable(tests_camera_core test/camera_core.cpp)
+  target_link_libraries(tests_camera_core
+    ${catkin_LIBRARIES}
+    ${GTEST_LIBRARIES}
+    )
+  add_dependencies(tests_camera_core ${PROJECT_NAME}_generate_messages_cpp ${PROJECT_NAME}_gencfg)
+  add_dependencies(tests_camera_core ${catkin_EXPORTED_TARGETS})
+
+  add_executable(tests_rgbd_topics test/rgbd_topics.cpp)
+  target_link_libraries(tests_rgbd_topics
+    ${catkin_LIBRARIES}
+    ${GTEST_LIBRARIES}
+    )
+  add_dependencies(tests_rgbd_topics ${PROJECT_NAME}_generate_messages_cpp)
+  add_dependencies(tests_rgbd_topics ${catkin_EXPORTED_TARGETS})
+
+  # add_rostest(test/r200_nodelet_disable_color.test)
+  # add_rostest(test/r200_nodelet_disable_depth.test)
+  # add_rostest(test/r200_nodelet_modify_params.test)
+  # add_rostest(test/r200_nodelet_resolution.test)
+endif()


### PR DESCRIPTION
- testing is not needed on build time.
- we can use `CATKIN_ENABLE_TESTING` variable to disable testing on build time.
- we can run test by `catkin run_tests realsense_camera`.
