### PR TITLE
Added initial support for ZR300 camera

### DIFF
--- a/realsense_camera/CMakeLists.txt
+++ b/realsense_camera/CMakeLists.txt
@@ -30,12 +30,18 @@ find_package(catkin REQUIRED COMPONENTS
   pcl_ros
 )
 
+add_message_files(
+  FILES
+  IMUInfo.msg
+)
+
 add_service_files(
   FILES
   CameraConfiguration.srv
   ForcePower.srv
   SetPower.srv
   IsPowered.srv
+  GetIMUInfo.srv
 )
 
 generate_messages(
@@ -48,6 +54,7 @@ generate_dynamic_reconfigure_options(
   cfg/r200_params.cfg
   cfg/f200_params.cfg
   cfg/sr300_params.cfg
+  cfg/zr300_params.cfg
 )
 
 #################################
@@ -71,7 +78,8 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
 )
 
-add_library(${PROJECT_NAME}_nodelet src/base_nodelet.cpp src/r200_nodelet.cpp src/f200_nodelet.cpp src/sr300_nodelet.cpp)
+add_library(${PROJECT_NAME}_nodelet src/base_nodelet.cpp src/r200_nodelet.cpp src/f200_nodelet.cpp src/sr300_nodelet.cpp
+  src/zr300_nodelet.cpp)
 target_link_libraries(${PROJECT_NAME}_nodelet
   ${catkin_LIBRARIES}
 )

--- a/realsense_camera/README.md
+++ b/realsense_camera/README.md
@@ -1,52 +1,43 @@
 #Intel&reg; RealSense&trade; Technology - ROS Integration
-## Supported Camera Types: R200, F200 and SR300
+## Supported Camera Types: R200, F200, SR300 and ZR300
 ###Configuration:
-| Version          | Best Known (indigo)  | Best Known (kinetic) |
-|:---------------- |:---------------------|:---------------------|
-| Operating System | Ubuntu 14.04.4 LTS   | Ubuntu 16.04 LTS     |
-| Kernel           | 4.4.0-34-generic     | 4.4.0-34-generic     |
-| Backend          | video4linux          | video4linux          |
-| librealsense     | 0.9.2                | 0.9.2                |
-| R200 Firmware    | 1.0.72.06            | 1.0.72.06            |
-| F200 Firmware    | 2.60.0.0             | 2.60.0.0             |
-| SR300 Firmware   | 3.10.10.0            | 3.10.10.0            |
+| Version        | Best Known (indigo)  | Best Known (kinetic) |
+|:-------------- |:---------------------|:---------------------|
+| OS             | Ubuntu 14.04.4 LTS   | Ubuntu 16.04 LTS     |
+| Kernel         | 4.4.0-34-generic     | 4.4.0-34-generic     |
+| Backend        | video4linux          | video4linux          |
+| librealsense   | 1.11.0               | 1.11.0               |
+| R200 Firmware  | 1.0.72.06            | 1.0.72.06            |
+| F200 Firmware  | 2.60.0.0             | 2.60.0.0             |
+| SR300 Firmware | 3.10.10.0            | 3.10.10.0            |
+| ZR300 Firmware | Camera: 2.0.71.20, Adapter: 1.27.0.0, Motion Module: 1.23.0.0 | Camera: 2.0.71.20, Adapter: 1.27.0.0, Motion Module: 1.23.0.0 |
 
 ###Installation:
-####ROS Debian Packages
+To begin with, ensure that ROS is installed. (See [wiki.ros.org/ROS/Installation](http://wiki.ros.org/ROS/Installation) for instructions).
+Then, either install the realsense_camera ROS debian package or build it from source.
 
-* Install ROS (see [wiki.ros.org/ROS/Installation](http://wiki.ros.org/ROS/Installation) for instructions).
-
-* Install the realsense_sense camera package
+####Installing the ROS Debian Package
+* Install the realsense_sense camera package. Replace `<*distro*>` with `kinetic` or `indigo`.
 
   `sudo apt-get install ros-<*distro*>-realsense-camera`
 
   This will also install the required `ros-<*distro*>-librealsense` library on your system.
 
-**NOTE:** Replace `<*distro*>` with `kinetic` or `indigo`.
-
-##### Librealsense REQUIRED Manual Installation Steps
-librealsense 0.9.2 and earlier require a few extra, manual steps to enable the use of the library.
-
-* Clone the librealsense GitHub repository:
-
-```
+* librealsense 0.9.2 and earlier require a few extra, manual steps to enable the use of the library.
+  * Clone the librealsense GitHub repository:
+  ```
   git clone https://github.com/IntelRealSense/librealsense.git
   cd librealsense
   git checkout -b b0.9.2 v0.9.2
-```
-
-* Follow the instructions for [Video4Linux
-  backend](https://github.com/IntelRealSense/librealsense/blob/master/doc/installation.md#video4linux-backend) **ONLY** 
-
-  **NOTE:** Only one of the three options for Step 3 should be completed
-
-**NOTE:** The next release of `ros-<*distro*>-librealsense` will no longer require these manual steps.
+  ```
+  * Follow the instructions for [Video4Linux
+  backend](https://github.com/IntelRealSense/librealsense/blob/master/doc/installation.md#video4linux-backend) **ONLY**.
+  Only one of the three options for Step 3 should be completed
 
 ####Building the Package from Source
-
+**NOTE:** Ensure that the compatible librealsense version specifed in the Configuration section is installed.
 * Create a local catkin workspace (see [wiki.ros.org](http://wiki.ros.org/) for instructions).
 * Clone the source from https://github.com/intel-ros/realsense.git.
-  Checkout the 'stable' tag for the most stable version (E.g. `git checkout stable`).
 * Run `rosdep install --skip-keys=librealsense --from-paths -i <src-dir of cloned realsense repo>` to install package dependencies.
 * Compile the realsense_camera package by executing the `catkin_make` command.
   Successful execution of command will build target <b>“realsense_camera_nodelet”</b>
@@ -81,11 +72,27 @@ IR camera
     camera/ir/camera_info
         Calibration data
 
-IR2 camera: Available only for <b>R200</b> cameras.
+IR2 camera: Available only for <b>R200</b> and <b>ZR300</b> cameras.
 
     camera/ir2/image_raw (sensor_msgs/Image)
     camera/ir2/camera_info
         Calibration data
+
+Fisheye camera: Available only for <b>ZR300</b> cameras.
+
+    camera/fisheye/image_raw (sensor_msgs/Image)
+    camera/fisheye/camera_info
+        Calibration data
+
+IMU: Available only for <b>ZR300</b> cameras.
+
+    camera/imu/data_raw (sensor_msgs/Imu)
+
+  Each imu topic message will either contain angular velocity or linear acceleration data.
+  The element 0 of the associated covariance matrix will be set to -1 to indicate the absence of data.
+  E.g. If the topic message does not contain angular velocity data, then the element 0 of the angular velocity covariance matrix will be set to -1.
+
+  This topic message does not contain orientation data and hence the element 0 of the orientation covariance matrix will always be -1.
 
 ####Services
     get_settings (camera/driver/get_settings)
@@ -96,6 +103,9 @@ IR2 camera: Available only for <b>R200</b> cameras.
         Sets camera power to turn camera on/off. It turns off the camera regardless of number of subscribers.
     is_powered (camera/driver/is_powered)
         Gets current state of camera power. It checks whether camera is on or off and returns true or false respectively.
+    get_imu_info (camera/driver/get_imu_info): Available only for ZR300 cameras.
+        Gets the IMU intrinsic data. Contains the custom IMUInfo.msg for the "accel" and "gyro" IMU sensors.
+   Refer to [IMUInfo.msg Definition](msg/IMUInfo.msg)
 
 ####Transform Frames
     rostopic echo /tf_static
@@ -112,29 +122,39 @@ IR2 camera: Available only for <b>R200</b> cameras.
             Bus Number-Port Number in the format "Bus#-Port#". If used with serial_no, both must match correctly for 
             camera to be connected.
         camera_type (string, default: blank)
-            Specify the type of the camera - "R200", "F200" or "SR300".
+            Specify the type of the camera - "R200", "F200", "SR300" or "ZR300".
         mode (string, default: preset)
             Specify the mode to start camera streams. Mode comprises of height, width and fps. 
             Preset mode enables default values whereas Manual mode enables the specified parameter values.
-        depth_width (int, default: 480 for R200, 640 for F200 and SR300)
+        enable_depth (bool, default: true)
+          Specify if to enable or not the depth and infrared camera(s).
+          Note: Infrared stream(s) will be enabled or disabled along with depth stream.
+        depth_width (int, default: 480 for R200 and ZR300, 640 for F200 and SR300)
             Specify the depth camera width resolution.
         depth_height (int, default: 360 for R200, 480 for F200 and SR300)
             Specify the depth camera height resolution.
+        depth_fps (int, default: 60)
+            Specify the depth camera FPS
+        enable_color (bool, default: true)
+            Specify if to enable or not the color camera.
         color_width (int, default: 640)
             Specify the color camera width resolution.
         color_height (int, default: 480)
             Specify the color camera height resolution.
         color_fps (int, default: 60)
             Specify the color camera FPS
-        depth_fps (int, default: 60)
-            Specify the depth camera FPS
-        enable_depth (bool, default: true) 
-          Specify if to enable or not the depth and infrared camera(s).
-          Note: Infrared stream(s) will be enabled or disabled along with depth stream.
-        enable_color (bool, default: true) 
-            Specify if to enable or not the color camera.
+        enable_fisheye (bool, default: true): Available only for ZR300 cameras.
+            Specify if to enable or not the fisheye camera.
+        fisheye_width (int, default: 640): Available only for ZR300 cameras.
+            Specify the fisheye camera width resolution.
+        fisheye_height (int, default: 480): Available only for ZR300 cameras.
+            Specify the fisheye camera height resolution.
+        fisheye_fps (int, default: 60): Available only for ZR300 cameras.
+            Specify the fisheye camera FPS
+        enable_imu (bool, default: true): Available only for ZR300 cameras.
+            Specify if to enable or not the IMU sensor.
         enable_pointcloud (bool, default: false) 
-            Specify if to enable or not the point cloud camera.
+            Specify if to enable or not the native pointcloud.
             By default, it is set to false due to performance issues.
         enable_tf (bool, default: true) 
             Specify if to enable or not the transform frames.
@@ -142,32 +162,28 @@ IR2 camera: Available only for <b>R200</b> cameras.
             Specify the base frame id of the camera.
         depth_frame_id (string, default: camera_depth_frame)
             Specify the depth frame id of the camera.
-        color_frame_id (string, default: camera_rgb_frame)
-            Specify the color frame id of the camera.
         depth_optical_frame_id (string, default: camera_depth_optical_frame)
             Specify the depth optical frame id of the camera.
+        color_frame_id (string, default: camera_rgb_frame)
+            Specify the color frame id of the camera.
         color_optical_frame_id (string, default: camera_rgb_optical_frame)
             Specify the color optical frame id of the camera.
         ir_frame_id (string, default: camera_ir_frame)
             Specify the IR frame id of the camera.
-
-Available only for <b>R200</b> cameras.
-
-        ir2_frame_id (string, default: camera_ir2_frame):
+        ir_optical_frame_id (string, default: camera_ir_optical_frame)
+            Specify the IR optical frame id of the camera.
+        ir2_frame_id (string, default: camera_ir2_frame): Available only for R200 and ZR300 cameras.
             Specify the IR2 frame id of the camera.
-        r200_depth_units : [1, 2147483647]
-        r200_depth_clamp_min : [0, 65535]
-        r200_depth_clamp_max : [0, 65535]
-        r200_depth_control_estimate_median_decrement : [0 - 255]
-        r200_depth_control_estimate_median_increment  : [0 - 255]
-        r200_depth_control_median_threshold : [0 - 1023]
-        r200_depth_control_score_minimum_threshold : [0 - 1023]
-        r200_depth_control_score_maximum_threshold : [0 - 1023]
-        r200_depth_control_texture_count_threshold : [0 - 31]
-        r200_depth_control_texture_difference_threshold : [0 - 1023]
-        r200_depth_control_second_peak_threshold : [0 - 1023]
-        r200_depth_control_neighbor_threshold : [0 - 1023]
-        r200_depth_control_lr_threshold : [0 - 2047]
+        ir2_optical_frame_id (string, default: camera_ir2_optical_frame): Available only for R200 and ZR300 cameras.
+            Specify the IR2 optical frame id of the camera.
+        fisheye_frame_id (string, default: camera_fisheye_frame): Available only for ZR300 cameras.
+            Specify the fisheye frame id of the camera.
+        fisheye_optical_frame_id (string, default: camera_fisheye_optical_frame): Available only for ZR300 cameras.
+            Specify the fisheye optical frame id of the camera.
+        imu_frame_id (string, default: camera_imu_frame): Available only for ZR300 cameras.
+            Specify the IMU frame id of the camera.
+        imu_optical_frame_id (string, default: camera_imu_optical_frame): Available only for ZR300 cameras.
+            Specify the IMU optical frame id of the camera.
 
 ####Dynamic Parameters
 
@@ -176,6 +192,8 @@ For <b>R200</b> cameras, refer to [r200_params.cfg](cfg/r200_params.cfg)
 For <b>F200</b> cameras, refer to [f200_params.cfg](cfg/f200_params.cfg)
 
 For <b>SR300</b> cameras, refer to [sr300_params.cfg](cfg/sr300_params.cfg)
+
+For <b>ZR300</b> cameras, refer to [zr300_params.cfg](cfg/zr300_params.cfg)
 
 Note: For Autoexposure edge parameters, max value will go only upto the bounds of the infrared image.
 E.g. For 320x240 infrared image, valid values are within 0-319 and 0-239)
@@ -206,6 +224,10 @@ For <b>F200</b> cameras
 For <b>SR300</b> cameras
 
     $ roslaunch realsense_camera sr300_nodelet_default.launch
+
+For <b>ZR300</b> cameras
+
+    $ roslaunch realsense_camera zr300_nodelet_default.launch
 
 Sample launch files are available in [launch](launch/). 
 Make sure the correct "camera_type" is specified to launch the desired camera.
@@ -243,7 +265,7 @@ For viewing supported camera settings with current values:
 
 ####Launching Multiple Cameras
 <b>Note:</b> The following example is based on <b>R200</b> cameras. 
-Similar options are applicable to F200 and SR300 cameras too, just by updating the "camera_type".
+Similar options are applicable to F200, SR300 and ZR300 cameras too, just by updating the "camera_type".
 
 For running multiple cameras simultaneously:  
 <b>Option 1:</b> Using single nodelet manager for all the cameras
@@ -286,13 +308,15 @@ Refer to the following:
 * [r200_nodelet.h](include/realsense_camera/r200_nodelet.h)
 * [f200_nodelet.h](include/realsense_camera/f200_nodelet.h)
 * [sr300_nodelet.h](include/realsense_camera/sr300_nodelet.h)
+* [zr300_nodelet.h](include/realsense_camera/zr300_nodelet.h)
 
 ###Limitations:
 
 * Currently, the camera nodelet only supports the following formats:
-    * Color stream:    "RGB8" for R200 and F200
-    * Depth stream:    "Z16" for R200 and F200
-    * Infrared stream(s): "Y8" for R200 and F200. "Y16" for SR300.
+    * Color stream:    "RGB8"
+    * Depth stream:    "Z16"
+    * Infrared stream(s): "Y8" for R200, F200 and ZR300. "Y16" for SR300.
+    * Fisheye stream: "RAW8"
 
 * Generating a Depth Registered Point Cloud is very memory intensive.
 E.g. The topic /camera/depth_registered/points, generated by launch file
@@ -309,6 +333,9 @@ Hence the launch file "r200_nodelet_rgbd.launch" will not generate data for the 
 
 * The performance benchmark for multiple cameras launched at the same time has not been defined yet.
 
+* For ZR300 cameras, the transform between base frame and imu frame has been hardcoded until librealsense
+supports fetching this data during runtime.
+
 ###Errata:
 
 * The usb-port-id logic does not work for F200 and SR300 cameras due to a known
@@ -324,3 +351,5 @@ Until it gets fixed, use a single launch file for multiple F200 or SR300 cameras
 [Issue #89](https://github.com/intel-ros/realsense/issues/89).
 Unlikely to be fixed as current plan is to
 [remove native point cloud generation](https://github.com/intel-ros/realsense/issues/47).
+
+* The service "get_imu_info" is yet to be tested.

--- a/realsense_camera/README.md
+++ b/realsense_camera/README.md
@@ -351,5 +351,3 @@ Until it gets fixed, use a single launch file for multiple F200 or SR300 cameras
 [Issue #89](https://github.com/intel-ros/realsense/issues/89).
 Unlikely to be fixed as current plan is to
 [remove native point cloud generation](https://github.com/intel-ros/realsense/issues/47).
-
-* The service "get_imu_info" is yet to be tested.

--- a/realsense_camera/cfg/zr300_params.cfg
+++ b/realsense_camera/cfg/zr300_params.cfg
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+PACKAGE="realsense_camera"
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+#             Name                                         Type      Level  Description                                   Default    Min     Max
+gen.add("enable_depth",                                    bool_t,   0,     "Enable Depth",                               True)
+gen.add("color_backlight_compensation",                    int_t,    0,     "Backlight Compensation",                     0,         0,      4)
+gen.add("color_brightness",                                int_t,    0,     "Brightness",                                 0,         0,      255)
+gen.add("color_contrast",                                  int_t,    0,     "Contrast",                                   50,        16,     64)
+gen.add("color_exposure",                                  int_t,    0,     "Exposure",                                   166,       50,     666)
+gen.add("color_gain",                                      int_t,    0,     "Gain",                                       64,        0,      256)
+gen.add("color_gamma",                                     int_t,    0,     "Gamma",                                      300,       100,    280)
+gen.add("color_hue",                                       int_t,    0,     "Hue",                                        0,         -2200,  2200)
+gen.add("color_saturation",                                int_t,    0,     "Saturation",                                 64,        0,      255)
+gen.add("color_sharpness",                                 int_t,    0,     "Sharpness",                                  50,        0,      7)
+
+# Must be set only if color_enable_auto_white_balance is disabled
+gen.add("color_white_balance",                             int_t,    0,     "White Balance",                              4600,      2000,   8000)
+
+gen.add("color_enable_auto_exposure",                      int_t,    0,     "Enable Auto Exposure",                       1,         0,      1)
+gen.add("color_enable_auto_white_balance",                 int_t,    0,     "Enable Auto White Balance",                  1,         0,      1)
+gen.add("r200_lr_auto_exposure_enabled",                   int_t,    0,     "LR Auto Exposure Enabled",                   0,         0,      1)
+gen.add("r200_lr_gain",                                    int_t,    0,     "LR Gain",                                    400,       100,    6399)
+
+# Must be set only if r200_lr_auto_exposure_enabled is disabled
+gen.add("r200_lr_exposure",                                int_t,    0,     "LR Exposure",                                164,       1,      164)
+
+gen.add("r200_emitter_enabled",                            int_t,    0,     "Emitter Enabled",                            0,         0,      1)
+gen.add("r200_depth_clamp_min",                            int_t,    0,     "Depth Clamp Min",                            0,         0,      65535)
+gen.add("r200_depth_clamp_max",                            int_t,    0,     "Depth Clamp Max",                            65535,     0,      65535)
+gen.add("r200_depth_control_estimate_median_decrement",    int_t,    0,     "Depth Control Estimate Median Decrement",    5,         0,      255)
+gen.add("r200_depth_control_estimate_median_increment",    int_t,    0,     "Depth Control Estimate Median Increment",    5,         0,      255)
+gen.add("r200_depth_control_median_threshold",             int_t,    0,     "Depth Control Median Threshold",             192,       0,      1023)
+gen.add("r200_depth_control_score_minimum_threshold",      int_t,    0,     "Depth Control Score Min Threshold",          1,         0,      1023)
+gen.add("r200_depth_control_score_maximum_threshold",      int_t,    0,     "Depth Control Score Max Threshold",          512,       0,      1023)
+gen.add("r200_depth_control_texture_count_threshold",      int_t,    0,     "Depth Control Texture Count Threshold",      6,         0,      31)
+gen.add("r200_depth_control_texture_difference_threshold", int_t,    0,     "Depth Control Texture Difference Threshold", 24,        0,      1023)
+gen.add("r200_depth_control_second_peak_threshold",        int_t,    0,     "Depth Control Second Peak Threshold",        27,        0,      1023)
+gen.add("r200_depth_control_neighbor_threshold",           int_t,    0,     "Depth Control Neighbor Threshold",           7,         0,      1023)
+gen.add("r200_depth_control_lr_threshold",                 int_t,    0,     "Depth Control LR Threshold",                 24,        0,      2047)
+gen.add("fisheye_exposure",                                int_t,    0,     "Fisheye Exposure",                           40,        40,     331)
+gen.add("fisheye_gain",                                    int_t,    0,     "Fisheye Gain",                               0,         0,      2047)
+gen.add("fisheye_strobe",                                  int_t,    0,     "Fisheye Strobe",                             0,         0,      1)
+gen.add("fisheye_external_trigger",                        int_t,    0,     "Fisheye External Trigger",                   0,         0,      1)
+gen.add("fisheye_enable_auto_exposure",                    int_t,    0,     "Fisheye Enable Auto Exposure",               1,         0,      1)
+gen.add("fisheye_auto_exposure_mode",                      int_t,    0,     "Fisheye Auto Exposure Mode",                 0,         0,      2)
+gen.add("fisheye_auto_exposure_antiflicker_rate",          int_t,    0,     "Fisheye Auto Exposure Antiflicker Rate",     60,        50,     60)
+gen.add("fisheye_auto_exposure_pixel_sample_rate",         int_t,    0,     "Fisheye Auto Exposure Pixel Sample Rate",    1,         1,      3)
+gen.add("fisheye_auto_exposure_skip_frames",               int_t,    0,     "Fisheye Auto Exposure Skip Frames",          2,         0,      3)
+gen.add("frames_queue_size",                               int_t,    0,     "Frames Queue Size",                          20,        1,      20)
+gen.add("hardware_logger_enabled",                         int_t,    0,     "Hardware Logger Enabled",                    0,         0,      1)
+
+exit(gen.generate(PACKAGE, "realsense_camera", "zr300_params"))

--- a/realsense_camera/cfg/zr300_params.cfg
+++ b/realsense_camera/cfg/zr300_params.cfg
@@ -29,19 +29,46 @@ gen.add("r200_lr_gain",                                    int_t,    0,     "LR 
 # Must be set only if r200_lr_auto_exposure_enabled is disabled
 gen.add("r200_lr_exposure",                                int_t,    0,     "LR Exposure",                                164,       1,      164)
 
-gen.add("r200_emitter_enabled",                            int_t,    0,     "Emitter Enabled",                            0,         0,      1)
+gen.add("r200_emitter_enabled",                            int_t,    0,     "Emitter Enabled",                            1,         0,      1)
 gen.add("r200_depth_clamp_min",                            int_t,    0,     "Depth Clamp Min",                            0,         0,      65535)
 gen.add("r200_depth_clamp_max",                            int_t,    0,     "Depth Clamp Max",                            65535,     0,      65535)
-gen.add("r200_depth_control_estimate_median_decrement",    int_t,    0,     "Depth Control Estimate Median Decrement",    5,         0,      255)
-gen.add("r200_depth_control_estimate_median_increment",    int_t,    0,     "Depth Control Estimate Median Increment",    5,         0,      255)
-gen.add("r200_depth_control_median_threshold",             int_t,    0,     "Depth Control Median Threshold",             192,       0,      1023)
-gen.add("r200_depth_control_score_minimum_threshold",      int_t,    0,     "Depth Control Score Min Threshold",          1,         0,      1023)
-gen.add("r200_depth_control_score_maximum_threshold",      int_t,    0,     "Depth Control Score Max Threshold",          512,       0,      1023)
-gen.add("r200_depth_control_texture_count_threshold",      int_t,    0,     "Depth Control Texture Count Threshold",      6,         0,      31)
-gen.add("r200_depth_control_texture_difference_threshold", int_t,    0,     "Depth Control Texture Difference Threshold", 24,        0,      1023)
-gen.add("r200_depth_control_second_peak_threshold",        int_t,    0,     "Depth Control Second Peak Threshold",        27,        0,      1023)
-gen.add("r200_depth_control_neighbor_threshold",           int_t,    0,     "Depth Control Neighbor Threshold",           7,         0,      1023)
-gen.add("r200_depth_control_lr_threshold",                 int_t,    0,     "Depth Control LR Threshold",                 24,        0,      2047)
+
+# Depth Control Grouping
+r200_depth_control = gen.add_group("R200 Depth Control")
+r200_dc_preset_enum = gen.enum(
+  [ gen.const("UNUSED",     int_t,  -1, "Individual Depth Control was changed"),
+    gen.const("Default",    int_t,  0,  "Default settings on chip. Similar to Medium. Best for Outdoors."),
+    gen.const("Off",        int_t,  1,  "Disable almost all hardware-based outlier removal."),
+    gen.const("Low",        int_t,  2,  "Lower number of outliers removed. Minimal false negatives."),
+    gen.const("Medium",     int_t,  3,  "Medium number of outliers removed. Balanced approach."),
+    gen.const("Optimized",  int_t,  4,  "Medium-High number of outliers removed. Derived optimization function."),
+    gen.const("High",       int_t,  5,  "Higher number of outliers removed. Minimal false positives.")],
+    "Depth Control Preset Choices")
+#                      Name
+#   Type      Level       Description                         Default   Min     Max     Method
+r200_depth_control.add("r200_dc_preset",
+    int_t,    64,         "R200 Depth Control Preset",        5,        -1,     5,      edit_method=r200_dc_preset_enum)
+r200_depth_control.add("r200_dc_estimate_median_decrement",
+    int_t,    32,         "Estimate Median Decrement",        5,        0,      255)
+r200_depth_control.add("r200_dc_estimate_median_increment",
+    int_t,    32,         "Estimate Median Increment",        5,        0,      255)
+r200_depth_control.add("r200_dc_median_threshold",
+    int_t,    32,         "Median Threshold",                 235,      0,      1023)
+r200_depth_control.add("r200_dc_score_minimum_threshold",
+    int_t,    32,         "Score Minimum Threshold",          27,       0,      1023)
+r200_depth_control.add("r200_dc_score_maximum_threshold",
+    int_t,    32,         "Score Maximum Threshold",          420,      0,      1023)
+r200_depth_control.add("r200_dc_texture_count_threshold",
+    int_t,    32,         "Texture Count Threshold",          8,        0,      31)
+r200_depth_control.add("r200_dc_texture_difference_threshold",
+    int_t,    32,         "Texture Difference Threshold",     80,       0,      1023)
+r200_depth_control.add("r200_dc_second_peak_threshold",
+    int_t,    32,         "Second Peak Threshold",            70,       0,      1023)
+r200_depth_control.add("r200_dc_neighbor_threshold",
+    int_t,    32,         "Neighbor Threshold",               90,       0,      1023)
+r200_depth_control.add("r200_dc_lr_threshold",
+    int_t,    32,         "LR Threshold",                     12,       0,      2047)
+
 gen.add("fisheye_exposure",                                int_t,    0,     "Fisheye Exposure",                           40,        40,     331)
 gen.add("fisheye_gain",                                    int_t,    0,     "Fisheye Gain",                               0,         0,      2047)
 gen.add("fisheye_strobe",                                  int_t,    0,     "Fisheye Strobe",                             0,         0,      1)

--- a/realsense_camera/include/realsense_camera/base_nodelet.h
+++ b/realsense_camera/include/realsense_camera/base_nodelet.h
@@ -93,6 +93,7 @@ namespace realsense_camera
     ros::NodeHandle nh_;
     ros::NodeHandle pnh_;
     ros::Time topic_ts_;
+    ros::Time static_transform_ts_;
     ros::Publisher pointcloud_publisher_;
     ros::ServiceServer get_options_service_;
     ros::ServiceServer set_power_service_;
@@ -116,14 +117,13 @@ namespace realsense_camera
     int cv_type_[STREAM_COUNT];
     int unit_step_size_[STREAM_COUNT];
     int step_[STREAM_COUNT];
-    int ts_[STREAM_COUNT];
+    double ts_[STREAM_COUNT];
     std::string frame_id_[STREAM_COUNT];
+    std::string optical_frame_id_[STREAM_COUNT];
     cv::Mat image_[STREAM_COUNT] = {};
     image_transport::CameraPublisher camera_publisher_[STREAM_COUNT] = {};
     sensor_msgs::CameraInfoPtr camera_info_ptr_[STREAM_COUNT] = {};
     std::string base_frame_id_;
-    std::string depth_frame_id_;
-    std::string color_frame_id_;
     float max_z_ = -1.0f;
     bool enable_pointcloud_;
     bool enable_tf_;

--- a/realsense_camera/include/realsense_camera/constants.h
+++ b/realsense_camera/include/realsense_camera/constants.h
@@ -37,25 +37,30 @@
 namespace realsense_camera
 {
     // Default Constants.
-    const int STREAM_COUNT = 4;
+    const int STREAM_COUNT = 5;
     const int DEPTH_WIDTH = 480;
     const int DEPTH_HEIGHT = 360;
     const int COLOR_WIDTH = 640;
     const int COLOR_HEIGHT = 480;
+    const int FISHEYE_WIDTH = 640;
+    const int FISHEYE_HEIGHT = 480;
     const int DEPTH_FPS = 60;
     const int COLOR_FPS = 60;
+    const int FISHEYE_FPS = 60;
     const bool ENABLE_DEPTH = true;
     const bool ENABLE_COLOR = true;
+    const bool ENABLE_FISHEYE = true;
+    const bool ENABLE_IMU = true;
     const bool ENABLE_PC = false;
     const bool ENABLE_TF = true;
     const std::string DEFAULT_MODE = "preset";
     const std::string DEFAULT_BASE_FRAME_ID = "camera_link";
     const std::string DEFAULT_DEPTH_FRAME_ID = "camera_depth_frame";
     const std::string DEFAULT_COLOR_FRAME_ID = "camera_rgb_frame";
+    const std::string DEFAULT_IR_FRAME_ID = "camera_ir_frame";
     const std::string DEFAULT_DEPTH_OPTICAL_FRAME_ID = "camera_depth_optical_frame";
     const std::string DEFAULT_COLOR_OPTICAL_FRAME_ID = "camera_rgb_optical_frame";
-    const std::string DEFAULT_IR_FRAME_ID = "camera_ir_frame";
-    const std::string DEFAULT_IR2_FRAME_ID = "camera_ir2_frame";
+    const std::string DEFAULT_IR_OPTICAL_FRAME_ID = "camera_ir_optical_frame";
     const std::string DEPTH_NAMESPACE = "depth";
     const std::string DEPTH_TOPIC = "image_raw";
     const std::string PC_TOPIC = "points";
@@ -64,16 +69,21 @@ namespace realsense_camera
     const std::string IR_NAMESPACE = "ir";
     const std::string IR_TOPIC = "image_raw";
     const std::string SETTINGS_SERVICE = "get_settings";
-    const std::string STREAM_DESC[STREAM_COUNT] = {"Depth", "Color", "IR", "IR2"};
     const std::string CAMERA_IS_POWERED_SERVICE = "is_powered";
     const std::string CAMERA_SET_POWER_SERVICE = "set_power";
     const std::string CAMERA_FORCE_POWER_SERVICE = "force_power";
+    const std::string STREAM_DESC[STREAM_COUNT] = {"Depth", "Color", "IR", "IR2", "Fisheye"};
+    const int EVENT_COUNT = 2;
     const double ROTATION_IDENTITY[] = {1, 0, 0, 0, 1, 0, 0, 0, 1};
     const float MILLIMETER_METERS  = 0.001;
 
-    // R200 Constants.
+    // R200 and ZR300 Constants.
     const std::string IR2_NAMESPACE = "ir2";
     const std::string IR2_TOPIC = "image_raw";
+    const std::string DEFAULT_IR2_FRAME_ID = "camera_ir2_frame";
+    const std::string DEFAULT_IR2_OPTICAL_FRAME_ID = "camera_ir2_optical_frame";
+
+    // R200 Constants.
     // Indoor Range: 0.7m - 3.5m, Outdoor Range: 10m
     const float R200_MAX_Z = 10.0f;   // in meters
 
@@ -84,5 +94,21 @@ namespace realsense_camera
     // SR300 Constants.
     // Indoor Range: 0.2m – 1.5m, Outdoor Range: n/a
     const float SR300_MAX_Z = 1.5f; // in meters
+
+    // ZR300 Constants.
+    // Indoor Range: 0.7m - 3.5m, Outdoor Range: 10m
+    const float ZR300_MAX_Z = 10.0f;   // in meters
+    const std::string FISHEYE_NAMESPACE = "fisheye";
+    const std::string FISHEYE_TOPIC = "image_raw";
+    const std::string IMU_NAMESPACE = "imu";
+    const std::string IMU_TOPIC = "data_raw";
+    const std::string IMU_INFO_SERVICE = "get_imu_info";
+    const std::string DEFAULT_FISHEYE_FRAME_ID = "camera_fisheye_frame";
+    const std::string DEFAULT_IMU_FRAME_ID = "camera_imu_frame";
+    const std::string DEFAULT_FISHEYE_OPTICAL_FRAME_ID = "camera_fisheye_optical_frame";
+    const std::string DEFAULT_IMU_OPTICAL_FRAME_ID = "camera_imu_optical_frame";
+    const std::string IMU_ACCEL = "IMU_ACCEL";
+    const std::string IMU_GYRO = "IMU_GYRO";
+    const double IMU_UNITS_TO_MSEC = 0.00003125;
 }
 #endif

--- a/realsense_camera/include/realsense_camera/zr300_nodelet.h
+++ b/realsense_camera/include/realsense_camera/zr300_nodelet.h
@@ -29,17 +29,20 @@
  *******************************************************************************/
 
 #pragma once
-#ifndef R200_NODELET
-#define R200_NODELET
+#ifndef ZR300_NODELET
+#define ZR300_NODELET
 
 #include <dynamic_reconfigure/server.h>
 
-#include <realsense_camera/r200_paramsConfig.h>
+#include <realsense_camera/zr300_paramsConfig.h>
+#include <realsense_camera/IMUInfo.h>
+#include <realsense_camera/GetIMUInfo.h>
 #include <realsense_camera/base_nodelet.h>
+#include <sensor_msgs/Imu.h>
 
 namespace realsense_camera
 {
-  class R200Nodelet: public realsense_camera::BaseNodelet
+  class ZR300Nodelet: public realsense_camera::BaseNodelet
   {
   public:
 
@@ -54,19 +57,39 @@ namespace realsense_camera
       RS_OPTION_R200_AUTO_EXPOSURE_RIGHT_EDGE,
       RS_OPTION_R200_AUTO_EXPOSURE_BOTTOM_EDGE
     };
-    boost::shared_ptr<dynamic_reconfigure::Server<realsense_camera::r200_paramsConfig>> dynamic_reconf_server_;
+    ros::ServiceServer get_imu_info_;
+    boost::shared_ptr<dynamic_reconfigure::Server<realsense_camera::zr300_paramsConfig>> dynamic_reconf_server_;
+    bool enable_imu_;
+    std::string imu_frame_id_;
+    std::string imu_optical_frame_id_;
+    float imu_angular_vel_[3];
+    float imu_linear_accel_[3];
+    float imu_angular_vel_cov_[9] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+    float imu_linear_accel_cov_[9] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+    double imu_ts_;
+    double prev_imu_ts_;
+    ros::Publisher imu_publisher_;
+    boost::shared_ptr<boost::thread> imu_thread_;
+    std::function<void(rs::motion_data)> motion_handler_;
+    std::function<void(rs::timestamp_data)> timestamp_handler_;
 
     // Member Functions.
     void getParameters();
     void advertiseTopics();
+    void advertiseServices();
+    bool getIMUInfo(realsense_camera::GetIMUInfo::Request & req,realsense_camera::GetIMUInfo::Response & res);
+/*TODO
+    void getIMUSensorInfo(realsense_camera::IMUInfo * imu_info,
+        rs_motion_device_intrinsic imu_intrinsic, ros::Time header_stamp, std::string header_frame_id);
+*/
     std::vector<std::string> setDynamicReconfServer();
     void startDynamicReconfCallback();
-    void setDynamicReconfigDepthControlPreset(int preset);
-    std::string setDynamicReconfigDepthControlIndividuals();
-    void configCallback(realsense_camera::r200_paramsConfig &config, uint32_t level);
+    void configCallback(realsense_camera::zr300_paramsConfig &config, uint32_t level);
     void setStreams();
     void publishTopics();
     void publishStaticTransforms();
+    void prepareIMU();
+    void setIMUCallbacks();
   };
 }
 #endif

--- a/realsense_camera/include/realsense_camera/zr300_nodelet.h
+++ b/realsense_camera/include/realsense_camera/zr300_nodelet.h
@@ -51,12 +51,6 @@ namespace realsense_camera
   protected:
 
     // Member Variables.
-    rs_option edge_options_[4] = {
-      RS_OPTION_R200_AUTO_EXPOSURE_LEFT_EDGE,
-      RS_OPTION_R200_AUTO_EXPOSURE_TOP_EDGE,
-      RS_OPTION_R200_AUTO_EXPOSURE_RIGHT_EDGE,
-      RS_OPTION_R200_AUTO_EXPOSURE_BOTTOM_EDGE
-    };
     ros::ServiceServer get_imu_info_;
     boost::shared_ptr<dynamic_reconfigure::Server<realsense_camera::zr300_paramsConfig>> dynamic_reconf_server_;
     bool enable_imu_;
@@ -78,12 +72,10 @@ namespace realsense_camera
     void advertiseTopics();
     void advertiseServices();
     bool getIMUInfo(realsense_camera::GetIMUInfo::Request & req,realsense_camera::GetIMUInfo::Response & res);
-/*TODO
-    void getIMUSensorInfo(realsense_camera::IMUInfo * imu_info,
-        rs_motion_device_intrinsic imu_intrinsic, ros::Time header_stamp, std::string header_frame_id);
-*/
     std::vector<std::string> setDynamicReconfServer();
     void startDynamicReconfCallback();
+    void setDynamicReconfigDepthControlPreset(int preset);
+    std::string setDynamicReconfigDepthControlIndividuals();
     void configCallback(realsense_camera::zr300_paramsConfig &config, uint32_t level);
     void setStreams();
     void publishTopics();

--- a/realsense_camera/launch/includes/nodelet.launch.xml
+++ b/realsense_camera/launch/includes/nodelet.launch.xml
@@ -7,24 +7,34 @@
   <arg name="rgb"          default="color" />
   <arg name="ir"           default="ir" />
   <arg name="ir2"          default="ir2" />
+  <arg name="fisheye"      default="fisheye" />
+  <arg name="imu"          default="imu" />
   <arg name="serial_no"    default="" />
   <arg name="usb_port_id"  default="" />
   <node pkg="nodelet" type="nodelet" name="driver"
     args="load realsense_camera/$(arg camera_type)Nodelet $(arg manager)">
-    <param name="serial_no"               type="str"  value="$(arg serial_no)" />
-    <param name="usb_port_id"             type="str"  value="$(arg usb_port_id)" />
-    <param name="camera_type"             type="str"  value="$(arg camera_type)" />
-    <param name="base_frame_id"           type="str"  value="$(arg camera)_link" />
-    <param name="depth_frame_id"          type="str"  value="$(arg camera)_depth_frame" />
-    <param name="color_frame_id"          type="str"  value="$(arg camera)_rgb_frame" />
-    <param name="depth_optical_frame_id"  type="str"  value="$(arg camera)_depth_optical_frame" />
-    <param name="color_optical_frame_id"  type="str"  value="$(arg camera)_rgb_optical_frame" />
-    <param name="ir_frame_id"             type="str"  value="$(arg camera)_ir_frame" />
-    <param name="ir2_frame_id"            type="str"  value="$(arg camera)_ir2_frame" />
+    <param name="serial_no"                type="str"  value="$(arg serial_no)" />
+    <param name="usb_port_id"              type="str"  value="$(arg usb_port_id)" />
+    <param name="camera_type"              type="str"  value="$(arg camera_type)" />
+    <param name="base_frame_id"            type="str"  value="$(arg camera)_link" />
+    <param name="depth_frame_id"           type="str"  value="$(arg camera)_depth_frame" />
+    <param name="color_frame_id"           type="str"  value="$(arg camera)_rgb_frame" />
+    <param name="ir_frame_id"              type="str"  value="$(arg camera)_ir_frame" />
+    <param name="ir2_frame_id"             type="str"  value="$(arg camera)_ir2_frame" />
+    <param name="fisheye_frame_id"         type="str"  value="$(arg camera)_fisheye_frame" />
+    <param name="imu_frame_id"             type="str"  value="$(arg camera)_imu_frame" />
+    <param name="depth_optical_frame_id"   type="str"  value="$(arg camera)_depth_optical_frame" />
+    <param name="color_optical_frame_id"   type="str"  value="$(arg camera)_rgb_optical_frame" />
+    <param name="ir_optical_frame_id"      type="str"  value="$(arg camera)_ir_optical_frame" />
+    <param name="ir2_optical_frame_id"     type="str"  value="$(arg camera)_ir2_optical_frame" />
+    <param name="fisheye_optical_frame_id" type="str"  value="$(arg camera)_fisheye_optical_frame" />
+    <param name="imu_optical_frame_id"     type="str"  value="$(arg camera)_imu_optical_frame" />
 
     <remap from="depth"    to="$(arg depth)" />
     <remap from="color"    to="$(arg rgb)" />
     <remap from="ir"       to="$(arg ir)" />
     <remap from="ir2"      to="$(arg ir2)" />
+    <remap from="fisheye"  to="$(arg fisheye)" />
+    <remap from="imu"      to="$(arg imu)" />
   </node>
 </launch>

--- a/realsense_camera/launch/zr300_nodelet_default.launch
+++ b/realsense_camera/launch/zr300_nodelet_default.launch
@@ -1,0 +1,20 @@
+<!-- Sample launch file for using RealSense ZR300 camera with default configurations -->
+<launch>
+  <arg name="manager"      value="nodelet_manager" />
+  <arg name="camera"       default="camera" />
+  <arg name="camera_type"  default="ZR300" /> <!-- Type of camera -->
+  <arg name="serial_no"    default="" />
+  <arg name="usb_port_id"  default="" /> <!-- USB "Bus#-Port#" -->
+
+  <group ns="$(arg camera)">
+    <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>
+
+    <include file="$(find realsense_camera)/launch/includes/nodelet.launch.xml">
+      <arg name="manager"      value="$(arg manager)" />
+      <arg name="camera"       value="$(arg camera)" />
+      <arg name="camera_type"  value="$(arg camera_type)" />
+      <arg name="serial_no"    value="$(arg serial_no)" />
+      <arg name="usb_port_id"  value="$(arg usb_port_id)" />
+    </include>
+  </group>
+</launch>

--- a/realsense_camera/msg/IMUInfo.msg
+++ b/realsense_camera/msg/IMUInfo.msg
@@ -1,0 +1,6 @@
+# header.frame_id is either set to "imu_accel" or "imu_gyro"
+# to distinguish between "accel" and "gyro" info.
+std_msgs/Header header
+float64[12] data
+float64[3] noise_variances
+float64[3] bias_variances

--- a/realsense_camera/nodelet_plugins.xml
+++ b/realsense_camera/nodelet_plugins.xml
@@ -16,4 +16,10 @@
   Intel(R) RealSense(TM) SR300 Camera nodelet.
   </description>
   </class>
+
+  <class name="realsense_camera/ZR300Nodelet" type="realsense_camera::ZR300Nodelet" base_class_type="nodelet::Nodelet">
+  <description>
+  Intel(R) RealSense(TM) ZR300 Camera nodelet.
+  </description>
+  </class>
 </library>

--- a/realsense_camera/src/r200_nodelet.cpp
+++ b/realsense_camera/src/r200_nodelet.cpp
@@ -258,7 +258,6 @@ namespace realsense_camera
     // level is the ORing of all levels which have a changed value
     std::bitset<32> bit_level{level};
 
-
     ROS_INFO_STREAM(nodelet_name_ << " - Setting dynamic camera options");
 
     // Set flags

--- a/realsense_camera/src/zr300_nodelet.cpp
+++ b/realsense_camera/src/zr300_nodelet.cpp
@@ -1,0 +1,603 @@
+/******************************************************************************
+ Copyright (c) 2016, Intel Corporation
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ 3. Neither the name of the copyright holder nor the names of its contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+#include <realsense_camera/zr300_nodelet.h>
+
+PLUGINLIB_EXPORT_CLASS (realsense_camera::ZR300Nodelet, nodelet::Nodelet)
+
+namespace realsense_camera
+{
+  /*
+   * Initialize the nodelet.
+   */
+  void ZR300Nodelet::onInit()
+  {
+    format_[RS_STREAM_COLOR] = RS_FORMAT_RGB8;
+    encoding_[RS_STREAM_COLOR] = sensor_msgs::image_encodings::RGB8;
+    cv_type_[RS_STREAM_COLOR] = CV_8UC3;
+    unit_step_size_[RS_STREAM_COLOR] = sizeof(unsigned char) * 3;
+
+    format_[RS_STREAM_DEPTH] = RS_FORMAT_Z16;
+    encoding_[RS_STREAM_DEPTH] = sensor_msgs::image_encodings::TYPE_16UC1;
+    cv_type_[RS_STREAM_DEPTH] = CV_16UC1;
+    unit_step_size_[RS_STREAM_DEPTH] = sizeof(uint16_t);
+
+    format_[RS_STREAM_INFRARED] = RS_FORMAT_Y8;
+    encoding_[RS_STREAM_INFRARED] = sensor_msgs::image_encodings::TYPE_8UC1;
+    cv_type_[RS_STREAM_INFRARED] = CV_8UC1;
+    unit_step_size_[RS_STREAM_INFRARED] = sizeof(unsigned char);
+
+    format_[RS_STREAM_INFRARED2] = RS_FORMAT_Y8;
+    encoding_[RS_STREAM_INFRARED2] = sensor_msgs::image_encodings::TYPE_8UC1;
+    cv_type_[RS_STREAM_INFRARED2] = CV_8UC1;
+    unit_step_size_[RS_STREAM_INFRARED2] = sizeof(unsigned char);
+
+    format_[RS_STREAM_FISHEYE] = RS_FORMAT_RAW8;
+    encoding_[RS_STREAM_FISHEYE] = sensor_msgs::image_encodings::TYPE_8UC1;
+    cv_type_[RS_STREAM_FISHEYE] = CV_8UC1;
+    unit_step_size_[RS_STREAM_FISHEYE] = sizeof(unsigned char);
+
+    max_z_ = ZR300_MAX_Z;
+
+    BaseNodelet::onInit();
+
+    if (enable_imu_ == true)
+    {
+      imu_thread_ =
+          boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&ZR300Nodelet::prepareIMU, this)));
+    }
+  }
+
+  /*
+   * Get the nodelet parameters.
+   */
+  void ZR300Nodelet::getParameters()
+  {
+    BaseNodelet::getParameters();
+    pnh_.param("ir2_frame_id", frame_id_[RS_STREAM_INFRARED2], DEFAULT_IR2_FRAME_ID);
+    pnh_.param("ir2_optical_frame_id", optical_frame_id_[RS_STREAM_INFRARED2], DEFAULT_IR2_OPTICAL_FRAME_ID);
+    pnh_.param("enable_fisheye", enable_[RS_STREAM_FISHEYE], ENABLE_FISHEYE);
+    pnh_.param("enable_imu", enable_imu_, ENABLE_IMU);
+    pnh_.param("fisheye_width", width_[RS_STREAM_FISHEYE], FISHEYE_WIDTH);
+    pnh_.param("fisheye_height", height_[RS_STREAM_FISHEYE], FISHEYE_HEIGHT);
+    pnh_.param("fisheye_fps", fps_[RS_STREAM_FISHEYE], FISHEYE_FPS);
+    pnh_.param("fisheye_frame_id", frame_id_[RS_STREAM_FISHEYE], DEFAULT_FISHEYE_FRAME_ID);
+    pnh_.param("fisheye_optical_frame_id", optical_frame_id_[RS_STREAM_FISHEYE], DEFAULT_FISHEYE_OPTICAL_FRAME_ID);
+    pnh_.param("imu_frame_id", imu_frame_id_, DEFAULT_IMU_FRAME_ID);
+    pnh_.param("imu_optical_frame_id", imu_optical_frame_id_, DEFAULT_IMU_OPTICAL_FRAME_ID);
+  }
+
+  /*
+   * Advertise topics.
+   */
+  void ZR300Nodelet::advertiseTopics()
+  {
+    BaseNodelet::advertiseTopics();
+    ros::NodeHandle ir2_nh(nh_, IR2_NAMESPACE);
+    image_transport::ImageTransport ir2_image_transport(ir2_nh);
+    camera_publisher_[RS_STREAM_INFRARED2] = ir2_image_transport.advertiseCamera(IR2_TOPIC, 1);
+
+    ros::NodeHandle fisheye_nh(nh_, FISHEYE_NAMESPACE);
+    image_transport::ImageTransport fisheye_image_transport(fisheye_nh);
+    camera_publisher_[RS_STREAM_FISHEYE] = fisheye_image_transport.advertiseCamera(FISHEYE_TOPIC, 1);
+
+    ros::NodeHandle imu_nh(nh_, IMU_NAMESPACE);
+    imu_publisher_ = imu_nh.advertise<sensor_msgs::Imu>(IMU_TOPIC, 1000);
+  }
+
+  /*
+   * Advertise services.
+   */
+  void ZR300Nodelet::advertiseServices()
+  {
+    BaseNodelet::advertiseServices();
+    get_imu_info_ = pnh_.advertiseService(IMU_INFO_SERVICE, &ZR300Nodelet::getIMUInfo, this);
+  }
+
+  /*
+   * Get IMU Info.
+   */
+  bool ZR300Nodelet::getIMUInfo(realsense_camera::GetIMUInfo::Request & req,
+      realsense_camera::GetIMUInfo::Response & res)
+  {
+    ros::Time header_stamp = ros::Time::now();
+    std::string header_frame_id;
+
+
+    rs_motion_intrinsics imu_intrinsics;
+    rs_get_motion_intrinsics(rs_device_, &imu_intrinsics, &rs_error_);
+    checkError();
+
+/*TODO
+    std::transform(IMU_ACCEL.begin(), IMU_ACCEL.end(), header_frame_id.begin(), ::tolower);
+    getIMUSensorInfo(&res.accel, imu_intrinsics.acc, header_stamp, header_frame_id);
+
+    std::transform(IMU_GYRO.begin(), IMU_GYRO.end(), header_frame_id.begin(), ::tolower);
+    getIMUSensorInfo(&res.gyro, imu_intrinsics.gyro, header_stamp, header_frame_id);
+*/
+
+    int index = 0;
+    res.accel.header.stamp = header_stamp;
+    res.accel.header.frame_id = IMU_ACCEL;
+    std::transform(res.accel.header.frame_id.begin(), res.accel.header.frame_id.end(),
+        res.accel.header.frame_id.begin(), ::tolower);
+
+    for (int i = 0; i < 3; ++i)
+    {
+      for (int j = 0; j < 4; ++j)
+      {
+        res.accel.data[index] = imu_intrinsics.acc.data[i][j];
+        ++index;
+      }
+      res.accel.noise_variances[i] = imu_intrinsics.acc.noise_variances[i];
+      res.accel.bias_variances[i] = imu_intrinsics.acc.bias_variances[i];
+    }
+
+    index = 0;
+    res.gyro.header.stamp = header_stamp;
+    res.gyro.header.frame_id = IMU_GYRO;
+    std::transform(res.gyro.header.frame_id.begin(), res.gyro.header.frame_id.end(),
+        res.gyro.header.frame_id.begin(), ::tolower);
+    for (int i = 0; i < 3; ++i)
+    {
+      for (int j = 0; j < 4; ++j)
+      {
+        res.gyro.data[index] = imu_intrinsics.gyro.data[i][j];
+        ++index;
+      }
+      res.gyro.noise_variances[i] = imu_intrinsics.gyro.noise_variances[i];
+      res.gyro.bias_variances[i] = imu_intrinsics.gyro.bias_variances[i];
+    }
+
+    return true;
+  }
+
+  /*
+   * Get IMU Info for each IMU sensor
+   */
+/* TODO
+  void getIMUSensorInfo(realsense_camera::IMUInfo * imu_info,
+      rs_motion_device_intrinsic imu_intrinsic, ros::Time header_stamp, std::string header_frame_id)
+  {
+    int index = 0;
+    imu_info->header.stamp = header_stamp;
+    imu_info->header.frame_id = header_frame_id;
+    for (int i = 0; i < 3; ++i)
+    {
+      for (int j = 0; j < 4; ++j)
+      {
+        imu_info->data[index] = imu_intrinsic.data[i][j];
+        ++index;
+      }
+      imu_info->noise_variances[i] = imu_intrinsic.noise_variances[i];
+      imu_info->bias_variances[i] = imu_intrinsic.bias_variances[i];
+    }
+  }
+*/
+
+  /*
+   * Set Dynamic Reconfigure Server and return the dynamic params.
+   */
+  std::vector<std::string> ZR300Nodelet::setDynamicReconfServer()
+  {
+    dynamic_reconf_server_.reset(new dynamic_reconfigure::Server<realsense_camera::zr300_paramsConfig>(pnh_));
+
+    // Get dynamic options from the dynamic reconfigure server.
+    realsense_camera::zr300_paramsConfig params_config;
+    dynamic_reconf_server_->getConfigDefault(params_config);
+    std::vector<realsense_camera::zr300_paramsConfig::AbstractParamDescriptionConstPtr> param_desc = params_config.__getParamDescriptions__();
+    std::vector<std::string> dynamic_params;
+    for (realsense_camera::zr300_paramsConfig::AbstractParamDescriptionConstPtr param_desc_ptr: param_desc)
+    {
+      dynamic_params.push_back((* param_desc_ptr).name);
+    }
+
+    return dynamic_params;
+  }
+
+  /*
+   * Start Dynamic Reconfigure Callback.
+   */
+  void ZR300Nodelet::startDynamicReconfCallback()
+  {
+    dynamic_reconf_server_->setCallback(boost::bind(&ZR300Nodelet::configCallback, this, _1, _2));
+  }
+
+  /*
+   * Get the dynamic param values.
+   */
+  void ZR300Nodelet::configCallback(realsense_camera::zr300_paramsConfig &config, uint32_t level)
+  {
+    // Set flags
+    if (config.enable_depth == false)
+    {
+      if (enable_[RS_STREAM_COLOR] == false)
+      {
+        ROS_INFO_STREAM(nodelet_name_ << " - Color stream is also disabled. Cannot disable depth stream");
+        config.enable_depth = true;
+      }
+      else
+      {
+        enable_[RS_STREAM_DEPTH] = false;
+      }
+    }
+    else
+    {
+      enable_[RS_STREAM_DEPTH] = true;
+    }
+
+    // Set common options
+    rs_set_device_option(rs_device_, RS_OPTION_COLOR_BACKLIGHT_COMPENSATION, config.color_backlight_compensation, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_COLOR_BRIGHTNESS, config.color_brightness, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_COLOR_CONTRAST, config.color_contrast, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_COLOR_EXPOSURE, config.color_exposure, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_COLOR_GAIN, config.color_gain, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_COLOR_GAMMA, config.color_gamma, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_COLOR_HUE, config.color_hue, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_COLOR_SATURATION, config.color_saturation, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_COLOR_SHARPNESS, config.color_sharpness, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_COLOR_ENABLE_AUTO_WHITE_BALANCE, config.color_enable_auto_white_balance, 0);
+    if (config.color_enable_auto_white_balance == 0)
+    {
+      rs_set_device_option(rs_device_, RS_OPTION_COLOR_WHITE_BALANCE, config.color_white_balance, 0);
+    }
+    rs_set_device_option(rs_device_, RS_OPTION_COLOR_ENABLE_AUTO_EXPOSURE, config.color_enable_auto_exposure, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_R200_LR_AUTO_EXPOSURE_ENABLED, config.r200_lr_auto_exposure_enabled, 0);
+    if (config.r200_lr_auto_exposure_enabled == 0)
+    {
+      rs_set_device_option(rs_device_, RS_OPTION_R200_LR_EXPOSURE, config.r200_lr_exposure, 0);
+    }
+    rs_set_device_option(rs_device_, RS_OPTION_R200_LR_GAIN, config.r200_lr_gain, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_R200_EMITTER_ENABLED, config.r200_emitter_enabled, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CLAMP_MIN, config.r200_depth_clamp_min, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CLAMP_MAX, config.r200_depth_clamp_max, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_ESTIMATE_MEDIAN_DECREMENT,
+        config.r200_depth_control_estimate_median_decrement, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_ESTIMATE_MEDIAN_INCREMENT,
+        config.r200_depth_control_estimate_median_increment, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_MEDIAN_THRESHOLD, config.r200_depth_control_median_threshold, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_SCORE_MINIMUM_THRESHOLD,
+        config.r200_depth_control_score_minimum_threshold, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_SCORE_MAXIMUM_THRESHOLD,
+        config.r200_depth_control_score_maximum_threshold, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_TEXTURE_COUNT_THRESHOLD,
+        config.r200_depth_control_texture_count_threshold, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_TEXTURE_DIFFERENCE_THRESHOLD,
+        config.r200_depth_control_texture_difference_threshold, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_SECOND_PEAK_THRESHOLD,
+        config.r200_depth_control_second_peak_threshold, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_NEIGHBOR_THRESHOLD,
+        config.r200_depth_control_neighbor_threshold, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_LR_THRESHOLD,
+        config.r200_depth_control_lr_threshold, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_FISHEYE_EXPOSURE,
+        config.fisheye_exposure, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_FISHEYE_GAIN, config.fisheye_gain, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_FISHEYE_STROBE, config.fisheye_strobe, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_FISHEYE_EXTERNAL_TRIGGER, config.fisheye_external_trigger, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_FISHEYE_ENABLE_AUTO_EXPOSURE, config.fisheye_enable_auto_exposure, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_FISHEYE_AUTO_EXPOSURE_MODE, config.fisheye_auto_exposure_mode, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_FISHEYE_AUTO_EXPOSURE_ANTIFLICKER_RATE,
+        config.fisheye_auto_exposure_antiflicker_rate, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_FISHEYE_AUTO_EXPOSURE_PIXEL_SAMPLE_RATE,
+        config.fisheye_auto_exposure_pixel_sample_rate, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_FISHEYE_AUTO_EXPOSURE_SKIP_FRAMES,
+        config.fisheye_auto_exposure_skip_frames, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_FRAMES_QUEUE_SIZE, config.frames_queue_size, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_HARDWARE_LOGGER_ENABLED, config.hardware_logger_enabled, 0);
+  }
+
+  /*
+   * Set the streams according to their corresponding flag values.
+   */
+  void ZR300Nodelet::setStreams()
+  {
+    BaseNodelet::setStreams();
+
+    if (enable_[RS_STREAM_DEPTH] == true)
+    {
+      enableStream(RS_STREAM_INFRARED2, width_[RS_STREAM_DEPTH], height_[RS_STREAM_DEPTH], format_[RS_STREAM_INFRARED2],
+          fps_[RS_STREAM_DEPTH]);
+      if (camera_info_ptr_[RS_STREAM_INFRARED2] == NULL)
+      {
+        ROS_DEBUG_STREAM(nodelet_name_ << " - Allocating resources for " << STREAM_DESC[RS_STREAM_INFRARED2]);
+        getStreamCalibData(RS_STREAM_INFRARED2);
+        step_[RS_STREAM_INFRARED2] = camera_info_ptr_[RS_STREAM_INFRARED2]->width * unit_step_size_[RS_STREAM_INFRARED2];
+        image_[RS_STREAM_INFRARED2] = cv::Mat(camera_info_ptr_[RS_STREAM_INFRARED2]->height,
+            camera_info_ptr_[RS_STREAM_INFRARED2]->width, cv_type_[RS_STREAM_INFRARED2], cv::Scalar(0, 0, 0));
+      }
+      ts_[RS_STREAM_INFRARED2] = -1;
+    }
+    else if (enable_[RS_STREAM_DEPTH] == false)
+    {
+      disableStream(RS_STREAM_INFRARED2);
+    }
+
+    if (enable_[RS_STREAM_FISHEYE] == true)
+    {
+      enableStream(RS_STREAM_FISHEYE, width_[RS_STREAM_FISHEYE], height_[RS_STREAM_FISHEYE], format_[RS_STREAM_FISHEYE],
+              fps_[RS_STREAM_FISHEYE]);
+      if (camera_info_ptr_[RS_STREAM_FISHEYE] == NULL)
+      {
+        ROS_DEBUG_STREAM(nodelet_name_ << " - Allocating resources for " << STREAM_DESC[RS_STREAM_FISHEYE]);
+        getStreamCalibData(RS_STREAM_FISHEYE);
+        step_[RS_STREAM_FISHEYE] = camera_info_ptr_[RS_STREAM_FISHEYE]->width * unit_step_size_[RS_STREAM_FISHEYE];
+        image_[RS_STREAM_FISHEYE] = cv::Mat(camera_info_ptr_[RS_STREAM_FISHEYE]->height,
+            camera_info_ptr_[RS_STREAM_FISHEYE]->width, cv_type_[RS_STREAM_FISHEYE], cv::Scalar(0, 0, 0));
+      }
+      ts_[RS_STREAM_FISHEYE] = -1;
+    }
+    else if (enable_[RS_STREAM_FISHEYE] == false)
+    {
+      disableStream(RS_STREAM_FISHEYE);
+    }
+  }
+
+  /*
+   * Publish topics for native streams.
+   */
+  void ZR300Nodelet::publishTopics()
+  {
+    BaseNodelet::publishTopics();
+
+    publishTopic(RS_STREAM_INFRARED2);
+    publishTopic(RS_STREAM_FISHEYE);
+  }
+
+  /*
+   * Prepare IMU.
+   */
+  void ZR300Nodelet::prepareIMU()
+  {
+    setIMUCallbacks();
+
+    ROS_INFO_STREAM(nodelet_name_ << " - Enabling IMU");
+    rs_enable_motion_tracking_cpp(rs_device_, new rs::motion_callback(motion_handler_),
+        new rs::timestamp_callback(timestamp_handler_), &rs_error_);
+    checkError();
+    rs_start_source(rs_device_, (rs_source)rs::source::motion_data, &rs_error_);
+    checkError();
+    prev_imu_ts_ = -1;
+    while (ros::ok())
+    {
+      if (imu_publisher_.getNumSubscribers() > 0)
+      {
+        if (prev_imu_ts_ != imu_ts_)
+        {
+          sensor_msgs::Imu imu_msg = sensor_msgs::Imu();
+          imu_msg.header.stamp = ros::Time::now();
+          imu_msg.header.frame_id = imu_optical_frame_id_;
+
+          imu_msg.orientation.x = 0.0;
+          imu_msg.orientation.y = 0.0;
+          imu_msg.orientation.z = 0.0;
+          imu_msg.orientation.w = 0.0;
+          imu_msg.orientation_covariance = {-1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+
+          imu_msg.angular_velocity.x = imu_angular_vel_[0];
+          imu_msg.angular_velocity.y = imu_angular_vel_[1];
+          imu_msg.angular_velocity.z = imu_angular_vel_[2];
+
+          imu_msg.linear_acceleration.x = imu_linear_accel_[0];
+          imu_msg.linear_acceleration.y = imu_linear_accel_[1];
+          imu_msg.linear_acceleration.z = imu_linear_accel_[2];
+
+          for (int i = 0; i < 9; ++i)
+          {
+            imu_msg.angular_velocity_covariance[i] = imu_angular_vel_cov_[i];
+            imu_msg.linear_acceleration_covariance[i] = imu_linear_accel_cov_[i];
+          }
+
+          imu_publisher_.publish(imu_msg);
+          prev_imu_ts_ = imu_ts_;
+        }
+      }
+    }
+
+    rs_stop_source(rs_device_, (rs_source)rs::source::motion_data, &rs_error_);
+    checkError();
+    rs_disable_motion_tracking(rs_device_, &rs_error_);
+    checkError();
+  }
+
+  /*
+   * Set IMU callbacks.
+   */
+  void ZR300Nodelet::setIMUCallbacks()
+  {
+    motion_handler_ = [&](rs::motion_data entry)
+    {
+        auto now = std::chrono::system_clock::now().time_since_epoch();
+        auto sys_time = std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
+        imu_ts_ = sys_time;
+        if (entry.timestamp_data.source_id == RS_EVENT_IMU_GYRO)
+        {
+          for (int i = 0; i < 3; ++i)
+          {
+            imu_angular_vel_[i] = entry.axes[i];
+            imu_linear_accel_[i] = 0.0;
+          }
+          imu_angular_vel_cov_[0] = 0.0;
+          imu_linear_accel_cov_[0] = -1.0;
+        }
+        else if (entry.timestamp_data.source_id == RS_EVENT_IMU_ACCEL)
+        {
+          for (int i = 0; i < 3; ++i)
+          {
+            imu_angular_vel_[i] = 0.0;
+            imu_linear_accel_[i] = entry.axes[i];
+          }
+          imu_angular_vel_cov_[0] = -1.0;
+          imu_linear_accel_cov_[0] = 0.0;
+        }
+
+        ROS_DEBUG_STREAM(" - Motion,\t host time " << sys_time
+            << "\ttimestamp: " << std::setprecision(8) << (double)entry.timestamp_data.timestamp*IMU_UNITS_TO_MSEC
+            << "\tsource: " << (rs::event)entry.timestamp_data.source_id
+            << "\tframe_num: " << entry.timestamp_data.frame_number
+            << "\tx: " << std::setprecision(5) <<  entry.axes[0]
+            << "\ty: " << entry.axes[1]
+            << "\tz: " << entry.axes[2]);
+    };
+
+    // Get timestamp that syncs all sensors.
+    timestamp_handler_ = [](rs::timestamp_data entry)
+    {
+        auto now = std::chrono::system_clock::now().time_since_epoch();
+        auto sys_time = std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
+
+        ROS_DEBUG_STREAM(" - TimeEvent, host time " << sys_time
+            << "\ttimestamp: " << std::setprecision(8) << (double)entry.timestamp*IMU_UNITS_TO_MSEC
+            << "\tsource: " << (rs::event)entry.source_id
+            << "\tframe_num: " << entry.frame_number);
+    };
+  }
+
+  /*
+   * Prepare and publish transforms.
+   */
+  void ZR300Nodelet::publishStaticTransforms()
+  {
+    BaseNodelet::publishStaticTransforms();
+
+    tf::Quaternion q_i2io;
+    tf::Quaternion q_f2fo;
+    tf::Quaternion q_imu2imuo;
+    rs_extrinsics z_extrinsic;
+    geometry_msgs::TransformStamped b2i_msg;
+    geometry_msgs::TransformStamped i2io_msg;
+    geometry_msgs::TransformStamped b2f_msg;
+    geometry_msgs::TransformStamped f2fo_msg;
+    geometry_msgs::TransformStamped b2imu_msg;
+    geometry_msgs::TransformStamped imu2imuo_msg;
+
+    // Get offset between base frame and infrared2 frame
+    rs_get_device_extrinsics(rs_device_, RS_STREAM_INFRARED2, RS_STREAM_COLOR, &z_extrinsic, &rs_error_);
+    checkError();
+
+    // Transform base frame to infrared2 frame
+    b2i_msg.header.stamp = static_transform_ts_;
+    b2i_msg.header.frame_id = base_frame_id_;
+    b2i_msg.child_frame_id = frame_id_[RS_STREAM_INFRARED2];
+    b2i_msg.transform.translation.x =  z_extrinsic.translation[2];
+    b2i_msg.transform.translation.y = -z_extrinsic.translation[0];
+    b2i_msg.transform.translation.z = -z_extrinsic.translation[1];
+    b2i_msg.transform.rotation.x = 0;
+    b2i_msg.transform.rotation.y = 0;
+    b2i_msg.transform.rotation.z = 0;
+    b2i_msg.transform.rotation.w = 1;
+    static_tf_broadcaster_.sendTransform(b2i_msg);
+
+    // Transform infrared2 frame to infrared2 optical frame
+    q_i2io.setEuler(M_PI/2, 0.0, -M_PI/2);
+    i2io_msg.header.stamp = static_transform_ts_;
+    i2io_msg.header.frame_id = frame_id_[RS_STREAM_INFRARED2];
+    i2io_msg.child_frame_id = optical_frame_id_[RS_STREAM_INFRARED2];
+    i2io_msg.transform.translation.x = 0;
+    i2io_msg.transform.translation.y = 0;
+    i2io_msg.transform.translation.z = 0;
+    i2io_msg.transform.rotation.x = q_i2io.getX();
+    i2io_msg.transform.rotation.y = q_i2io.getY();
+    i2io_msg.transform.rotation.z = q_i2io.getZ();
+    i2io_msg.transform.rotation.w = q_i2io.getW();
+    static_tf_broadcaster_.sendTransform(i2io_msg);
+
+    // Get offset between base frame and fisheye frame
+    rs_get_device_extrinsics(rs_device_, RS_STREAM_FISHEYE, RS_STREAM_COLOR, &z_extrinsic, &rs_error_);
+    checkError();
+
+    // Transform base frame to fisheye frame
+    b2f_msg.header.stamp = static_transform_ts_;
+    b2f_msg.header.frame_id = base_frame_id_;
+    b2f_msg.child_frame_id = frame_id_[RS_STREAM_FISHEYE];
+    b2f_msg.transform.translation.x =  z_extrinsic.translation[2];
+    b2f_msg.transform.translation.y = -z_extrinsic.translation[0];
+    b2f_msg.transform.translation.z = -z_extrinsic.translation[1];
+    b2f_msg.transform.rotation.x = 0;
+    b2f_msg.transform.rotation.y = 0;
+    b2f_msg.transform.rotation.z = 0;
+    b2f_msg.transform.rotation.w = 1;
+    static_tf_broadcaster_.sendTransform(b2f_msg);
+
+    // Transform fisheye frame to fisheye optical frame
+    q_f2fo.setEuler(M_PI/2, 0.0, -M_PI/2);
+    f2fo_msg.header.stamp = static_transform_ts_;
+    f2fo_msg.header.frame_id = frame_id_[RS_STREAM_FISHEYE];
+    f2fo_msg.child_frame_id = optical_frame_id_[RS_STREAM_FISHEYE];
+    f2fo_msg.transform.translation.x = 0;
+    f2fo_msg.transform.translation.y = 0;
+    f2fo_msg.transform.translation.z = 0;
+    f2fo_msg.transform.rotation.x = q_f2fo.getX();
+    f2fo_msg.transform.rotation.y = q_f2fo.getY();
+    f2fo_msg.transform.rotation.z = q_f2fo.getZ();
+    f2fo_msg.transform.rotation.w = q_f2fo.getW();
+    static_tf_broadcaster_.sendTransform(f2fo_msg);
+
+
+    // Get offset between base frame and imu frame
+/*  Temporarily commenting out the code. Instead, hardcoding the values until fully supported by librealsense API.
+
+    rs_get_motion_extrinsics_from(rs_device_, RS_STREAM_COLOR, &z_extrinsic, &rs_error_);
+    checkError();
+*/
+    z_extrinsic.translation[0] = -0.07;
+    z_extrinsic.translation[1] = 0.0;
+    z_extrinsic.translation[2] = 0.0;
+
+    // Transform base frame to imu frame
+    b2imu_msg.header.stamp = static_transform_ts_;
+    b2imu_msg.header.frame_id = base_frame_id_;
+    b2imu_msg.child_frame_id = imu_frame_id_;
+    b2imu_msg.transform.translation.x =  z_extrinsic.translation[2];
+    b2imu_msg.transform.translation.y = -z_extrinsic.translation[0];
+    b2imu_msg.transform.translation.z = -z_extrinsic.translation[1];
+    b2imu_msg.transform.rotation.x = 0;
+    b2imu_msg.transform.rotation.y = 0;
+    b2imu_msg.transform.rotation.z = 0;
+    b2imu_msg.transform.rotation.w = 1;
+    static_tf_broadcaster_.sendTransform(b2imu_msg);
+
+    // Transform imu frame to imu optical frame
+    q_imu2imuo.setEuler(M_PI/2, 0.0, -M_PI/2);
+    imu2imuo_msg.header.stamp = static_transform_ts_;
+    imu2imuo_msg.header.frame_id = imu_frame_id_;
+    imu2imuo_msg.child_frame_id = imu_optical_frame_id_;
+    imu2imuo_msg.transform.translation.x = 0;
+    imu2imuo_msg.transform.translation.y = 0;
+    imu2imuo_msg.transform.translation.z = 0;
+    imu2imuo_msg.transform.rotation.x = q_imu2imuo.getX();
+    imu2imuo_msg.transform.rotation.y = q_imu2imuo.getY();
+    imu2imuo_msg.transform.rotation.z = q_imu2imuo.getZ();
+    imu2imuo_msg.transform.rotation.w = q_imu2imuo.getW();
+    static_tf_broadcaster_.sendTransform(imu2imuo_msg);
+
+  }
+}  // end namespace
+

--- a/realsense_camera/src/zr300_nodelet.cpp
+++ b/realsense_camera/src/zr300_nodelet.cpp
@@ -135,14 +135,6 @@ namespace realsense_camera
     rs_get_motion_intrinsics(rs_device_, &imu_intrinsics, &rs_error_);
     checkError();
 
-/*TODO
-    std::transform(IMU_ACCEL.begin(), IMU_ACCEL.end(), header_frame_id.begin(), ::tolower);
-    getIMUSensorInfo(&res.accel, imu_intrinsics.acc, header_stamp, header_frame_id);
-
-    std::transform(IMU_GYRO.begin(), IMU_GYRO.end(), header_frame_id.begin(), ::tolower);
-    getIMUSensorInfo(&res.gyro, imu_intrinsics.gyro, header_stamp, header_frame_id);
-*/
-
     int index = 0;
     res.accel.header.stamp = header_stamp;
     res.accel.header.frame_id = IMU_ACCEL;
@@ -180,29 +172,6 @@ namespace realsense_camera
   }
 
   /*
-   * Get IMU Info for each IMU sensor
-   */
-/* TODO
-  void getIMUSensorInfo(realsense_camera::IMUInfo * imu_info,
-      rs_motion_device_intrinsic imu_intrinsic, ros::Time header_stamp, std::string header_frame_id)
-  {
-    int index = 0;
-    imu_info->header.stamp = header_stamp;
-    imu_info->header.frame_id = header_frame_id;
-    for (int i = 0; i < 3; ++i)
-    {
-      for (int j = 0; j < 4; ++j)
-      {
-        imu_info->data[index] = imu_intrinsic.data[i][j];
-        ++index;
-      }
-      imu_info->noise_variances[i] = imu_intrinsic.noise_variances[i];
-      imu_info->bias_variances[i] = imu_intrinsic.bias_variances[i];
-    }
-  }
-*/
-
-  /*
    * Set Dynamic Reconfigure Server and return the dynamic params.
    */
   std::vector<std::string> ZR300Nodelet::setDynamicReconfServer()
@@ -231,10 +200,149 @@ namespace realsense_camera
   }
 
   /*
+   * Change the Depth Control Preset
+   */
+  void ZR300Nodelet::setDynamicReconfigDepthControlPreset(int preset)
+  {
+    // There is not a C++ API for dynamic reconfig so we need to use a system call
+    // Adding the sleep to ensure the current callback can end before we
+    // attempt the next callback from the system call.
+    std::string system_cmd = "(sleep 1 ; rosrun dynamic_reconfigure dynparam set "
+      + nodelet_name_ + " r200_dc_preset " + std::to_string(preset) + ")&";
+
+    int status = std::system(system_cmd.c_str());
+    if (status < 0)
+    {
+      ROS_WARN_STREAM(nodelet_name_ <<
+          " - Failed to set dynamic_reconfigure dc preset via system:"
+          << strerror(errno));
+    }
+    else
+    {
+      if (!WIFEXITED(status))
+      {
+        ROS_WARN_STREAM(nodelet_name_ <<
+            " - Failed to set dynamic_reconfigure dc preset via system");
+      }
+    }
+  }
+
+  /*
+   * Change the Depth Control Individual values
+   * GET ALL of the DC options from librealsense
+   * Call dynamic reconfig and set all 10 values as a set
+   */
+  std::string ZR300Nodelet::setDynamicReconfigDepthControlIndividuals()
+  {
+    std::string current_dc;
+    std::string option_value;
+
+    // There is not a C++ API for dynamic reconfig so we need to use a system call
+    // Adding the sleep to ensure the current callback can end before we
+    // attempt the next callback from the system call.
+    std::string system_cmd =
+      "(sleep 1 ; rosrun dynamic_reconfigure dynparam set ";
+    system_cmd += nodelet_name_ + " " +
+      "\"{" +
+      "'r200_dc_estimate_median_decrement':";
+    option_value =
+      std::to_string(static_cast<uint32_t>(rs_get_device_option(rs_device_,
+              RS_OPTION_R200_DEPTH_CONTROL_ESTIMATE_MEDIAN_DECREMENT, 0)));
+    current_dc += option_value + ":";
+    system_cmd += option_value +
+      ", 'r200_dc_estimate_median_increment':";
+    option_value =
+      std::to_string(static_cast<uint32_t>(rs_get_device_option(rs_device_,
+              RS_OPTION_R200_DEPTH_CONTROL_ESTIMATE_MEDIAN_INCREMENT, 0)));
+    current_dc += option_value + ":";
+    system_cmd += option_value +
+      ", 'r200_dc_median_threshold':";
+    option_value =
+      std::to_string(static_cast<uint32_t>(rs_get_device_option(rs_device_,
+              RS_OPTION_R200_DEPTH_CONTROL_MEDIAN_THRESHOLD, 0)));
+    current_dc += option_value + ":";
+    system_cmd += option_value +
+      ", 'r200_dc_score_minimum_threshold':";
+    option_value =
+      std::to_string(static_cast<uint32_t>(rs_get_device_option(rs_device_,
+              RS_OPTION_R200_DEPTH_CONTROL_SCORE_MINIMUM_THRESHOLD, 0)));
+    current_dc += option_value + ":";
+    system_cmd += option_value +
+      ", 'r200_dc_score_maximum_threshold':";
+    option_value =
+      std::to_string(static_cast<uint32_t>(rs_get_device_option(rs_device_,
+              RS_OPTION_R200_DEPTH_CONTROL_SCORE_MAXIMUM_THRESHOLD, 0)));
+    current_dc += option_value + ":";
+    system_cmd += option_value +
+      ", 'r200_dc_texture_count_threshold':";
+    option_value =
+      std::to_string(static_cast<uint32_t>(rs_get_device_option(rs_device_,
+              RS_OPTION_R200_DEPTH_CONTROL_TEXTURE_COUNT_THRESHOLD, 0)));
+    current_dc += option_value + ":";
+    system_cmd += option_value +
+      ", 'r200_dc_texture_difference_threshold':";
+    option_value =
+      std::to_string(static_cast<uint32_t>(rs_get_device_option(rs_device_,
+              RS_OPTION_R200_DEPTH_CONTROL_TEXTURE_DIFFERENCE_THRESHOLD, 0)));
+    current_dc += option_value + ":";
+    system_cmd += option_value +
+      ", 'r200_dc_second_peak_threshold':";
+    option_value =
+      std::to_string(static_cast<uint32_t>(rs_get_device_option(rs_device_,
+              RS_OPTION_R200_DEPTH_CONTROL_SECOND_PEAK_THRESHOLD, 0)));
+    current_dc += option_value + ":";
+    system_cmd += option_value +
+      ", 'r200_dc_neighbor_threshold':";
+    option_value =
+      std::to_string(static_cast<uint32_t>(rs_get_device_option(rs_device_,
+              RS_OPTION_R200_DEPTH_CONTROL_NEIGHBOR_THRESHOLD, 0)));
+    current_dc += option_value + ":";
+    system_cmd += option_value +
+      ", 'r200_dc_lr_threshold':";
+    option_value =
+      std::to_string(static_cast<uint32_t>(rs_get_device_option(rs_device_,
+              RS_OPTION_R200_DEPTH_CONTROL_LR_THRESHOLD, 0)));
+    current_dc += option_value;
+    system_cmd += option_value +
+      "}\")&";
+
+    ROS_DEBUG_STREAM(nodelet_name_ << " - Setting DC: " << system_cmd);
+
+    int status = std::system(system_cmd.c_str());
+    if (status < 0)
+    {
+      ROS_WARN_STREAM(nodelet_name_ <<
+          " - Failed to set dynamic_reconfigure dc manual via system:"
+          << strerror(errno));
+    }
+    else
+    {
+      if (!WIFEXITED(status))
+      {
+        ROS_WARN_STREAM(nodelet_name_ <<
+            " - Failed to set dynamic_reconfigure dc manual via system");
+      }
+    }
+
+    return current_dc;
+  }
+
+  /*
    * Get the dynamic param values.
    */
   void ZR300Nodelet::configCallback(realsense_camera::zr300_paramsConfig &config, uint32_t level)
   {
+    // Save the dc_preset value as there is no getter API for this value
+    static int dc_preset = -2;
+    int previous_dc_preset = dc_preset;
+    // Save the last depth control preset values as a string
+    static std::string last_dc;
+
+    // level is the ORing of all levels which have a changed value
+    std::bitset<32> bit_level{level};
+
+    ROS_INFO_STREAM(nodelet_name_ << " - Setting dynamic camera options");
+
     // Set flags
     if (config.enable_depth == false)
     {
@@ -278,25 +386,86 @@ namespace realsense_camera
     rs_set_device_option(rs_device_, RS_OPTION_R200_EMITTER_ENABLED, config.r200_emitter_enabled, 0);
     rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CLAMP_MIN, config.r200_depth_clamp_min, 0);
     rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CLAMP_MAX, config.r200_depth_clamp_max, 0);
-    rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_ESTIMATE_MEDIAN_DECREMENT,
-        config.r200_depth_control_estimate_median_decrement, 0);
-    rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_ESTIMATE_MEDIAN_INCREMENT,
-        config.r200_depth_control_estimate_median_increment, 0);
-    rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_MEDIAN_THRESHOLD, config.r200_depth_control_median_threshold, 0);
-    rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_SCORE_MINIMUM_THRESHOLD,
-        config.r200_depth_control_score_minimum_threshold, 0);
-    rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_SCORE_MAXIMUM_THRESHOLD,
-        config.r200_depth_control_score_maximum_threshold, 0);
-    rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_TEXTURE_COUNT_THRESHOLD,
-        config.r200_depth_control_texture_count_threshold, 0);
-    rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_TEXTURE_DIFFERENCE_THRESHOLD,
-        config.r200_depth_control_texture_difference_threshold, 0);
-    rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_SECOND_PEAK_THRESHOLD,
-        config.r200_depth_control_second_peak_threshold, 0);
-    rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_NEIGHBOR_THRESHOLD,
-        config.r200_depth_control_neighbor_threshold, 0);
-    rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_LR_THRESHOLD,
-        config.r200_depth_control_lr_threshold, 0);
+
+    // Depth Control Group Settings
+    // NOTE: do NOT use the config.groups values as they are zero the first time called
+    if (bit_level.test(5)) // 2^5 = 32 : Individual Depth Control settings
+    {
+      std::string current_dc;
+
+      ROS_DEBUG_STREAM(nodelet_name_ << " - Setting Individual Depth Control");
+
+      rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_ESTIMATE_MEDIAN_DECREMENT,
+          config.r200_dc_estimate_median_decrement, 0);
+      current_dc += std::to_string(static_cast<uint32_t>(config.r200_dc_estimate_median_decrement)) + ":";
+      rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_ESTIMATE_MEDIAN_INCREMENT,
+          config.r200_dc_estimate_median_increment, 0);
+      current_dc += std::to_string(static_cast<uint32_t>(config.r200_dc_estimate_median_increment)) + ":";
+      rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_MEDIAN_THRESHOLD,
+          config.r200_dc_median_threshold, 0);
+      current_dc += std::to_string(static_cast<uint32_t>(config.r200_dc_median_threshold)) + ":";
+      rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_SCORE_MINIMUM_THRESHOLD,
+          config.r200_dc_score_minimum_threshold, 0);
+      current_dc += std::to_string(static_cast<uint32_t>(config.r200_dc_score_minimum_threshold)) + ":";
+      rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_SCORE_MAXIMUM_THRESHOLD,
+          config.r200_dc_score_maximum_threshold, 0);
+      current_dc += std::to_string(static_cast<uint32_t>(config.r200_dc_score_maximum_threshold)) + ":";
+      rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_TEXTURE_COUNT_THRESHOLD,
+          config.r200_dc_texture_count_threshold, 0);
+      current_dc += std::to_string(static_cast<uint32_t>(config.r200_dc_texture_count_threshold)) + ":";
+      rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_TEXTURE_DIFFERENCE_THRESHOLD,
+          config.r200_dc_texture_difference_threshold, 0);
+      current_dc += std::to_string(static_cast<uint32_t>(config.r200_dc_texture_difference_threshold)) + ":";
+      rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_SECOND_PEAK_THRESHOLD,
+          config.r200_dc_second_peak_threshold, 0);
+      current_dc += std::to_string(static_cast<uint32_t>(config.r200_dc_second_peak_threshold)) + ":";
+      rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_NEIGHBOR_THRESHOLD,
+          config.r200_dc_neighbor_threshold, 0);
+      current_dc += std::to_string(static_cast<uint32_t>(config.r200_dc_neighbor_threshold)) + ":";
+      rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_LR_THRESHOLD,
+          config.r200_dc_lr_threshold, 0);
+      current_dc += std::to_string(static_cast<uint32_t>(config.r200_dc_lr_threshold));
+
+      // Preset also change in the same update callback?
+      if (bit_level.test(6)) // 2^6 = 64 : Depth Control Preset
+      {
+        dc_preset = config.r200_dc_preset;
+
+        if (previous_dc_preset != -2 && // not the first pass special case (-2)
+            dc_preset != -1) // not already set to unused (-1)
+        {
+          ROS_DEBUG_STREAM(nodelet_name_ << " - Forcing Depth Control Preset to Unused");
+          setDynamicReconfigDepthControlPreset(-1);
+        }
+      }
+      else
+      {
+        // Changing individual Depth Control params means preset is Unused/Invalid
+        // if the individual values are not the same as the preset values
+        if (dc_preset != -1 && current_dc != last_dc)
+        {
+          ROS_DEBUG_STREAM(nodelet_name_ << " - Setting Depth Control Preset to Unused");
+          setDynamicReconfigDepthControlPreset(-1);
+        }
+      }
+    }
+    else
+    { // Individual Depth Control not set
+      if (bit_level.test(6)) // 2^6 = 64 : Depth Control Preset
+      {
+        dc_preset = config.r200_dc_preset;
+
+        if (dc_preset != -1)
+        {
+          ROS_DEBUG_STREAM(nodelet_name_ << " - Set Depth Control Preset to " << dc_preset);
+          rs_apply_depth_control_preset(rs_device_, dc_preset);
+
+          // Save the preset value string
+          last_dc = setDynamicReconfigDepthControlIndividuals();
+        }
+      }
+    }
+
     rs_set_device_option(rs_device_, RS_OPTION_FISHEYE_EXPOSURE,
         config.fisheye_exposure, 0);
     rs_set_device_option(rs_device_, RS_OPTION_FISHEYE_GAIN, config.fisheye_gain, 0);

--- a/realsense_camera/srv/GetIMUInfo.srv
+++ b/realsense_camera/srv/GetIMUInfo.srv
@@ -1,0 +1,3 @@
+---
+IMUInfo accel
+IMUInfo gyro

--- a/realsense_camera/test/camera_core.h
+++ b/realsense_camera/test/camera_core.h
@@ -35,6 +35,7 @@
 #include <vector>
 
 #include <sensor_msgs/PointCloud2.h>
+#include <sensor_msgs/Imu.h>
 #include <sensor_msgs/point_cloud2_iterator.h>
 #include <sensor_msgs/image_encodings.h>
 #include <image_transport/image_transport.h>
@@ -67,18 +68,19 @@ int g_depth_width_exp = 0;
 uint32_t g_depth_step_exp; // Expected depth step.
 uint32_t g_color_step_exp; // Expected color step.
 uint32_t g_infrared1_step_exp; // Expected infrared1 step.
-uint32_t g_infrared2_step_exp; // Expected infrared2 step.
 
 bool g_enable_color = true;
 bool g_enable_depth = true;
+bool g_enable_fisheye = true;
+bool g_enable_imu = true;
 bool g_enable_pointcloud = false;
 
 std::string g_depth_encoding_exp; // Expected depth encoding.
 std::string g_color_encoding_exp; // Expected color encoding.
 std::string g_infrared1_encoding_exp; // Expected infrared1 encoding.
-std::string g_infrared2_encoding_exp; // Expected infrared2 encoding.
 
 image_transport::CameraSubscriber g_camera_subscriber[STREAM_COUNT];
+ros::Subscriber g_sub_imu;
 ros::Subscriber g_sub_pc;
 
 ros::ServiceClient g_settings_srv_client;
@@ -93,12 +95,15 @@ bool g_depth_recv = false;
 bool g_color_recv = false;
 bool g_infrared1_recv = false;
 bool g_infrared2_recv = false;
+bool g_fisheye_recv = false;
+bool g_imu_recv = false;
 bool g_pc_recv = false;
 
 float g_depth_avg = 0.0f;
 float g_color_avg = 0.0f;
 float g_infrared1_avg = 0.0f;
 float g_infrared2_avg = 0.0f;
+float g_fisheye_avg = 0.0f;
 float g_pc_depth_avg = 0.0f;
 
 int g_height_recv[STREAM_COUNT] = {0};
@@ -113,6 +118,7 @@ double g_color_caminfo_D_recv[5] = {0.0};
 double g_depth_caminfo_D_recv[5] = {0.0};
 double g_infrared1_caminfo_D_recv[5] = {0.0};
 double g_infrared2_caminfo_D_recv[5] = {0.0};
+double g_fisheye_caminfo_D_recv[5] = {0.0};
 
 double g_caminfo_rotation_recv[STREAM_COUNT][9] = {{0.0}};
 double g_caminfo_projection_recv[STREAM_COUNT][12] = {{0.0}};

--- a/realsense_camera/test/zr300_nodelet_default.test
+++ b/realsense_camera/test/zr300_nodelet_default.test
@@ -1,0 +1,14 @@
+<launch>
+  <arg name="camera"       value="camera" />
+  <arg name="camera_type"  default="ZR300" />
+
+  <!-- Start camera -->
+  <include file="$(find realsense_camera)/launch/zr300_nodelet_default.launch">
+    <arg name="camera"      value="$(arg camera)" />
+    <arg name="camera_type" value="$(arg camera_type)" />
+  </include>
+
+  <!-- Start test -->
+  <test pkg="realsense_camera" type="tests_camera_core" test-name="realsense_camera_test"
+    args="camera_type $(arg camera_type)" />
+</launch>


### PR DESCRIPTION
**Please ensure the above _guidelines for contributing_ are met.**

Fixes Issue: 
Added initial support for ZR300 camera

Changes proposed in this pull request: 
- Updated code for librealsense v1.9.7 compatibility.
- Added optical frame ids for IR and IR2 streams to keep it consistent with the Depth and Color streams.
- Added Fisheye stream for ZR300.
- Added IMU capability for ZR300.
- Added basic unit tests for Fisheye and IMU data
- Update README with ZR300 details and erratum.
