### PR TITLE
Add support for SR300

### DIFF
--- a/realsense_camera/CMakeLists.txt
+++ b/realsense_camera/CMakeLists.txt
@@ -47,6 +47,7 @@ generate_messages(
 generate_dynamic_reconfigure_options(
   cfg/r200_params.cfg
   cfg/f200_params.cfg
+  cfg/sr300_params.cfg
 )
 
 #################################
@@ -70,7 +71,7 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
 )
 
-add_library(${PROJECT_NAME}_nodelet src/base_nodelet.cpp src/r200_nodelet.cpp src/f200_nodelet.cpp)
+add_library(${PROJECT_NAME}_nodelet src/base_nodelet.cpp src/r200_nodelet.cpp src/f200_nodelet.cpp src/sr300_nodelet.cpp)
 target_link_libraries(${PROJECT_NAME}_nodelet
   ${catkin_LIBRARIES}
   # This should be removed once librealsense is a required component

--- a/realsense_camera/cfg/sr300_params.cfg
+++ b/realsense_camera/cfg/sr300_params.cfg
@@ -6,21 +6,21 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
-#             Name                               Type      Level       Description                     Default    Min     Max
-gen.add("enable_depth",                          bool_t,   0,          "Enable Depth",                 True)
-gen.add("color_backlight_compensation",          int_t,    0,          "Backlight Compensation",       1,         0,      4)
-gen.add("color_brightness",                      int_t,    0,          "Brightness",                   55,        0,      255)
-gen.add("color_contrast",                        int_t,    0,          "Contrast",                     32,        16,     64)
-gen.add("color_gain",                            int_t,    0,          "Gain",                         64,        64,     2540)
-gen.add("color_gamma",                           int_t,    0,          "Gamma",                        220,       100,    280)
-gen.add("color_hue",                             int_t,    0,          "Hue",                          0,         -22,    22)
-gen.add("color_saturation",                      int_t,    0,          "Saturation",                   128,       0,      255)
-gen.add("color_sharpness",                       int_t,    0,          "Sharpness",                    0,         0,      7)
+#             Name                                     Type    Level Description                     Default    Min     Max
+gen.add("enable_depth",                                bool_t, 0,    "Enable Depth",                 True)
+gen.add("color_backlight_compensation",                int_t,  0,    "Backlight Compensation",       1,         0,      4)
+gen.add("color_brightness",                            int_t,  0,    "Brightness",                   0,         0,      255)
+gen.add("color_contrast",                              int_t,  0,    "Contrast",                     50,        16,     64)
+gen.add("color_gain",                                  int_t,  0,    "Gain",                         64,        64,     2540)
+gen.add("color_gamma",                                 int_t,  0,    "Gamma",                        300,       100,    512)
+gen.add("color_hue",                                   int_t,  0,    "Hue",                          0,         -22,    22)
+gen.add("color_saturation",                            int_t,  0,    "Saturation",                   64,        0,      255)
+gen.add("color_sharpness",                             int_t,  0,    "Sharpness",                    50,        0,      128)
 
 # Must be set only if color_enable_auto_white_balance is disabled
-gen.add("color_white_balance",                   int_t,    0,          "White Balance",                3200,      2500,   6500)
+gen.add("color_white_balance",                         int_t,  0,    "White Balance",                4600,      2500,   6500)
 
-gen.add("color_enable_auto_white_balance",       int_t,    0,          "Enable Auto White Balance",    1,         0,      1)
+gen.add("color_enable_auto_white_balance",             int_t,  0,    "Enable Auto White Balance",    1,         0,      1)
 
 # Options common with f200
 gen.add("f200_laser_power",                            int_t,  0,    "Laser Power",                  16,        1,      16)
@@ -29,23 +29,27 @@ gen.add("f200_motion_range",                           int_t,  0,    "Motion Ran
 gen.add("f200_filter_option",                          int_t,  0,    "Filter Option",                5,         1,      7)
 gen.add("f200_confidence_threshold",                   int_t,  0,    "Confidence Threshold",         6,         1,      15)
 
-gen.add("sr300_dynamic_fps", int_t, 0, "Dynamic Fps", 1, 2, 60)
-gen.add("sr300_auto_range_enable_motion_versus_range", int_t, 0, "Auto Range Enable Motion Versus Range", 1, 0, 2)
-gen.add("sr300_auto_range_enable_laser", int_t, 0, "Auto Range Enable Laser", 1, 0, 1)
-gen.add("sr300_auto_range_min_motion_versus_range", int_t, 0, "Auto Range Min Motion Versus Range", 1, -32767, 32767)
-gen.add("sr300_auto_range_max_motion_versus_range", int_t, 0, "Auto Range Max Motion Versus Range", 1, -32767, 32767)
-gen.add("sr300_auto_range_start_motion_versus_range", int_t, 0, "Auto Range Start Motion Versus Range", 1, -32767, 32767)
-gen.add("sr300_auto_range_min_laser", int_t, 0, "Auto Range Min Laser", 1, -32767, 32767)
-gen.add("sr300_auto_range_max_laser", int_t, 0, "Auto Range Max Laser", 1, -32767, 32767)
-gen.add("sr300_auto_range_start_laser", int_t, 0, "Auto Range Start Laser", 1, -32767, 32767)
-gen.add("sr300_auto_range_upper_threshold", int_t, 0, "Auto Range Upper Threshold", 0, 0, 65535)
-gen.add("sr300_auto_range_lower_threshold", int_t, 0, "Auto Range Lower Threshold", 0, 0, 65535)
-gen.add("sr300_wakeup_dev_phase1_period", int_t, 0, "Wakeup Dev Phase1 Period", 1, 0, 65535)
-gen.add("sr300_wakeup_dev_phase1_fps", int_t, 0, "Wakeup Dev Phase1 Fps", 1, 0, 3)
-gen.add("sr300_wakeup_dev_phase2_period", int_t, 0, "Wakeup Dev Phase2 Period", 1, 0, 65535)
-gen.add("sr300_wakeup_dev_phase2_fps", int_t, 0, "Wakeup Dev Phase2 Fps", 1, 0, 3)
-gen.add("sr300_wakeup_dev_reset", int_t, 0, "Wakeup Dev Reset", 1, 0, 0)
-gen.add("sr300_wake_on_usb_reason", int_t, 0, "Wake On Usb Reason", 1, 0, 3)
-gen.add("sr300_wake_on_usb_confidence", int_t, 0, "Wake On Usb Confidence" , 1, 0, 100)
+gen.add("sr300_dynamic_fps",                           int_t,  0,    "Dynamic Fps",                  0,         0,      0)
+
+# Auto range
+gen.add("sr300_auto_range_enable_motion_versus_range", int_t,  0,    "Enable Motion Versus Range",   1,         0,      2)
+gen.add("sr300_auto_range_enable_laser",               int_t,  0,    "Enable Laser",                 1,         0,      1)
+gen.add("sr300_auto_range_min_motion_versus_range",    int_t,  0,    "Min Motion Versus Range",      180,       -32767, 32767)
+gen.add("sr300_auto_range_max_motion_versus_range",    int_t,  0,    "Max Motion Versus Range",      605,       -32767, 32767)
+gen.add("sr300_auto_range_start_motion_versus_range",  int_t,  0,    "Start Motion Versus Range",    303,       -32767, 32767)
+gen.add("sr300_auto_range_min_laser",                  int_t,  0,    "Min Laser",                    2,         -32767, 32767)
+gen.add("sr300_auto_range_max_laser",                  int_t,  0,    "Max Laser",                    16,        -32767, 32767)
+gen.add("sr300_auto_range_start_laser",                int_t,  0,    "Start Laser",                  -1,        -32767, 32767)
+gen.add("sr300_auto_range_upper_threshold",            int_t,  0,    "Upper Threshold",              1250,      0,      65535)
+gen.add("sr300_auto_range_lower_threshold",            int_t,  0,    "Lower Threshold",              650,       0,      65535)
+
+# Wake up
+gen.add("sr300_wakeup_dev_phase1_period",              int_t,  0,    "Dev Phase1 Period",            1,         0,      65535)
+gen.add("sr300_wakeup_dev_phase1_fps",                 int_t,  0,    "Dev Phase1 Fps",               1,         0,      3)
+gen.add("sr300_wakeup_dev_phase2_period",              int_t,  0,    "Dev Phase2 Period",            1,         0,      65535)
+gen.add("sr300_wakeup_dev_phase2_fps",                 int_t,  0,    "Dev Phase2 Fps",               1,         0,      3)
+gen.add("sr300_wakeup_dev_reset",                      int_t,  0,    "Dev Reset",                    1,         0,      0)
+gen.add("sr300_wake_on_usb_reason",                    int_t,  0,    "Wake On Usb Reason",           1,         0,      3)
+gen.add("sr300_wake_on_usb_confidence",                int_t,  0,    "Wake On Usb Confidence" ,      1,         0,      100)
 
 exit(gen.generate(PACKAGE, "realsense_camera", "sr300_params"))

--- a/realsense_camera/cfg/sr300_params.cfg
+++ b/realsense_camera/cfg/sr300_params.cfg
@@ -22,6 +22,13 @@ gen.add("color_white_balance",                   int_t,    0,          "White Ba
 
 gen.add("color_enable_auto_white_balance",       int_t,    0,          "Enable Auto White Balance",    1,         0,      1)
 
+# Options common with f200
+gen.add("f200_laser_power",                            int_t,  0,    "Laser Power",                  16,        1,      16)
+gen.add("f200_accuracy",                               int_t,  0,    "Accuracy",                     2,         1,      3)
+gen.add("f200_motion_range",                           int_t,  0,    "Motion Range",                 1,         1,      100)
+gen.add("f200_filter_option",                          int_t,  0,    "Filter Option",                5,         1,      7)
+gen.add("f200_confidence_threshold",                   int_t,  0,    "Confidence Threshold",         6,         1,      15)
+
 gen.add("sr300_dynamic_fps", int_t, 0, "Dynamic Fps", 1, 2, 60)
 gen.add("sr300_auto_range_enable_motion_versus_range", int_t, 0, "Auto Range Enable Motion Versus Range", 1, 0, 2)
 gen.add("sr300_auto_range_enable_laser", int_t, 0, "Auto Range Enable Laser", 1, 0, 1)

--- a/realsense_camera/cfg/sr300_params.cfg
+++ b/realsense_camera/cfg/sr300_params.cfg
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+PACKAGE="realsense_camera"
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+#             Name                               Type      Level       Description                     Default    Min     Max
+gen.add("enable_depth",                          bool_t,   0,          "Enable Depth",                 True)
+gen.add("color_backlight_compensation",          int_t,    0,          "Backlight Compensation",       1,         0,      4)
+gen.add("color_brightness",                      int_t,    0,          "Brightness",                   55,        0,      255)
+gen.add("color_contrast",                        int_t,    0,          "Contrast",                     32,        16,     64)
+gen.add("color_gain",                            int_t,    0,          "Gain",                         64,        64,     2540)
+gen.add("color_gamma",                           int_t,    0,          "Gamma",                        220,       100,    280)
+gen.add("color_hue",                             int_t,    0,          "Hue",                          0,         -22,    22)
+gen.add("color_saturation",                      int_t,    0,          "Saturation",                   128,       0,      255)
+gen.add("color_sharpness",                       int_t,    0,          "Sharpness",                    0,         0,      7)
+
+# Must be set only if color_enable_auto_white_balance is disabled
+gen.add("color_white_balance",                   int_t,    0,          "White Balance",                3200,      2500,   6500)
+
+gen.add("color_enable_auto_white_balance",       int_t,    0,          "Enable Auto White Balance",    1,         0,      1)
+
+gen.add("sr300_dynamic_fps", int_t, 0, "Dynamic Fps", 1, 2, 60)
+gen.add("sr300_auto_range_enable_motion_versus_range", int_t, 0, "Auto Range Enable Motion Versus Range", 1, 0, 2)
+gen.add("sr300_auto_range_enable_laser", int_t, 0, "Auto Range Enable Laser", 1, 0, 1)
+gen.add("sr300_auto_range_min_motion_versus_range", int_t, 0, "Auto Range Min Motion Versus Range", 1, -32767, 32767)
+gen.add("sr300_auto_range_max_motion_versus_range", int_t, 0, "Auto Range Max Motion Versus Range", 1, -32767, 32767)
+gen.add("sr300_auto_range_start_motion_versus_range", int_t, 0, "Auto Range Start Motion Versus Range", 1, -32767, 32767)
+gen.add("sr300_auto_range_min_laser", int_t, 0, "Auto Range Min Laser", 1, -32767, 32767)
+gen.add("sr300_auto_range_max_laser", int_t, 0, "Auto Range Max Laser", 1, -32767, 32767)
+gen.add("sr300_auto_range_start_laser", int_t, 0, "Auto Range Start Laser", 1, -32767, 32767)
+gen.add("sr300_auto_range_upper_threshold", int_t, 0, "Auto Range Upper Threshold", 0, 0, 65535)
+gen.add("sr300_auto_range_lower_threshold", int_t, 0, "Auto Range Lower Threshold", 0, 0, 65535)
+gen.add("sr300_wakeup_dev_phase1_period", int_t, 0, "Wakeup Dev Phase1 Period", 1, 0, 65535)
+gen.add("sr300_wakeup_dev_phase1_fps", int_t, 0, "Wakeup Dev Phase1 Fps", 1, 0, 3)
+gen.add("sr300_wakeup_dev_phase2_period", int_t, 0, "Wakeup Dev Phase2 Period", 1, 0, 65535)
+gen.add("sr300_wakeup_dev_phase2_fps", int_t, 0, "Wakeup Dev Phase2 Fps", 1, 0, 3)
+gen.add("sr300_wakeup_dev_reset", int_t, 0, "Wakeup Dev Reset", 1, 0, 0)
+gen.add("sr300_wake_on_usb_reason", int_t, 0, "Wake On Usb Reason", 1, 0, 3)
+gen.add("sr300_wake_on_usb_confidence", int_t, 0, "Wake On Usb Confidence" , 1, 0, 100)
+
+exit(gen.generate(PACKAGE, "realsense_camera", "sr300_params"))

--- a/realsense_camera/include/realsense_camera/constants.h
+++ b/realsense_camera/include/realsense_camera/constants.h
@@ -71,5 +71,8 @@ namespace realsense_camera
 
     // F200 Constants.
     const int F200_MAX_Z = 1;      // in meters
+
+    // SR300 Constants.
+    const int SR300_MAX_Z = 1;      // in meters
 }
 #endif

--- a/realsense_camera/include/realsense_camera/sr300_nodelet.h
+++ b/realsense_camera/include/realsense_camera/sr300_nodelet.h
@@ -1,0 +1,59 @@
+/******************************************************************************
+ Copyright (c) 2016, Intel Corporation
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ 3. Neither the name of the copyright holder nor the names of its contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+#pragma once
+#ifndef SR300_NODELET
+#define SR300_NODELET
+
+#include <dynamic_reconfigure/server.h>
+
+#include <realsense_camera/sr300_paramsConfig.h>
+#include <realsense_camera/base_nodelet.h>
+
+namespace realsense_camera
+{
+  class SR300Nodelet: public realsense_camera::BaseNodelet
+  {
+  public:
+
+    void onInit();
+
+  protected:
+
+    // Member Variables.
+    boost::shared_ptr<dynamic_reconfigure::Server<realsense_camera::sr300_paramsConfig>> dynamic_reconf_server_;
+
+    // Member Functions.
+    std::vector<std::string> setDynamicReconfServer();
+    void startDynamicReconfCallback();
+    void configCallback(realsense_camera::sr300_paramsConfig &config, uint32_t level);
+  };
+}
+#endif

--- a/realsense_camera/launch/sr300_nodelet_default.launch
+++ b/realsense_camera/launch/sr300_nodelet_default.launch
@@ -1,4 +1,4 @@
-<!-- Sample launch file for using RealSense F200 camera with default configurations -->
+<!-- Sample launch file for using RealSense SR300 camera with default configurations -->
 <launch>
   <arg name="manager"      value="nodelet_manager" />
   <arg name="camera"       default="camera" />

--- a/realsense_camera/launch/sr300_nodelet_default.launch
+++ b/realsense_camera/launch/sr300_nodelet_default.launch
@@ -1,0 +1,18 @@
+<!-- Sample launch file for using RealSense F200 camera with default configurations -->
+<launch>
+  <arg name="manager"      value="nodelet_manager" />
+  <arg name="camera"       default="camera" />
+  <arg name="camera_type"  default="SR300" /> <!-- Type of camera -->
+  <arg name="serial_no"    default="" />
+  <arg name="usb_port_id"  default="" /> <!-- USB "Bus#-Port#" -->
+
+  <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>
+
+  <include file="$(find realsense_camera)/launch/includes/nodelet.launch.xml">
+    <arg name="manager"      value="$(arg manager)" />
+    <arg name="camera"       value="$(arg camera)" />
+    <arg name="camera_type"  value="$(arg camera_type)" />
+    <arg name="serial_no"    value="$(arg serial_no)" />
+    <arg name="usb_port_id"  value="$(arg usb_port_id)" />
+  </include>
+</launch>

--- a/realsense_camera/launch/sr300_nodelet_rgbd.launch
+++ b/realsense_camera/launch/sr300_nodelet_rgbd.launch
@@ -1,0 +1,86 @@
+<!-- Sample launch file for using RealSense SR300 camera with default configurations -->
+<launch>
+  <arg name="camera"             default="camera" />
+  <arg name="camera_type"        default="SR300" /> <!-- Type of camera -->
+  <arg name="serial_no"          default="" />
+  <arg name="usb_port_id"        default="" /> <!-- USB "Bus#-Port#" -->
+
+  <!-- Best know configuration for generating depth registered point cloud. -->
+  <arg name="mode"            default="manual" />
+  <arg name="color_width"     default="640" />
+  <arg name="color_height"    default="480" />
+  <arg name="depth_width"     default="640" />
+  <arg name="depth_height"    default="480" />
+  <arg name="depth_fps"       default="60" />
+  <arg name="color_fps"       default="60" />
+
+
+  <!-- Optionally suppress loading the driver nodelet. Useful while playing back recorded raw data from a bag.-->
+  <arg name="load_driver"   default="true" />
+  <arg name="publish_tf"    default="true" />
+
+  <!-- Processing Modules -->
+  <arg name="rgb_processing"                  default="true"/>
+  <arg name="ir_processing"                   default="true"/>
+  <arg name="depth_processing"                default="true"/>
+  <arg name="depth_registered_processing"     default="true"/>
+  <arg name="disparity_processing"            default="false"/>
+  <arg name="disparity_registered_processing" default="false"/>
+  <arg name="hw_registered_processing"        default="false" />
+  <arg name="sw_registered_processing"        default="true" />
+  <arg name="enable_pointcloud"               default="true" />
+
+  <!-- Disable respawn topics by default -->
+  <arg name="respawn" default="false" />
+
+  <!-- Worker threads for the nodelet manager -->
+  <arg name="num_worker_threads" default="4" />
+
+  <!-- Push down all topics/nodelets into "camera" namespace -->
+  <group ns="$(arg camera)">
+
+    <!-- Start nodelet manager in provided namespace -->
+    <arg name="manager" value="$(arg camera)_nodelet_manager" />
+    <arg name="debug" default="false" /> <!-- Run manager in GDB? -->
+    <include file="$(find rgbd_launch)/launch/includes/manager.launch.xml">
+      <arg name="name"                value="$(arg manager)" />
+      <arg name="debug"               value="$(arg debug)" />
+      <arg name="num_worker_threads"  value="$(arg num_worker_threads)" />
+    </include>
+
+    <!-- Load driver -->
+    <include if="$(arg load_driver)"
+             file="$(find realsense_camera)/launch/includes/nodelet_rgbd.launch.xml">
+      <arg name="manager"          value="$(arg manager)" />
+      <arg name="camera"           value="$(arg camera)" />
+      <arg name="camera_type"      value="$(arg camera_type)" />
+      <arg name="serial_no"        value="$(arg serial_no)" />
+      <arg name="usb_port_id"      value="$(arg usb_port_id)" />
+      <arg name="depth_processing" value="$(arg depth_processing)" />
+      <arg name="rgb_processing"   value="$(arg rgb_processing)" />
+      <arg name="ir_processing"    value="$(arg ir_processing)" />
+      <arg name="publish_tf"       value="$(arg publish_tf)" />
+      <arg name="mode"             value="$(arg mode)" />
+      <arg name="depth_width"      value="$(arg depth_width)" />
+      <arg name="depth_height"     value="$(arg depth_height)" />
+      <arg name="color_width"      value="$(arg color_width)" />
+      <arg name="color_height"     value="$(arg color_height)" />
+      <arg name="depth_fps"        value="$(arg depth_fps)" />
+      <arg name="color_fps"        value="$(arg color_fps)" />
+    </include>
+
+    <!-- Load standard constellation of processing nodelets -->
+    <include file="$(find rgbd_launch)/launch/includes/processing.launch.xml">
+      <arg name="manager"                         value="$(arg manager)" />
+      <arg name="respawn"                         value="$(arg respawn)" />
+      <arg name="rgb_processing"                  value="$(arg rgb_processing)" />
+      <arg name="ir_processing"                   value="$(arg ir_processing)" />
+      <arg name="depth_processing"                value="$(arg depth_processing)" />
+      <arg name="depth_registered_processing"     value="$(arg depth_registered_processing)" />
+      <arg name="disparity_processing"            value="$(arg disparity_processing)" />
+      <arg name="disparity_registered_processing" value="$(arg disparity_registered_processing)" />
+      <arg name="hw_registered_processing"        value="$(arg hw_registered_processing)" />
+      <arg name="sw_registered_processing"        value="$(arg sw_registered_processing)" />
+    </include>
+  </group>
+</launch>

--- a/realsense_camera/nodelet_plugins.xml
+++ b/realsense_camera/nodelet_plugins.xml
@@ -10,4 +10,10 @@
   Intel(R) RealSense(TM) F200 Camera nodelet.
   </description>
   </class>
+
+  <class name="realsense_camera/SR300Nodelet" type="realsense_camera::SR300Nodelet" base_class_type="nodelet::Nodelet">
+  <description>
+  Intel(R) RealSense(TM) SR300 Camera nodelet.
+  </description>
+  </class>
 </library>

--- a/realsense_camera/src/sr300_nodelet.cpp
+++ b/realsense_camera/src/sr300_nodelet.cpp
@@ -112,6 +112,13 @@ namespace realsense_camera
       rs_set_device_option(rs_device_, RS_OPTION_COLOR_WHITE_BALANCE, config.color_white_balance, 0);
     }
 
+    // Set F200 specific options
+    rs_set_device_option(rs_device_, RS_OPTION_F200_LASER_POWER, config.f200_laser_power, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_F200_ACCURACY, config.f200_accuracy, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_F200_MOTION_RANGE, config.f200_motion_range, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_F200_FILTER_OPTION, config.f200_filter_option, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_F200_CONFIDENCE_THRESHOLD, config.f200_confidence_threshold, 0);
+
     // Set sr300 specific options
     rs_set_device_option(rs_device_, RS_OPTION_SR300_DYNAMIC_FPS, config.sr300_dynamic_fps, 0);
     rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_ENABLE_MOTION_VERSUS_RANGE, config.sr300_auto_range_enable_motion_versus_range, 0);

--- a/realsense_camera/src/sr300_nodelet.cpp
+++ b/realsense_camera/src/sr300_nodelet.cpp
@@ -122,13 +122,19 @@ namespace realsense_camera
     // Set sr300 specific options
     rs_set_device_option(rs_device_, RS_OPTION_SR300_DYNAMIC_FPS, config.sr300_dynamic_fps, 0);
     rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_ENABLE_MOTION_VERSUS_RANGE, config.sr300_auto_range_enable_motion_versus_range, 0);
+    if (config.sr300_auto_range_enable_motion_versus_range == 1)
+    {
+      rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_MIN_MOTION_VERSUS_RANGE, config.sr300_auto_range_min_motion_versus_range, 0);
+      rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_MAX_MOTION_VERSUS_RANGE, config.sr300_auto_range_max_motion_versus_range, 0);
+      rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_START_MOTION_VERSUS_RANGE, config.sr300_auto_range_start_motion_versus_range, 0);
+    }
     rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_ENABLE_LASER, config.sr300_auto_range_enable_laser, 0);
-    rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_MIN_MOTION_VERSUS_RANGE, config.sr300_auto_range_min_motion_versus_range, 0);
-    rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_MAX_MOTION_VERSUS_RANGE, config.sr300_auto_range_max_motion_versus_range, 0);
-    rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_START_MOTION_VERSUS_RANGE, config.sr300_auto_range_start_motion_versus_range, 0);
-    rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_MIN_LASER, config.sr300_auto_range_min_laser, 0);
-    rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_MAX_LASER, config.sr300_auto_range_max_laser, 0);
-    rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_START_LASER, config.sr300_auto_range_start_laser, 0);
+    if (config.sr300_auto_range_enable_laser == 1)
+    {
+      rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_MIN_LASER, config.sr300_auto_range_min_laser, 0);
+      rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_MAX_LASER, config.sr300_auto_range_max_laser, 0);
+      rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_START_LASER, config.sr300_auto_range_start_laser, 0);
+    }
     rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_UPPER_THRESHOLD, config.sr300_auto_range_upper_threshold, 0);
     rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_LOWER_THRESHOLD, config.sr300_auto_range_lower_threshold, 0);
     rs_set_device_option(rs_device_, RS_OPTION_SR300_WAKEUP_DEV_PHASE1_PERIOD, config.sr300_wakeup_dev_phase1_period, 0);

--- a/realsense_camera/src/sr300_nodelet.cpp
+++ b/realsense_camera/src/sr300_nodelet.cpp
@@ -1,0 +1,136 @@
+/******************************************************************************
+ Copyright (c) 2016, Intel Corporation
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ 3. Neither the name of the copyright holder nor the names of its contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+#include <realsense_camera/sr300_nodelet.h>
+
+PLUGINLIB_EXPORT_CLASS (realsense_camera::SR300Nodelet, nodelet::Nodelet)
+
+namespace realsense_camera
+{
+  /*
+   * Initialize the nodelet.
+   */
+  void SR300Nodelet::onInit()
+  {
+    max_z_ = SR300_MAX_Z;
+    BaseNodelet::onInit();
+  }
+
+  /*
+   * Set Dynamic Reconfigure Server and return the dynamic params.
+   */
+  std::vector<std::string> SR300Nodelet::setDynamicReconfServer()
+  {
+    dynamic_reconf_server_.reset(new dynamic_reconfigure::Server<realsense_camera::sr300_paramsConfig>(pnh_));
+
+    // Get dynamic options from the dynamic reconfigure server.
+    realsense_camera::sr300_paramsConfig params_config;
+    dynamic_reconf_server_->getConfigDefault(params_config);
+    std::vector<realsense_camera::sr300_paramsConfig::AbstractParamDescriptionConstPtr> param_desc =
+        params_config.__getParamDescriptions__();
+    std::vector<std::string> dynamic_params;
+    for (realsense_camera::sr300_paramsConfig::AbstractParamDescriptionConstPtr param_desc_ptr: param_desc)
+    {
+      dynamic_params.push_back((* param_desc_ptr).name);
+    }
+
+    return dynamic_params;
+  }
+
+  /*
+   * Start Dynamic Reconfigure Callback.
+   */
+  void SR300Nodelet::startDynamicReconfCallback()
+  {
+    dynamic_reconf_server_->setCallback(boost::bind(&SR300Nodelet::configCallback, this, _1, _2));
+  }
+
+  /*
+   * Get the dynamic param values.
+   */
+  void SR300Nodelet::configCallback(realsense_camera::sr300_paramsConfig &config, uint32_t level)
+  {
+    ROS_INFO_STREAM(nodelet_name_ << " - Setting dynamic camera options");
+    // Set flags
+    if (config.enable_depth == false)
+    {
+      if (enable_[RS_STREAM_COLOR] == false)
+      {
+        ROS_INFO_STREAM(nodelet_name_ << " - Color stream is also disabled. Cannot disable depth stream");
+        config.enable_depth = true;
+      }
+      else
+      {
+        enable_[RS_STREAM_DEPTH] = false;
+      }
+    }
+    else
+    {
+      enable_[RS_STREAM_DEPTH] = true;
+    }
+
+    // Set common options
+    rs_set_device_option(rs_device_, RS_OPTION_COLOR_BACKLIGHT_COMPENSATION, config.color_backlight_compensation, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_COLOR_BRIGHTNESS, config.color_brightness, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_COLOR_CONTRAST, config.color_contrast, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_COLOR_GAIN, config.color_gain, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_COLOR_GAMMA, config.color_gamma, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_COLOR_HUE, config.color_hue, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_COLOR_SATURATION, config.color_saturation, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_COLOR_SHARPNESS, config.color_sharpness, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_COLOR_ENABLE_AUTO_WHITE_BALANCE,
+        config.color_enable_auto_white_balance, 0);
+    if (config.color_enable_auto_white_balance == 0)
+    {
+      rs_set_device_option(rs_device_, RS_OPTION_COLOR_WHITE_BALANCE, config.color_white_balance, 0);
+    }
+
+    // Set sr300 specific options
+    rs_set_device_option(rs_device_, RS_OPTION_SR300_DYNAMIC_FPS, config.sr300_dynamic_fps, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_ENABLE_MOTION_VERSUS_RANGE, config.sr300_auto_range_enable_motion_versus_range, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_ENABLE_LASER, config.sr300_auto_range_enable_laser, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_MIN_MOTION_VERSUS_RANGE, config.sr300_auto_range_min_motion_versus_range, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_MAX_MOTION_VERSUS_RANGE, config.sr300_auto_range_max_motion_versus_range, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_START_MOTION_VERSUS_RANGE, config.sr300_auto_range_start_motion_versus_range, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_MIN_LASER, config.sr300_auto_range_min_laser, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_MAX_LASER, config.sr300_auto_range_max_laser, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_START_LASER, config.sr300_auto_range_start_laser, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_UPPER_THRESHOLD, config.sr300_auto_range_upper_threshold, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_LOWER_THRESHOLD, config.sr300_auto_range_lower_threshold, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_SR300_WAKEUP_DEV_PHASE1_PERIOD, config.sr300_wakeup_dev_phase1_period, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_SR300_WAKEUP_DEV_PHASE1_FPS, config.sr300_wakeup_dev_phase1_fps, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_SR300_WAKEUP_DEV_PHASE2_PERIOD, config.sr300_wakeup_dev_phase2_period, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_SR300_WAKEUP_DEV_PHASE2_FPS, config.sr300_wakeup_dev_phase2_fps, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_SR300_WAKEUP_DEV_RESET, config.sr300_wakeup_dev_reset, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_SR300_WAKE_ON_USB_REASON, config.sr300_wake_on_usb_reason, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_SR300_WAKE_ON_USB_CONFIDENCE, config.sr300_wake_on_usb_confidence, 0);
+  }
+}  // end namespace
+

--- a/realsense_camera/test/sr300_nodelet_camera_options.test
+++ b/realsense_camera/test/sr300_nodelet_camera_options.test
@@ -1,0 +1,110 @@
+<launch>
+  <arg name="manager"      value="nodelet_manager" />
+  <arg name="camera"       default="camera" />
+  <arg name="camera_type"  default="SR300" /> <!-- Type of camera -->
+  <arg name="serial_no"    default="" />
+  <arg name="usb_port_id"  default="" /> <!-- USB "Bus#-Port#" -->
+  <arg name="mode"                                            default="preset" />
+
+  <arg name="color_backlight_compensation"                    default="2" />
+  <arg name="color_brightness"                                default="56" />
+  <arg name="color_contrast"                                  default="34" />
+  <arg name="color_gain"                                      default="66" />
+  <arg name="color_gamma"                                     default="222" />
+  <arg name="color_hue"                                       default="2" />
+  <arg name="color_saturation"                                default="90" />
+  <arg name="color_sharpness"                                 default="2" />
+  <arg name="color_enable_auto_white_balance"                 default="0" />
+  <arg name="color_white_balance"                             default="3400" />
+  <arg name="sr300_dynamic_fps"                               default="60"/>
+  <arg name="sr300_auto_range_enable_motion_versus_range"     default="1"/>
+  <arg name="sr300_auto_range_enable_laser"                   default="0"/>
+  <arg name="sr300_auto_range_min_motion_versus_range"        default="1"/>
+  <arg name="sr300_auto_range_max_motion_versus_range"        default="800"/>
+  <arg name="sr300_auto_range_start_motion_versus_range"      default="5"/>
+  <arg name="sr300_auto_range_min_laser"                      default="4"/>
+  <arg name="sr300_auto_range_max_laser"                      default="16"/>
+  <arg name="sr300_auto_range_start_laser"                    default="-1"/>
+  <arg name="sr300_auto_range_upper_threshold"                default="60"/>
+  <arg name="sr300_auto_range_lower_threshold"                default="2"/>
+  <arg name="sr300_wakeup_dev_phase1_period"                  default="2"/>
+  <arg name="sr300_wakeup_dev_phase1_fps"                     default="2"/>
+  <arg name="sr300_wakeup_dev_phase2_period"                  default="2"/>
+  <arg name="sr300_wakeup_dev_phase2_fps"                     default="2"/>
+  <arg name="sr300_wakeup_dev_reset"                          default="1"/>
+  <arg name="sr300_wake_on_usb_reason"                        default="0"/>
+  <arg name="sr300_wake_on_usb_confidence"                    default="0"/>
+
+  <param name="$(arg camera)/mode"                            type="str"  value="$(arg mode)" />
+  <param name="$(arg camera)/color_backlight_compensation"    type="int" value="$(arg color_backlight_compensation)" />
+  <param name="$(arg camera)/color_brightness"                type="int" value="$(arg color_brightness)" />
+  <param name="$(arg camera)/color_contrast"                  type="int" value="$(arg color_contrast)" />
+  <param name="$(arg camera)/color_gain"                      type="int" value="$(arg color_gain)" />
+  <param name="$(arg camera)/color_gamma"                     type="int" value="$(arg color_gamma)" />
+  <param name="$(arg camera)/color_hue"                       type="int" value="$(arg color_hue)" />
+  <param name="$(arg camera)/color_saturation"                type="int" value="$(arg color_saturation)" />
+  <param name="$(arg camera)/color_sharpness"                 type="int" value="$(arg color_sharpness)" />
+  <param name="$(arg camera)/color_enable_auto_white_balance" type="int" value="$(arg color_enable_auto_white_balance)" />
+  <param name="$(arg camera)/color_white_balance"             type="int" value="$(arg color_white_balance)" />
+  <param name="$(arg camera)/sr300_dynamic_fps"                           type="int" value="$(arg sr300_dynamic_fps)"/>
+  <param name="$(arg camera)/sr300_auto_range_enable_motion_versus_range" type="int" value="$(arg sr300_auto_range_enable_motion_versus_range)"/>
+  <param name="$(arg camera)/sr300_auto_range_enable_laser"               type="int" value="$(arg sr300_auto_range_enable_laser)"/>
+  <param name="$(arg camera)/sr300_auto_range_min_motion_versus_range"    type="int" value="$(arg sr300_auto_range_min_motion_versus_range)"/>
+  <param name="$(arg camera)/sr300_auto_range_max_motion_versus_range"    type="int" value="$(arg sr300_auto_range_max_motion_versus_range)"/>
+  <param name="$(arg camera)/sr300_auto_range_start_motion_versus_range"  type="int" value="$(arg sr300_auto_range_start_motion_versus_range)"/>
+  <param name="$(arg camera)/sr300_auto_range_min_laser"                  type="int" value="$(arg sr300_auto_range_min_laser)"/>
+  <param name="$(arg camera)/sr300_auto_range_max_laser"                  type="int" value="$(arg sr300_auto_range_max_laser)"/>
+  <param name="$(arg camera)/sr300_auto_range_start_laser"                type="int" value="$(arg sr300_auto_range_start_laser)"/>
+  <param name="$(arg camera)/sr300_auto_range_upper_threshold"            type="int" value="$(arg sr300_auto_range_upper_threshold)"/>
+  <param name="$(arg camera)/sr300_auto_range_lower_threshold"            type="int" value="$(arg sr300_auto_range_lower_threshold)"/>
+  <param name="$(arg camera)/sr300_wakeup_dev_phase1_period"              type="int" value="$(arg sr300_wakeup_dev_phase1_period)"/>
+  <param name="$(arg camera)/sr300_wakeup_dev_phase1_period"              type="int" value="$(arg sr300_wakeup_dev_phase1_period)"/>
+  <param name="$(arg camera)/sr300_wakeup_dev_phase1_fps"                 type="int" value="$(arg sr300_wakeup_dev_phase1_fps)"/>
+  <param name="$(arg camera)/sr300_wakeup_dev_phase2_period"              type="int" value="$(arg sr300_wakeup_dev_phase2_period)"/>
+  <param name="$(arg camera)/sr300_wakeup_dev_phase2_fps"                 type="int" value="$(arg sr300_wakeup_dev_phase2_fps)"/>
+  <param name="$(arg camera)/sr300_wakeup_dev_reset"                      type="int" value="$(arg sr300_wakeup_dev_reset)"/>
+  <param name="$(arg camera)/sr300_wake_on_usb_reason"                    type="int" value="$(arg sr300_wake_on_usb_reason)"/>
+  <param name="$(arg camera)/sr300_wake_on_usb_confidence"                type="int" value="$(arg sr300_wake_on_usb_confidence)"/>
+
+  <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>
+
+  <include file="$(find realsense_camera)/launch/includes/nodelet.launch.xml">
+    <arg name="manager"      value="$(arg manager)" />
+    <arg name="camera"       value="$(arg camera)" />
+    <arg name="camera_type"  value="$(arg camera_type)" />
+    <arg name="serial_no"    value="$(arg serial_no)" />
+    <arg name="usb_port_id"  value="$(arg usb_port_id)" />
+  </include>
+
+  <!-- Start test -->
+  <test pkg="realsense_camera" type="tests_camera_core" test-name="realsense_camera_test"
+    args="camera_type $(arg camera_type)
+    color_backlight_compensation $(arg color_backlight_compensation)
+    color_brightness $(arg color_brightness)
+    color_contrast $(arg color_contrast)
+    color_gain $(arg color_gain)
+    color_gamma $(arg color_gamma)
+    color_hue $(arg color_hue)
+    color_saturation $(arg color_saturation)
+    color_sharpness $(arg color_sharpness)
+    color_enable_auto_white_balance $(arg color_enable_auto_white_balance)
+    color_white_balance $(arg color_white_balance)
+    sr300_dynamic_fps $(arg sr300_dynamic_fps)
+    sr300_auto_range_enable_motion_versus_range $(arg sr300_auto_range_enable_motion_versus_range)
+    sr300_auto_range_enable_laser $(arg sr300_auto_range_enable_laser)
+    sr300_auto_range_min_motion_versus_range $(arg sr300_auto_range_min_motion_versus_range)
+    sr300_auto_range_max_motion_versus_range $(arg sr300_auto_range_max_motion_versus_range)
+    sr300_auto_range_start_motion_versus_range $(arg sr300_auto_range_start_motion_versus_range)
+    sr300_auto_range_min_laser $(arg sr300_auto_range_min_laser)
+    sr300_auto_range_max_laser $(arg sr300_auto_range_max_laser)
+    sr300_auto_range_start_laser $(arg sr300_auto_range_start_laser)
+    sr300_auto_range_upper_threshold $(arg sr300_auto_range_upper_threshold)
+    sr300_auto_range_lower_threshold $(arg sr300_auto_range_lower_threshold)
+    sr300_wakeup_dev_phase1_period $(arg sr300_wakeup_dev_phase1_period)
+    sr300_wakeup_dev_phase1_fps $(arg sr300_wakeup_dev_phase1_fps)
+    sr300_wakeup_dev_phase2_period $(arg sr300_wakeup_dev_phase2_period)
+    sr300_wakeup_dev_phase2_fps $(arg sr300_wakeup_dev_phase2_fps)
+    sr300_wakeup_dev_reset $(arg sr300_wakeup_dev_reset)
+    sr300_wake_on_usb_reason $(arg sr300_wake_on_usb_reason)
+    sr300_wake_on_usb_confidence $(arg sr300_wake_on_usb_confidence)"/>
+</launch>

--- a/realsense_camera/test/sr300_nodelet_camera_options.test
+++ b/realsense_camera/test/sr300_nodelet_camera_options.test
@@ -16,6 +16,11 @@
   <arg name="color_sharpness"                                 default="2" />
   <arg name="color_enable_auto_white_balance"                 default="0" />
   <arg name="color_white_balance"                             default="3400" />
+  <arg name="f200_laser_power"                                default="14" />
+  <arg name="f200_accuracy"                                   default="3" />
+  <arg name="f200_motion_range"                               default="2" />
+  <arg name="f200_filter_option"                              default="6" />
+  <arg name="f200_confidence_threshold"                       default="8" />
   <arg name="sr300_dynamic_fps"                               default="60"/>
   <arg name="sr300_auto_range_enable_motion_versus_range"     default="1"/>
   <arg name="sr300_auto_range_enable_laser"                   default="0"/>
@@ -46,6 +51,11 @@
   <param name="$(arg camera)/color_sharpness"                 type="int" value="$(arg color_sharpness)" />
   <param name="$(arg camera)/color_enable_auto_white_balance" type="int" value="$(arg color_enable_auto_white_balance)" />
   <param name="$(arg camera)/color_white_balance"             type="int" value="$(arg color_white_balance)" />
+  <param name="$(arg camera)/f200_laser_power"                type="int" value="$(arg f200_laser_power)" />
+  <param name="$(arg camera)/f200_accuracy"                   type="int" value="$(arg f200_accuracy)" />
+  <param name="$(arg camera)/f200_motion_range"               type="int" value="$(arg f200_motion_range)" />
+  <param name="$(arg camera)/f200_filter_option"              type="int" value="$(arg f200_filter_option)" />
+  <param name="$(arg camera)/f200_confidence_threshold"       type="int" value="$(arg f200_confidence_threshold)" />
   <param name="$(arg camera)/sr300_dynamic_fps"                           type="int" value="$(arg sr300_dynamic_fps)"/>
   <param name="$(arg camera)/sr300_auto_range_enable_motion_versus_range" type="int" value="$(arg sr300_auto_range_enable_motion_versus_range)"/>
   <param name="$(arg camera)/sr300_auto_range_enable_laser"               type="int" value="$(arg sr300_auto_range_enable_laser)"/>
@@ -89,6 +99,11 @@
     color_sharpness $(arg color_sharpness)
     color_enable_auto_white_balance $(arg color_enable_auto_white_balance)
     color_white_balance $(arg color_white_balance)
+    f200_laser_power $(arg f200_laser_power)
+    f200_accuracy $(arg f200_accuracy)
+    f200_motion_range $(arg f200_motion_range)
+    f200_filter_option $(arg f200_filter_option)
+    f200_confidence_threshold $(arg f200_confidence_threshold)
     sr300_dynamic_fps $(arg sr300_dynamic_fps)
     sr300_auto_range_enable_motion_versus_range $(arg sr300_auto_range_enable_motion_versus_range)
     sr300_auto_range_enable_laser $(arg sr300_auto_range_enable_laser)

--- a/realsense_camera/test/sr300_nodelet_camera_options.test
+++ b/realsense_camera/test/sr300_nodelet_camera_options.test
@@ -6,39 +6,32 @@
   <arg name="usb_port_id"  default="" /> <!-- USB "Bus#-Port#" -->
   <arg name="mode"                                            default="preset" />
 
-  <arg name="color_backlight_compensation"                    default="2" />
-  <arg name="color_brightness"                                default="56" />
-  <arg name="color_contrast"                                  default="34" />
-  <arg name="color_gain"                                      default="66" />
-  <arg name="color_gamma"                                     default="222" />
-  <arg name="color_hue"                                       default="2" />
-  <arg name="color_saturation"                                default="90" />
-  <arg name="color_sharpness"                                 default="2" />
+  <arg name="color_backlight_compensation"                    default="1" />
+  <arg name="color_brightness"                                default="55" />
+  <arg name="color_contrast"                                  default="32" />
+  <arg name="color_gain"                                      default="64" />
+  <arg name="color_gamma"                                     default="220" />
+  <arg name="color_hue"                                       default="0" />
+  <arg name="color_saturation"                                default="100" />
+  <arg name="color_sharpness"                                 default="0" />
   <arg name="color_enable_auto_white_balance"                 default="0" />
-  <arg name="color_white_balance"                             default="3400" />
-  <arg name="f200_laser_power"                                default="14" />
-  <arg name="f200_accuracy"                                   default="3" />
-  <arg name="f200_motion_range"                               default="2" />
-  <arg name="f200_filter_option"                              default="6" />
-  <arg name="f200_confidence_threshold"                       default="8" />
-  <arg name="sr300_dynamic_fps"                               default="60"/>
+  <arg name="color_white_balance"                             default="3200" />
+  <arg name="f200_laser_power"                                default="16" />
+  <arg name="f200_accuracy"                                   default="2" />
+  <arg name="f200_motion_range"                               default="0" />
+  <arg name="f200_filter_option"                              default="5" />
+  <arg name="f200_confidence_threshold"                       default="6" />
+  <arg name="sr300_dynamic_fps"                               default="0"/>
   <arg name="sr300_auto_range_enable_motion_versus_range"     default="1"/>
-  <arg name="sr300_auto_range_enable_laser"                   default="0"/>
-  <arg name="sr300_auto_range_min_motion_versus_range"        default="1"/>
-  <arg name="sr300_auto_range_max_motion_versus_range"        default="800"/>
-  <arg name="sr300_auto_range_start_motion_versus_range"      default="5"/>
-  <arg name="sr300_auto_range_min_laser"                      default="4"/>
+  <arg name="sr300_auto_range_enable_laser"                   default="1"/>
+  <arg name="sr300_auto_range_min_motion_versus_range"        default="180"/>
+  <arg name="sr300_auto_range_max_motion_versus_range"        default="605"/>
+  <arg name="sr300_auto_range_start_motion_versus_range"      default="303"/>
+  <arg name="sr300_auto_range_min_laser"                      default="2"/>
   <arg name="sr300_auto_range_max_laser"                      default="16"/>
   <arg name="sr300_auto_range_start_laser"                    default="-1"/>
-  <arg name="sr300_auto_range_upper_threshold"                default="60"/>
-  <arg name="sr300_auto_range_lower_threshold"                default="2"/>
-  <arg name="sr300_wakeup_dev_phase1_period"                  default="2"/>
-  <arg name="sr300_wakeup_dev_phase1_fps"                     default="2"/>
-  <arg name="sr300_wakeup_dev_phase2_period"                  default="2"/>
-  <arg name="sr300_wakeup_dev_phase2_fps"                     default="2"/>
-  <arg name="sr300_wakeup_dev_reset"                          default="1"/>
-  <arg name="sr300_wake_on_usb_reason"                        default="0"/>
-  <arg name="sr300_wake_on_usb_confidence"                    default="0"/>
+  <arg name="sr300_auto_range_upper_threshold"                default="1250"/>
+  <arg name="sr300_auto_range_lower_threshold"                default="650"/>
 
   <param name="$(arg camera)/mode"                            type="str"  value="$(arg mode)" />
   <param name="$(arg camera)/color_backlight_compensation"    type="int" value="$(arg color_backlight_compensation)" />
@@ -67,14 +60,6 @@
   <param name="$(arg camera)/sr300_auto_range_start_laser"                type="int" value="$(arg sr300_auto_range_start_laser)"/>
   <param name="$(arg camera)/sr300_auto_range_upper_threshold"            type="int" value="$(arg sr300_auto_range_upper_threshold)"/>
   <param name="$(arg camera)/sr300_auto_range_lower_threshold"            type="int" value="$(arg sr300_auto_range_lower_threshold)"/>
-  <param name="$(arg camera)/sr300_wakeup_dev_phase1_period"              type="int" value="$(arg sr300_wakeup_dev_phase1_period)"/>
-  <param name="$(arg camera)/sr300_wakeup_dev_phase1_period"              type="int" value="$(arg sr300_wakeup_dev_phase1_period)"/>
-  <param name="$(arg camera)/sr300_wakeup_dev_phase1_fps"                 type="int" value="$(arg sr300_wakeup_dev_phase1_fps)"/>
-  <param name="$(arg camera)/sr300_wakeup_dev_phase2_period"              type="int" value="$(arg sr300_wakeup_dev_phase2_period)"/>
-  <param name="$(arg camera)/sr300_wakeup_dev_phase2_fps"                 type="int" value="$(arg sr300_wakeup_dev_phase2_fps)"/>
-  <param name="$(arg camera)/sr300_wakeup_dev_reset"                      type="int" value="$(arg sr300_wakeup_dev_reset)"/>
-  <param name="$(arg camera)/sr300_wake_on_usb_reason"                    type="int" value="$(arg sr300_wake_on_usb_reason)"/>
-  <param name="$(arg camera)/sr300_wake_on_usb_confidence"                type="int" value="$(arg sr300_wake_on_usb_confidence)"/>
 
   <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>
 
@@ -114,12 +99,5 @@
     sr300_auto_range_max_laser $(arg sr300_auto_range_max_laser)
     sr300_auto_range_start_laser $(arg sr300_auto_range_start_laser)
     sr300_auto_range_upper_threshold $(arg sr300_auto_range_upper_threshold)
-    sr300_auto_range_lower_threshold $(arg sr300_auto_range_lower_threshold)
-    sr300_wakeup_dev_phase1_period $(arg sr300_wakeup_dev_phase1_period)
-    sr300_wakeup_dev_phase1_fps $(arg sr300_wakeup_dev_phase1_fps)
-    sr300_wakeup_dev_phase2_period $(arg sr300_wakeup_dev_phase2_period)
-    sr300_wakeup_dev_phase2_fps $(arg sr300_wakeup_dev_phase2_fps)
-    sr300_wakeup_dev_reset $(arg sr300_wakeup_dev_reset)
-    sr300_wake_on_usb_reason $(arg sr300_wake_on_usb_reason)
-    sr300_wake_on_usb_confidence $(arg sr300_wake_on_usb_confidence)"/>
+    sr300_auto_range_lower_threshold $(arg sr300_auto_range_lower_threshold)"/>
 </launch>

--- a/realsense_camera/test/sr300_nodelet_disable_color.test
+++ b/realsense_camera/test/sr300_nodelet_disable_color.test
@@ -1,0 +1,6 @@
+<launch>
+  <arg name="camera_type"  value="SR300" />
+  <include file="$(find realsense_camera)/test/r200_nodelet_disable_color.test">
+    <arg name="camera_type" value="$(arg camera_type)" />
+  </include>
+</launch>

--- a/realsense_camera/test/sr300_nodelet_disable_depth.test
+++ b/realsense_camera/test/sr300_nodelet_disable_depth.test
@@ -1,0 +1,6 @@
+<launch>
+  <arg name="camera_type"  value="SR300" />
+  <include file="$(find realsense_camera)/test/r200_nodelet_disable_depth.test">
+    <arg name="camera_type" value="$(arg camera_type)" />
+  </include>
+</launch>

--- a/realsense_camera/test/sr300_nodelet_modify_params.test
+++ b/realsense_camera/test/sr300_nodelet_modify_params.test
@@ -1,0 +1,10 @@
+<launch>
+  <arg name="camera_type"  value="SR300" />
+  <arg name="depth_width"  value="640" />
+  <arg name="depth_height" value="480" />
+  <include file="$(find realsense_camera)/test/r200_nodelet_modify_params.test">
+    <arg name="camera_type"  value="$(arg camera_type)" />
+    <arg name="depth_width"  value="$(arg depth_width)" />
+    <arg name="depth_height" value="$(arg depth_height)" />
+  </include>
+</launch>

--- a/realsense_camera/test/sr300_nodelet_resolution.test
+++ b/realsense_camera/test/sr300_nodelet_resolution.test
@@ -1,0 +1,6 @@
+<launch>
+  <arg name="camera_type"  value="SR300" />
+  <include file="$(find realsense_camera)/test/r200_nodelet_resolution.test">
+    <arg name="camera_type"  value="$(arg camera_type)" />
+  </include>
+</launch>

--- a/realsense_camera/test/sr300_nodelet_rgbd.test
+++ b/realsense_camera/test/sr300_nodelet_rgbd.test
@@ -1,0 +1,10 @@
+<launch>
+  <arg name="camera_type"  value="SR300" />
+  <arg name="depth_width"  value="640" />
+  <arg name="depth_height" value="480" />
+  <include file="$(find realsense_camera)/test/r200_nodelet_rgbd.test">
+    <arg name="camera_type"  value="$(arg camera_type)" />
+    <arg name="depth_width"  value="$(arg depth_width)" />
+    <arg name="depth_height" value="$(arg depth_height)" />
+  </include>
+</launch>


### PR DESCRIPTION
This is an attempt to add support to the SR300.

Changes proposed in this pull request:
- Add a nodelet to handle SR300
- Add a launch file to publish streams from SR300
- Add a launch file to publish point cloud from processing of SR300 streams

I have tested it with the following configuration. 
It works, topics are published correctly and can be visualized with rqt/rviz.

| Version | Your Configuration |
| :-- | :-- |
| Operating System | Ubuntu 14.04.4 LTS |
| Kernel | 4.2.0 |
| Backend | video4linux |
| ROS | indigo |
| librealsense | 0.9.1 |
| SR300 Firmware | 3.10.10.0 |

However, I still have some unit tests failing:

```
~/catkin_ws/src/realsense/realsense_camera/test/camera_core.cpp:330
Value of: g_depth_avg > 0
  Actual: false
Expected: true
```

and 

```
~/catkin_ws/src/realsense/realsense_camera/test/camera_core.cpp:558
Value of: g_pc_depth_avg > 0
  Actual: false
Expected: true
```

Also, the stream of the IR camera is very noisy (black and white strips are overlayed with the actual stream). Do you think this has to do with the parameters fixed by default ?
