### PR TITLE
Drop invalid SR300 Camera option

### DIFF
--- a/realsense_camera/cfg/sr300_params.cfg
+++ b/realsense_camera/cfg/sr300_params.cfg
@@ -29,8 +29,6 @@ gen.add("f200_motion_range",                           int_t,  0,    "Motion Ran
 gen.add("f200_filter_option",                          int_t,  0,    "Filter Option",                5,         0,      7)
 gen.add("f200_confidence_threshold",                   int_t,  0,    "Confidence Threshold",         3,         0,      15)
 
-gen.add("sr300_dynamic_fps",                           int_t,  0,    "Dynamic Fps",                  0,         0,      0)
-
 # Following are the Auto range options
 gen.add("sr300_auto_range_enable_motion_versus_range", int_t,  0,    "Enable Motion Versus Range",   1,         0,      2)
 gen.add("sr300_auto_range_enable_laser",               int_t,  0,    "Enable Laser",                 1,         0,      1)

--- a/realsense_camera/src/sr300_nodelet.cpp
+++ b/realsense_camera/src/sr300_nodelet.cpp
@@ -136,7 +136,6 @@ namespace realsense_camera
     rs_set_device_option(rs_device_, RS_OPTION_F200_CONFIDENCE_THRESHOLD, config.f200_confidence_threshold, 0);
 
     // Set SR300 specific options
-    rs_set_device_option(rs_device_, RS_OPTION_SR300_DYNAMIC_FPS, config.sr300_dynamic_fps, 0);
     rs_set_device_option(rs_device_, RS_OPTION_SR300_AUTO_RANGE_ENABLE_MOTION_VERSUS_RANGE, config.sr300_auto_range_enable_motion_versus_range, 0);
     if (config.sr300_auto_range_enable_motion_versus_range == 1)
     {


### PR DESCRIPTION
Causes compilation failures with newer releases of librealsense.
Was never functional.
