### PR TITLE
Remove sr300 wake up options

### DIFF
--- a/realsense_camera/README.md
+++ b/realsense_camera/README.md
@@ -283,5 +283,3 @@ Hence the launch file "r200_nodelet_rgbd.launch" will not generate data for the 
 * The usb-port-id logic does not work for F200 and SR300 cameras due to a known librealsense [bug] (https://github.com/IntelRealSense/librealsense/issues/220). Until it gets fixed,
  use serial_no when multiple F200 or SR300 cameras are connected to the system.
 
-* The get_settings service returns invalid values for certain SR300 camera options due to a known librealsense [bug] (https://github.com/IntelRealSense/librealsense/issues/231).
-

--- a/realsense_camera/cfg/sr300_params.cfg
+++ b/realsense_camera/cfg/sr300_params.cfg
@@ -8,7 +8,7 @@ gen = ParameterGenerator()
 
 #             Name                                     Type    Level Description                     Default    Min     Max
 gen.add("enable_depth",                                bool_t, 0,    "Enable Depth",                 True)
-gen.add("color_backlight_compensation",                int_t,  0,    "Backlight Compensation",       1,         0,      4)
+gen.add("color_backlight_compensation",                int_t,  0,    "Backlight Compensation",       0,         0,      4)
 gen.add("color_brightness",                            int_t,  0,    "Brightness",                   0,         -64,    64)
 gen.add("color_contrast",                              int_t,  0,    "Contrast",                     50,        0,      100)
 gen.add("color_gain",                                  int_t,  0,    "Gain",                         64,        0,      128)
@@ -24,10 +24,10 @@ gen.add("color_enable_auto_white_balance",             int_t,  0,    "Enable Aut
 
 # Options common with F200
 gen.add("f200_laser_power",                            int_t,  0,    "Laser Power",                  16,        0,      16)
-gen.add("f200_accuracy",                               int_t,  0,    "Accuracy",                     2,         1,      3)
-gen.add("f200_motion_range",                           int_t,  0,    "Motion Range",                 1,         0,      100)
+gen.add("f200_accuracy",                               int_t,  0,    "Accuracy",                     1,         1,      3)
+gen.add("f200_motion_range",                           int_t,  0,    "Motion Range",                 9,         0,      100)
 gen.add("f200_filter_option",                          int_t,  0,    "Filter Option",                5,         0,      7)
-gen.add("f200_confidence_threshold",                   int_t,  0,    "Confidence Threshold",         6,         0,      15)
+gen.add("f200_confidence_threshold",                   int_t,  0,    "Confidence Threshold",         3,         0,      15)
 
 gen.add("sr300_dynamic_fps",                           int_t,  0,    "Dynamic Fps",                  0,         0,      0)
 

--- a/realsense_camera/cfg/sr300_params.cfg
+++ b/realsense_camera/cfg/sr300_params.cfg
@@ -49,12 +49,12 @@ gen.add("sr300_auto_range_upper_threshold",            int_t,  0,    "Upper Thre
 gen.add("sr300_auto_range_lower_threshold",            int_t,  0,    "Lower Threshold",              650,       0,      65535)
 
 # Following are the Wake up options
-gen.add("sr300_wakeup_dev_phase1_period",              int_t,  0,    "Dev Phase1 Period",            1,         0,      65535)
-gen.add("sr300_wakeup_dev_phase1_fps",                 int_t,  0,    "Dev Phase1 Fps",               1,         0,      3)
-gen.add("sr300_wakeup_dev_phase2_period",              int_t,  0,    "Dev Phase2 Period",            1,         0,      65535)
-gen.add("sr300_wakeup_dev_phase2_fps",                 int_t,  0,    "Dev Phase2 Fps",               1,         0,      3)
-gen.add("sr300_wakeup_dev_reset",                      int_t,  0,    "Dev Reset",                    1,         0,      0)
-gen.add("sr300_wake_on_usb_reason",                    int_t,  0,    "Wake On Usb Reason",           1,         0,      3)
-gen.add("sr300_wake_on_usb_confidence",                int_t,  0,    "Wake On Usb Confidence" ,      1,         0,      100)
+#gen.add("sr300_wakeup_dev_phase1_period",              int_t,  0,    "Dev Phase1 Period",            1,         0,      65535)
+#gen.add("sr300_wakeup_dev_phase1_fps",                 int_t,  0,    "Dev Phase1 Fps",               1,         0,      3)
+#gen.add("sr300_wakeup_dev_phase2_period",              int_t,  0,    "Dev Phase2 Period",            1,         0,      65535)
+#gen.add("sr300_wakeup_dev_phase2_fps",                 int_t,  0,    "Dev Phase2 Fps",               1,         0,      3)
+#gen.add("sr300_wakeup_dev_reset",                      int_t,  0,    "Dev Reset",                    0,         0,      0)
+#gen.add("sr300_wake_on_usb_reason",                    int_t,  0,    "Wake On Usb Reason",           1,         0,      3)
+#gen.add("sr300_wake_on_usb_confidence",                int_t,  0,    "Wake On Usb Confidence" ,      1,         0,      100)
 
 exit(gen.generate(PACKAGE, "realsense_camera", "sr300_params"))

--- a/realsense_camera/src/sr300_nodelet.cpp
+++ b/realsense_camera/src/sr300_nodelet.cpp
@@ -153,6 +153,7 @@ namespace realsense_camera
     }
     rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_UPPER_THRESHOLD, config.sr300_auto_range_upper_threshold, 0);
     rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_LOWER_THRESHOLD, config.sr300_auto_range_lower_threshold, 0);
+/*
     rs_set_device_option(rs_device_, RS_OPTION_SR300_WAKEUP_DEV_PHASE1_PERIOD, config.sr300_wakeup_dev_phase1_period, 0);
     rs_set_device_option(rs_device_, RS_OPTION_SR300_WAKEUP_DEV_PHASE1_FPS, config.sr300_wakeup_dev_phase1_fps, 0);
     rs_set_device_option(rs_device_, RS_OPTION_SR300_WAKEUP_DEV_PHASE2_PERIOD, config.sr300_wakeup_dev_phase2_period, 0);
@@ -160,6 +161,7 @@ namespace realsense_camera
     rs_set_device_option(rs_device_, RS_OPTION_SR300_WAKEUP_DEV_RESET, config.sr300_wakeup_dev_reset, 0);
     rs_set_device_option(rs_device_, RS_OPTION_SR300_WAKE_ON_USB_REASON, config.sr300_wake_on_usb_reason, 0);
     rs_set_device_option(rs_device_, RS_OPTION_SR300_WAKE_ON_USB_CONFIDENCE, config.sr300_wake_on_usb_confidence, 0);
+*/
   }
 }  // end namespace
 


### PR DESCRIPTION
**Please ensure the above _guidelines for contributing_ are met.**

Fixes Issue: Related to librealsense [PR 240](https://github.com/IntelRealSense/librealsense/pull/240)
Changes proposed in this pull request:
- Temporarily removed the Wake Up options for SR300
- Updated default values for SR300 camera options
