### PR TITLE
use nodehandles to enable easier remapping

### DIFF
--- a/realsense_camera/include/realsense_camera/constants.h
+++ b/realsense_camera/include/realsense_camera/constants.h
@@ -56,17 +56,21 @@ namespace realsense_camera
     const std::string DEFAULT_COLOR_OPTICAL_FRAME_ID = "camera_rgb_optical_frame";
     const std::string DEFAULT_IR_FRAME_ID = "camera_ir_frame";
     const std::string DEFAULT_IR2_FRAME_ID = "camera_ir2_frame";
-    const std::string DEPTH_TOPIC = "camera/depth/image_raw";
-    const std::string COLOR_TOPIC = "camera/color/image_raw";
-    const std::string IR_TOPIC = "camera/ir/image_raw";
-    const std::string PC_TOPIC = "camera/depth/points";
-    const std::string SETTINGS_SERVICE = "camera/get_settings";
+    const std::string DEPTH_NAMESPACE = "depth";
+    const std::string DEPTH_TOPIC = "image_raw";
+    const std::string PC_TOPIC = "points";
+    const std::string COLOR_NAMESPACE = "color";
+    const std::string COLOR_TOPIC = "image_raw";
+    const std::string IR_NAMESPACE = "ir";
+    const std::string IR_TOPIC = "image_raw";
+    const std::string SETTINGS_SERVICE = "get_settings";
     const std::string STREAM_DESC[STREAM_COUNT] = {"Depth", "Color", "IR", "IR2"};
     const double ROTATION_IDENTITY[] = {1, 0, 0, 0, 1, 0, 0, 0, 1};
     const float MILLIMETER_METERS  = 0.001;
 
     // R200 Constants.
-    const std::string IR2_TOPIC = "camera/ir2/image_raw";
+    const std::string IR2_NAMESPACE = "ir2";
+    const std::string IR2_TOPIC = "image_raw";
     // Indoor Range: 0.7m - 3.5m, Outdoor Range: 10m
     const float R200_MAX_Z = 10.0f;   // in meters
 

--- a/realsense_camera/launch/includes/nodelet.launch.xml
+++ b/realsense_camera/launch/includes/nodelet.launch.xml
@@ -21,16 +21,5 @@
     <param name="color_optical_frame_id"  type="str"  value="$(arg camera)_rgb_optical_frame" />
     <param name="ir_frame_id"             type="str"  value="$(arg camera)_ir_frame" />
     <param name="ir2_frame_id"            type="str"  value="$(arg camera)_ir2_frame" />
-
-    <remap from="camera/depth/image_raw"    to="$(arg camera)/$(arg depth)/image_raw" />
-    <remap from="camera/color/image_raw"    to="$(arg camera)/$(arg rgb)/image_raw" />
-    <remap from="camera/ir/image_raw"       to="$(arg camera)/$(arg ir)/image_raw" />
-    <remap from="camera/ir2/image_raw"      to="$(arg camera)/$(arg ir2)/image_raw" />
-    <remap from="camera/depth/points"       to="$(arg camera)/$(arg depth)/points" />
-    <remap from="camera/depth/camera_info"  to="$(arg camera)/$(arg depth)/camera_info" />
-    <remap from="camera/color/camera_info"  to="$(arg camera)/$(arg rgb)/camera_info" />
-    <remap from="camera/ir/camera_info"     to="$(arg camera)/$(arg ir)/camera_info" />
-    <remap from="camera/ir2/camera_info"    to="$(arg camera)/$(arg ir2)/camera_info" />
-    <remap from="camera/get_settings"       to="$(arg camera)/get_settings" />
   </node>
 </launch>

--- a/realsense_camera/launch/includes/nodelet_rgbd.launch.xml
+++ b/realsense_camera/launch/includes/nodelet_rgbd.launch.xml
@@ -58,15 +58,5 @@
         <param name="color_optical_frame_id"  type="str"  value="$(arg camera)_$(arg rgb)_optical_frame" />
         <param name="ir_frame_id"             type="str"  value="$(arg camera)_$(arg ir)_frame" />
         <param name="ir2_frame_id"            type="str"  value="$(arg camera)_$(arg ir2)_frame" />
-
-        <remap from="camera/depth/image_raw"        to="$(arg depth)/image_raw" />
-        <remap from="camera/color/image_raw"        to="$(arg rgb)/image_raw" />
-        <remap from="camera/ir/image_raw"           to="$(arg ir)/image_raw" />
-        <remap from="camera/ir2/image_raw"          to="$(arg ir2)/image_raw" />
-        <remap from="camera/depth/points"           to="$(arg depth)/points" />
-        <remap from="camera/depth/camera_info"      to="$(arg depth)/camera_info" />
-        <remap from="camera/color/camera_info"      to="$(arg rgb)/camera_info" />
-        <remap from="camera/ir/camera_info"         to="$(arg ir)/camera_info" />
-        <remap from="camera/ir2/camera_info"        to="$(arg ir2)/camera_info" />
     </node>
 </launch>

--- a/realsense_camera/src/base_nodelet.cpp
+++ b/realsense_camera/src/base_nodelet.cpp
@@ -246,11 +246,18 @@ namespace realsense_camera
    */
   void BaseNodelet::advertiseTopics()
   {
-    image_transport::ImageTransport image_transport(nh_);
-    camera_publisher_[RS_STREAM_COLOR] = image_transport.advertiseCamera(COLOR_TOPIC, 1);
-    camera_publisher_[RS_STREAM_DEPTH] = image_transport.advertiseCamera(DEPTH_TOPIC, 1);
-    camera_publisher_[RS_STREAM_INFRARED] = image_transport.advertiseCamera(IR_TOPIC, 1);
-    pointcloud_publisher_ = nh_.advertise<sensor_msgs::PointCloud2>(PC_TOPIC, 1);
+    ros::NodeHandle color_nh(nh_, COLOR_NAMESPACE);
+    image_transport::ImageTransport color_image_transport(color_nh);
+    camera_publisher_[RS_STREAM_COLOR] = color_image_transport.advertiseCamera(COLOR_TOPIC, 1);
+
+    ros::NodeHandle depth_nh(nh_, DEPTH_NAMESPACE);
+    image_transport::ImageTransport depth_image_transport(depth_nh);
+    camera_publisher_[RS_STREAM_DEPTH] = depth_image_transport.advertiseCamera(DEPTH_TOPIC, 1);
+    pointcloud_publisher_ = depth_nh.advertise<sensor_msgs::PointCloud2>(PC_TOPIC, 1);
+
+    ros::NodeHandle ir_nh(nh_, IR_NAMESPACE);
+    image_transport::ImageTransport ir_image_transport(ir_nh);
+    camera_publisher_[RS_STREAM_INFRARED] = ir_image_transport.advertiseCamera(IR_TOPIC, 1);
   }
 
   /*
@@ -258,7 +265,7 @@ namespace realsense_camera
    */
   void BaseNodelet::advertiseServices()
   {
-    get_options_service_ = nh_.advertiseService(SETTINGS_SERVICE, &BaseNodelet::getCameraOptionValues, this);
+    get_options_service_ = pnh_.advertiseService(SETTINGS_SERVICE, &BaseNodelet::getCameraOptionValues, this);
   }
 
   /*

--- a/realsense_camera/src/r200_nodelet.cpp
+++ b/realsense_camera/src/r200_nodelet.cpp
@@ -79,9 +79,9 @@ namespace realsense_camera
   void R200Nodelet::advertiseTopics()
   {
     BaseNodelet::advertiseTopics();
-
-    image_transport::ImageTransport image_transport(nh_);
-    camera_publisher_[RS_STREAM_INFRARED2] = image_transport.advertiseCamera(IR2_TOPIC, 1);
+    ros::NodeHandle ir2_nh(nh_, IR2_NAMESPACE);
+    image_transport::ImageTransport ir2_image_transport(ir2_nh);
+    camera_publisher_[RS_STREAM_INFRARED2] = ir2_image_transport.advertiseCamera(IR2_TOPIC, 1);
   }
 
   /*
@@ -225,4 +225,3 @@ namespace realsense_camera
     publishTopic(RS_STREAM_INFRARED2);
   }
 }  // end namespace
-


### PR DESCRIPTION
Remapping is not supported for substrings. By creating intermediate nodehandles the namespaces can be remapped in aggregate. Without this my testing of https://github.com/turtlebot/turtlebot_apps/pull/152 was failing due to partial remappings.
