### PR TITLE
Topic name publishing and remapping

### DIFF
--- a/realsense_camera/README.md
+++ b/realsense_camera/README.md
@@ -88,13 +88,13 @@ IR2 camera: Available only for <b>R200</b> cameras.
         Calibration data
 
 ####Services
-    get_settings (camera/get_settings)
+    get_settings (camera/driver/get_settings)
         Gets the current value of the supported camera options in "options:value" format separated by semicolon.
-    set_power < true/false > (camera/set_power < true/false >) # true - to power on the camera, false - to power off the camera
+    set_power < true/false > (camera/driver/set_power < true/false >) # true - to power on the camera, false - to power off the camera
         Sets camera power to turn camera on/off. It turns off the camera only if camera has no subscribers. Otherwise it returns false.
-    force_power < true/false > (camera/force_power < true/false >) # true - to power on the camera, false - to forcefully power off the camera
+    force_power < true/false > (camera/driver/force_power < true/false >) # true - to power on the camera, false - to forcefully power off the camera
         Sets camera power to turn camera on/off. It turns off the camera regardless of number of subscribers.
-    is_powered (camera/is_powered)
+    is_powered (camera/driver/is_powered)
         Gets current state of camera power. It checks whether camera is on or off and returns true or false respectively.
 
 ####Transform Frames

--- a/realsense_camera/include/realsense_camera/constants.h
+++ b/realsense_camera/include/realsense_camera/constants.h
@@ -56,11 +56,14 @@ namespace realsense_camera
     const std::string DEFAULT_COLOR_OPTICAL_FRAME_ID = "camera_rgb_optical_frame";
     const std::string DEFAULT_IR_FRAME_ID = "camera_ir_frame";
     const std::string DEFAULT_IR2_FRAME_ID = "camera_ir2_frame";
-    const std::string DEPTH_TOPIC = "camera/depth/image_raw";
-    const std::string COLOR_TOPIC = "camera/color/image_raw";
-    const std::string IR_TOPIC = "camera/ir/image_raw";
-    const std::string PC_TOPIC = "camera/depth/points";
-    const std::string SETTINGS_SERVICE = "camera/get_settings";
+    const std::string DEPTH_NAMESPACE = "depth";
+    const std::string DEPTH_TOPIC = "image_raw";
+    const std::string PC_TOPIC = "points";
+    const std::string COLOR_NAMESPACE = "color";
+    const std::string COLOR_TOPIC = "image_raw";
+    const std::string IR_NAMESPACE = "ir";
+    const std::string IR_TOPIC = "image_raw";
+    const std::string SETTINGS_SERVICE = "get_settings";
     const std::string STREAM_DESC[STREAM_COUNT] = {"Depth", "Color", "IR", "IR2"};
     const std::string CAMERA_IS_POWERED_SERVICE = "camera/is_powered";
     const std::string CAMERA_SET_POWER_SERVICE = "camera/set_power";
@@ -69,7 +72,8 @@ namespace realsense_camera
     const float MILLIMETER_METERS  = 0.001;
 
     // R200 Constants.
-    const std::string IR2_TOPIC = "camera/ir2/image_raw";
+    const std::string IR2_NAMESPACE = "ir2";
+    const std::string IR2_TOPIC = "image_raw";
     // Indoor Range: 0.7m - 3.5m, Outdoor Range: 10m
     const float R200_MAX_Z = 10.0f;   // in meters
 

--- a/realsense_camera/include/realsense_camera/constants.h
+++ b/realsense_camera/include/realsense_camera/constants.h
@@ -65,9 +65,9 @@ namespace realsense_camera
     const std::string IR_TOPIC = "image_raw";
     const std::string SETTINGS_SERVICE = "get_settings";
     const std::string STREAM_DESC[STREAM_COUNT] = {"Depth", "Color", "IR", "IR2"};
-    const std::string CAMERA_IS_POWERED_SERVICE = "camera/is_powered";
-    const std::string CAMERA_SET_POWER_SERVICE = "camera/set_power";
-    const std::string CAMERA_FORCE_POWER_SERVICE = "camera/force_power";
+    const std::string CAMERA_IS_POWERED_SERVICE = "is_powered";
+    const std::string CAMERA_SET_POWER_SERVICE = "set_power";
+    const std::string CAMERA_FORCE_POWER_SERVICE = "force_power";
     const double ROTATION_IDENTITY[] = {1, 0, 0, 0, 1, 0, 0, 0, 1};
     const float MILLIMETER_METERS  = 0.001;
 

--- a/realsense_camera/launch/f200_nodelet_default.launch
+++ b/realsense_camera/launch/f200_nodelet_default.launch
@@ -1,18 +1,20 @@
 <!-- Sample launch file for using RealSense F200 camera with default configurations -->
 <launch>
-  <arg name="manager"      value="nodelet_manager" />
   <arg name="camera"       default="camera" />
   <arg name="camera_type"  default="F200" /> <!-- Type of camera -->
   <arg name="serial_no"    default="" />
   <arg name="usb_port_id"  default="" /> <!-- USB "Bus#-Port#" -->
+  <arg name="manager"      value="$(arg camera)_nodelet_manager" />
 
-  <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>
+  <group ns="$(arg camera)">
+    <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>
 
-  <include file="$(find realsense_camera)/launch/includes/nodelet.launch.xml">
-    <arg name="manager"      value="$(arg manager)" />
-    <arg name="camera"       value="$(arg camera)" />
-    <arg name="camera_type"  value="$(arg camera_type)" />
-    <arg name="serial_no"    value="$(arg serial_no)" />
-    <arg name="usb_port_id"  value="$(arg usb_port_id)" />
-  </include>
+    <include file="$(find realsense_camera)/launch/includes/nodelet.launch.xml">
+      <arg name="manager"      value="$(arg manager)" />
+      <arg name="camera"       value="$(arg camera)" />
+      <arg name="camera_type"  value="$(arg camera_type)" />
+      <arg name="serial_no"    value="$(arg serial_no)" />
+      <arg name="usb_port_id"  value="$(arg usb_port_id)" />
+    </include>
+  </group>
 </launch>

--- a/realsense_camera/launch/includes/nodelet.launch.xml
+++ b/realsense_camera/launch/includes/nodelet.launch.xml
@@ -9,7 +9,7 @@
   <arg name="ir2"          default="ir2" />
   <arg name="serial_no"    default="" />
   <arg name="usb_port_id"  default="" />
-  <node pkg="nodelet" type="nodelet" name="$(arg camera)"
+  <node pkg="nodelet" type="nodelet" name="driver"
     args="load realsense_camera/$(arg camera_type)Nodelet $(arg manager)">
     <param name="serial_no"               type="str"  value="$(arg serial_no)" />
     <param name="usb_port_id"             type="str"  value="$(arg usb_port_id)" />
@@ -22,18 +22,9 @@
     <param name="ir_frame_id"             type="str"  value="$(arg camera)_ir_frame" />
     <param name="ir2_frame_id"            type="str"  value="$(arg camera)_ir2_frame" />
 
-    <remap from="camera/depth/image_raw"    to="$(arg camera)/$(arg depth)/image_raw" />
-    <remap from="camera/color/image_raw"    to="$(arg camera)/$(arg rgb)/image_raw" />
-    <remap from="camera/ir/image_raw"       to="$(arg camera)/$(arg ir)/image_raw" />
-    <remap from="camera/ir2/image_raw"      to="$(arg camera)/$(arg ir2)/image_raw" />
-    <remap from="camera/depth/points"       to="$(arg camera)/$(arg depth)/points" />
-    <remap from="camera/depth/camera_info"  to="$(arg camera)/$(arg depth)/camera_info" />
-    <remap from="camera/color/camera_info"  to="$(arg camera)/$(arg rgb)/camera_info" />
-    <remap from="camera/ir/camera_info"     to="$(arg camera)/$(arg ir)/camera_info" />
-    <remap from="camera/ir2/camera_info"    to="$(arg camera)/$(arg ir2)/camera_info" />
-    <remap from="camera/get_settings"       to="$(arg camera)/get_settings" />
-    <remap from="camera/set_power"          to="$(arg camera)/set_power" />
-    <remap from="camera/force_power"        to="$(arg camera)/force_power" />
-    <remap from="camera/is_powered"         to="$(arg camera)/is_powered" />
+    <remap from="depth"    to="$(arg depth)" />
+    <remap from="color"    to="$(arg rgb)" />
+    <remap from="ir"       to="$(arg ir)" />
+    <remap from="ir2"      to="$(arg ir2)" />
   </node>
 </launch>

--- a/realsense_camera/launch/includes/nodelet_rgbd.launch.xml
+++ b/realsense_camera/launch/includes/nodelet_rgbd.launch.xml
@@ -35,7 +35,7 @@
     <arg name="enable_pointcloud"   default="false" />
 <!-- realsense_camera -->
 
-    <node pkg="nodelet" type="nodelet" name="$(arg camera)"
+    <node pkg="nodelet" type="nodelet" name="driver"
         args="load realsense_camera/$(arg camera_type)Nodelet $(arg manager)">
         <param name="serial_no"               type="str"  value="$(arg serial_no)" />
         <param name="usb_port_id"             type="str"  value="$(arg usb_port_id)" />
@@ -59,14 +59,9 @@
         <param name="ir_frame_id"             type="str"  value="$(arg camera)_$(arg ir)_frame" />
         <param name="ir2_frame_id"            type="str"  value="$(arg camera)_$(arg ir2)_frame" />
 
-        <remap from="camera/depth/image_raw"        to="$(arg depth)/image_raw" />
-        <remap from="camera/color/image_raw"        to="$(arg rgb)/image_raw" />
-        <remap from="camera/ir/image_raw"           to="$(arg ir)/image_raw" />
-        <remap from="camera/ir2/image_raw"          to="$(arg ir2)/image_raw" />
-        <remap from="camera/depth/points"           to="$(arg depth)/points" />
-        <remap from="camera/depth/camera_info"      to="$(arg depth)/camera_info" />
-        <remap from="camera/color/camera_info"      to="$(arg rgb)/camera_info" />
-        <remap from="camera/ir/camera_info"         to="$(arg ir)/camera_info" />
-        <remap from="camera/ir2/camera_info"        to="$(arg ir2)/camera_info" />
+        <remap from="depth"    to="$(arg depth)" />
+        <remap from="color"    to="$(arg rgb)" />
+        <remap from="ir"       to="$(arg ir)" />
+        <remap from="ir2"      to="$(arg ir2)" />
     </node>
 </launch>

--- a/realsense_camera/launch/r200_nodelet_default.launch
+++ b/realsense_camera/launch/r200_nodelet_default.launch
@@ -1,18 +1,20 @@
 <!-- Sample launch file for using RealSense R200 camera with default configurations -->
 <launch>
-  <arg name="manager"      value="nodelet_manager" />
   <arg name="camera"       default="camera" />
   <arg name="camera_type"  default="R200" /> <!-- Type of camera -->
   <arg name="serial_no"    default="" />
   <arg name="usb_port_id"  default="" /> <!-- USB "Bus#-Port#" -->
+  <arg name="manager"      value="$(arg camera)_nodelet_manager" />
 
-  <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>
+  <group ns="$(arg camera)">
+    <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>
 
-  <include file="$(find realsense_camera)/launch/includes/nodelet.launch.xml">
-    <arg name="manager"      value="$(arg manager)" />
-    <arg name="camera"       value="$(arg camera)" />
-    <arg name="camera_type"  value="$(arg camera_type)" />
-    <arg name="serial_no"    value="$(arg serial_no)" />
-    <arg name="usb_port_id"  value="$(arg usb_port_id)" />
-  </include>
+    <include file="$(find realsense_camera)/launch/includes/nodelet.launch.xml">
+      <arg name="manager"      value="$(arg manager)" />
+      <arg name="camera"       value="$(arg camera)" />
+      <arg name="camera_type"  value="$(arg camera_type)" />
+      <arg name="serial_no"    value="$(arg serial_no)" />
+      <arg name="usb_port_id"  value="$(arg usb_port_id)" />
+    </include>
+  </group>
 </launch>

--- a/realsense_camera/launch/r200_nodelet_modify_params.launch
+++ b/realsense_camera/launch/r200_nodelet_modify_params.launch
@@ -20,26 +20,28 @@
   <arg name="depth_fps"         default="30" />
   <arg name="color_fps"         default="30" />
 
-  <param name="$(arg camera)/enable_depth"      type="bool" value="$(arg enable_depth)" />
-  <param name="$(arg camera)/enable_color"      type="bool" value="$(arg enable_color)" />
-  <param name="$(arg camera)/enable_pointcloud" type="bool" value="$(arg enable_pointcloud)" />
-  <param name="$(arg camera)/enable_tf"         type="bool" value="$(arg enable_tf)" />
-  <param name="$(arg camera)/mode"              type="str"  value="$(arg mode)" />
-  <param name="$(arg camera)/depth_width"       type="int"  value="$(arg depth_width)" />
-  <param name="$(arg camera)/depth_height"      type="int"  value="$(arg depth_height)" />
-  <param name="$(arg camera)/color_width"       type="int"  value="$(arg color_width)" />
-  <param name="$(arg camera)/color_height"      type="int"  value="$(arg color_height)" />
-  <param name="$(arg camera)/depth_fps"         type="int"  value="$(arg depth_fps)" />
-  <param name="$(arg camera)/color_fps"         type="int"  value="$(arg color_fps)" />
+  <param name="$(arg camera)/driver/enable_depth"      type="bool" value="$(arg enable_depth)" />
+  <param name="$(arg camera)/driver/enable_color"      type="bool" value="$(arg enable_color)" />
+  <param name="$(arg camera)/driver/enable_pointcloud" type="bool" value="$(arg enable_pointcloud)" />
+  <param name="$(arg camera)/driver/enable_tf"         type="bool" value="$(arg enable_tf)" />
+  <param name="$(arg camera)/driver/mode"              type="str"  value="$(arg mode)" />
+  <param name="$(arg camera)/driver/depth_width"       type="int"  value="$(arg depth_width)" />
+  <param name="$(arg camera)/driver/depth_height"      type="int"  value="$(arg depth_height)" />
+  <param name="$(arg camera)/driver/color_width"       type="int"  value="$(arg color_width)" />
+  <param name="$(arg camera)/driver/color_height"      type="int"  value="$(arg color_height)" />
+  <param name="$(arg camera)/driver/depth_fps"         type="int"  value="$(arg depth_fps)" />
+  <param name="$(arg camera)/driver/color_fps"         type="int"  value="$(arg color_fps)" />
   <!-- Refer to the README file for list of supported parameters -->
 
-  <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>
+  <group ns="$(arg camera)">
+    <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>
 
-  <include file="$(find realsense_camera)/launch/includes/nodelet.launch.xml">
-    <arg name="manager"      value="$(arg manager)" />
-    <arg name="camera"       value="$(arg camera)" />
-    <arg name="camera_type"  value="$(arg camera_type)" />
-    <arg name="serial_no"    value="$(arg serial_no)" />
-    <arg name="usb_port_id"  value="$(arg usb_port_id)" />
-  </include>
+    <include file="$(find realsense_camera)/launch/includes/nodelet.launch.xml">
+      <arg name="manager"      value="$(arg manager)" />
+      <arg name="camera"       value="$(arg camera)" />
+      <arg name="camera_type"  value="$(arg camera_type)" />
+      <arg name="serial_no"    value="$(arg serial_no)" />
+      <arg name="usb_port_id"  value="$(arg usb_port_id)" />
+    </include>
+  </group>
 </launch>

--- a/realsense_camera/launch/r200_nodelet_multiple_cameras.launch
+++ b/realsense_camera/launch/r200_nodelet_multiple_cameras.launch
@@ -1,24 +1,37 @@
 <!-- Sample launch file for using multiple RealSense R200 cameras -->
 <launch>
-  <arg name="manager" value="nodelet_manager" /> <!-- Single nodelet manager for all cameras -->
+  <arg name="camera1"              default="camera1" />
+  <arg name="camera1_camera_type"  default="R200"    /> <!-- Type of camera -->
+  <arg name="camera1_serial_no"    default=""        /> <!-- Note: Replace with actual serial number -->
+  <arg name="camera1_usb_port_id"  default=""        /> <!-- USB "Bus#-Port#" -->
+  <arg name="camera2"              default="camera2" />
+  <arg name="camera2_camera_type"  default="R200"    /> <!-- Type of camera -->
+  <arg name="camera2_serial_no"    default=""        /> <!-- Note: Replace with actual serial number -->
+  <arg name="camera2_usb_port_id"  default=""        /> <!-- USB "Bus#-Port#" -->
+  
+  <arg name="manager" value="camera_nodelet_manager" /> <!-- Single nodelet manager for all cameras -->
   <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>
 
   <!-- User must include the .xml file for each camera with unique values for "camera" and 
        either the "serial_no" or "usb_port_id" of the camera.
        "camera" should be a user friendly string that follows the ROS Names convention. -->
-  <include file="$(find realsense_camera)/launch/includes/nodelet.launch.xml">
-    <arg name="manager"      value="$(arg manager)" />
-    <arg name="camera"       value="camera1" />
-    <arg name="camera_type"  value="R200" /> <!-- Type of camera -->
-    <arg name="serial_no"    value="1" /> <!-- Note: Replace with actual serial number -->
-    <arg name="usb_port_id"  value="" /> <!-- USB "Bus#-Port#" -->
-  </include>
+  <group ns="$(arg camera1)">
+    <include file="$(find realsense_camera)/launch/includes/nodelet.launch.xml">
+      <arg name="manager"      value="/$(arg manager)" />
+      <arg name="camera"       value="$(arg camera1)" />
+      <arg name="camera_type"  value="$(arg camera1_camera_type)" />
+      <arg name="serial_no"    value="$(arg camera1_serial_no)" />
+      <arg name="usb_port_id"  value="$(arg camera1_usb_port_id)" />
+    </include>
+  </group> 
 
-  <include file="$(find realsense_camera)/launch/includes/nodelet.launch.xml">
-    <arg name="manager"      value="$(arg manager)" />
-    <arg name="camera"       value="camera2" />
-    <arg name="camera_type"  default="R200" /> <!-- Type of camera -->
-    <arg name="serial_no"    value="2" /> <!-- Note: Replace with actual serial number -->
-    <arg name="usb_port_id"  value="" /> <!-- USB "Bus#-Port#" -->
-  </include>
+  <group ns="$(arg camera2)">
+    <include file="$(find realsense_camera)/launch/includes/nodelet.launch.xml">
+      <arg name="manager"      value="/$(arg manager)" />
+      <arg name="camera"       value="$(arg camera2)" />
+      <arg name="camera_type"  value="$(arg camera2_camera_type)" />
+      <arg name="serial_no"    value="$(arg camera2_serial_no)" />
+      <arg name="usb_port_id"  value="$(arg camera2_usb_port_id)" />
+    </include>
+  </group>
 </launch>

--- a/realsense_camera/launch/sr300_nodelet_default.launch
+++ b/realsense_camera/launch/sr300_nodelet_default.launch
@@ -1,18 +1,20 @@
 <!-- Sample launch file for using RealSense SR300 camera with default configurations -->
 <launch>
-  <arg name="manager"      value="nodelet_manager" />
   <arg name="camera"       default="camera" />
   <arg name="camera_type"  default="SR300" /> <!-- Type of camera -->
   <arg name="serial_no"    default="" />
   <arg name="usb_port_id"  default="" /> <!-- USB "Bus#-Port#" -->
+  <arg name="manager"      value="$(arg camera)_nodelet_manager" />
 
-  <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>
+  <group ns="$(arg camera)">
+    <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>
 
-  <include file="$(find realsense_camera)/launch/includes/nodelet.launch.xml">
-    <arg name="manager"      value="$(arg manager)" />
-    <arg name="camera"       value="$(arg camera)" />
-    <arg name="camera_type"  value="$(arg camera_type)" />
-    <arg name="serial_no"    value="$(arg serial_no)" />
-    <arg name="usb_port_id"  value="$(arg usb_port_id)" />
-  </include>
+    <include file="$(find realsense_camera)/launch/includes/nodelet.launch.xml">
+      <arg name="manager"      value="$(arg manager)" />
+      <arg name="camera"       value="$(arg camera)" />
+      <arg name="camera_type"  value="$(arg camera_type)" />
+      <arg name="serial_no"    value="$(arg serial_no)" />
+      <arg name="usb_port_id"  value="$(arg usb_port_id)" />
+    </include>
+  </group>
 </launch>

--- a/realsense_camera/src/base_nodelet.cpp
+++ b/realsense_camera/src/base_nodelet.cpp
@@ -246,11 +246,18 @@ namespace realsense_camera
    */
   void BaseNodelet::advertiseTopics()
   {
-    image_transport::ImageTransport image_transport(nh_);
-    camera_publisher_[RS_STREAM_COLOR] = image_transport.advertiseCamera(COLOR_TOPIC, 1);
-    camera_publisher_[RS_STREAM_DEPTH] = image_transport.advertiseCamera(DEPTH_TOPIC, 1);
-    camera_publisher_[RS_STREAM_INFRARED] = image_transport.advertiseCamera(IR_TOPIC, 1);
-    pointcloud_publisher_ = nh_.advertise<sensor_msgs::PointCloud2>(PC_TOPIC, 1);
+    ros::NodeHandle color_nh(nh_, COLOR_NAMESPACE);
+    image_transport::ImageTransport color_image_transport(color_nh);
+    camera_publisher_[RS_STREAM_COLOR] = color_image_transport.advertiseCamera(COLOR_TOPIC, 1);
+
+    ros::NodeHandle depth_nh(nh_, DEPTH_NAMESPACE);
+    image_transport::ImageTransport depth_image_transport(depth_nh);
+    camera_publisher_[RS_STREAM_DEPTH] = depth_image_transport.advertiseCamera(DEPTH_TOPIC, 1);
+    pointcloud_publisher_ = depth_nh.advertise<sensor_msgs::PointCloud2>(PC_TOPIC, 1);
+
+    ros::NodeHandle ir_nh(nh_, IR_NAMESPACE);
+    image_transport::ImageTransport ir_image_transport(ir_nh);
+    camera_publisher_[RS_STREAM_INFRARED] = ir_image_transport.advertiseCamera(IR_TOPIC, 1);
   }
 
   /*
@@ -258,11 +265,11 @@ namespace realsense_camera
    */
   void BaseNodelet::advertiseServices()
   {
-    get_options_service_ = nh_.advertiseService(SETTINGS_SERVICE, &BaseNodelet::getCameraOptionValues, this);
-    set_power_service_ = nh_.advertiseService(CAMERA_SET_POWER_SERVICE, &BaseNodelet::setPowerCameraService, this);
-    force_power_service_ = nh_.advertiseService(CAMERA_FORCE_POWER_SERVICE, &BaseNodelet::forcePowerCameraService, this);
-    is_powered_service_ = nh_.advertiseService(CAMERA_IS_POWERED_SERVICE, &BaseNodelet::isPoweredCameraService, this);
-}
+    get_options_service_ = pnh_.advertiseService(SETTINGS_SERVICE, &BaseNodelet::getCameraOptionValues, this);
+    set_power_service_ = pnh_.advertiseService(CAMERA_SET_POWER_SERVICE, &BaseNodelet::setPowerCameraService, this);
+    force_power_service_ = pnh_.advertiseService(CAMERA_FORCE_POWER_SERVICE, &BaseNodelet::forcePowerCameraService, this);
+    is_powered_service_ = pnh_.advertiseService(CAMERA_IS_POWERED_SERVICE, &BaseNodelet::isPoweredCameraService, this);
+  }
 
   /*
    * Get the latest values of the camera options.

--- a/realsense_camera/src/r200_nodelet.cpp
+++ b/realsense_camera/src/r200_nodelet.cpp
@@ -79,9 +79,9 @@ namespace realsense_camera
   void R200Nodelet::advertiseTopics()
   {
     BaseNodelet::advertiseTopics();
-
-    image_transport::ImageTransport image_transport(nh_);
-    camera_publisher_[RS_STREAM_INFRARED2] = image_transport.advertiseCamera(IR2_TOPIC, 1);
+    ros::NodeHandle ir2_nh(nh_, IR2_NAMESPACE);
+    image_transport::ImageTransport ir2_image_transport(ir2_nh);
+    camera_publisher_[RS_STREAM_INFRARED2] = ir2_image_transport.advertiseCamera(IR2_TOPIC, 1);
   }
 
   /*
@@ -225,4 +225,3 @@ namespace realsense_camera
     publishTopic(RS_STREAM_INFRARED2);
   }
 }  // end namespace
-

--- a/realsense_camera/test/f200_nodelet_camera_options.test
+++ b/realsense_camera/test/f200_nodelet_camera_options.test
@@ -1,5 +1,4 @@
 <launch>
-  <arg name="manager"      value="nodelet_manager" />
   <arg name="camera"       default="camera" />
   <arg name="camera_type"  default="F200" /> <!-- Type of camera -->
   <arg name="serial_no"    default="" />
@@ -22,31 +21,28 @@
   <arg name="f200_filter_option"                              default="6" />
   <arg name="f200_confidence_threshold"                       default="8" />
 
-  <param name="$(arg camera)/mode"                            type="str"  value="$(arg mode)" />
-  <param name="$(arg camera)/color_backlight_compensation"    type="int" value="$(arg color_backlight_compensation)" />
-  <param name="$(arg camera)/color_brightness"                type="int" value="$(arg color_brightness)" />
-  <param name="$(arg camera)/color_contrast"                  type="int" value="$(arg color_contrast)" />
-  <param name="$(arg camera)/color_gain"                      type="int" value="$(arg color_gain)" />
-  <param name="$(arg camera)/color_gamma"                     type="int" value="$(arg color_gamma)" />
-  <param name="$(arg camera)/color_hue"                       type="int" value="$(arg color_hue)" />
-  <param name="$(arg camera)/color_saturation"                type="int" value="$(arg color_saturation)" />
-  <param name="$(arg camera)/color_sharpness"                 type="int" value="$(arg color_sharpness)" />
-  <param name="$(arg camera)/color_enable_auto_white_balance" type="int" value="$(arg color_enable_auto_white_balance)" />
-  <param name="$(arg camera)/color_white_balance"             type="int" value="$(arg color_white_balance)" />
-  <param name="$(arg camera)/f200_laser_power"                type="int" value="$(arg f200_laser_power)" />
-  <param name="$(arg camera)/f200_accuracy"                   type="int" value="$(arg f200_accuracy)" />
-  <param name="$(arg camera)/f200_motion_range"               type="int" value="$(arg f200_motion_range)" />
-  <param name="$(arg camera)/f200_filter_option"              type="int" value="$(arg f200_filter_option)" />
-  <param name="$(arg camera)/f200_confidence_threshold"       type="int" value="$(arg f200_confidence_threshold)" />
+  <param name="$(arg camera)/driver/mode"                            type="str"  value="$(arg mode)" />
+  <param name="$(arg camera)/driver/color_backlight_compensation"    type="int" value="$(arg color_backlight_compensation)" />
+  <param name="$(arg camera)/driver/color_brightness"                type="int" value="$(arg color_brightness)" />
+  <param name="$(arg camera)/driver/color_contrast"                  type="int" value="$(arg color_contrast)" />
+  <param name="$(arg camera)/driver/color_gain"                      type="int" value="$(arg color_gain)" />
+  <param name="$(arg camera)/driver/color_gamma"                     type="int" value="$(arg color_gamma)" />
+  <param name="$(arg camera)/driver/color_hue"                       type="int" value="$(arg color_hue)" />
+  <param name="$(arg camera)/driver/color_saturation"                type="int" value="$(arg color_saturation)" />
+  <param name="$(arg camera)/driver/color_sharpness"                 type="int" value="$(arg color_sharpness)" />
+  <param name="$(arg camera)/driver/color_enable_auto_white_balance" type="int" value="$(arg color_enable_auto_white_balance)" />
+  <param name="$(arg camera)/driver/color_white_balance"             type="int" value="$(arg color_white_balance)" />
+  <param name="$(arg camera)/driver/f200_laser_power"                type="int" value="$(arg f200_laser_power)" />
+  <param name="$(arg camera)/driver/f200_accuracy"                   type="int" value="$(arg f200_accuracy)" />
+  <param name="$(arg camera)/driver/f200_motion_range"               type="int" value="$(arg f200_motion_range)" />
+  <param name="$(arg camera)/driver/f200_filter_option"              type="int" value="$(arg f200_filter_option)" />
+  <param name="$(arg camera)/driver/f200_confidence_threshold"       type="int" value="$(arg f200_confidence_threshold)" />
 
-  <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>
-
-  <include file="$(find realsense_camera)/launch/includes/nodelet.launch.xml">
-    <arg name="manager"      value="$(arg manager)" />
-    <arg name="camera"       value="$(arg camera)" />
-    <arg name="camera_type"  value="$(arg camera_type)" />
-    <arg name="serial_no"    value="$(arg serial_no)" />
-    <arg name="usb_port_id"  value="$(arg usb_port_id)" />
+  <include file="$(find realsense_camera)/launch/f200_nodelet_default.launch">
+    <arg name="camera"      value="$(arg camera)" />
+    <arg name="camera_type" value="$(arg camera_type)" />
+    <arg name="serial_no"   value="$(arg serial_no)" />
+    <arg name="usb_port_id" value="$(arg usb_port_id)" />
   </include>
 
   <!-- Start test -->

--- a/realsense_camera/test/r200_nodelet_camera_options.test
+++ b/realsense_camera/test/r200_nodelet_camera_options.test
@@ -1,5 +1,4 @@
 <launch>
-  <arg name="manager"      value="nodelet_manager" />
   <arg name="camera"       default="camera" />
   <arg name="camera_type"  default="R200" /> <!-- Type of camera -->
   <arg name="serial_no"    default="" />
@@ -33,42 +32,39 @@
   <arg name="r200_depth_control_neighbor_threshold"           default="8" />
   <arg name="r200_depth_control_lr_threshold"                 default="22" />
 
-  <param name="$(arg camera)/mode"                                              type="str"  value="$(arg mode)" />
-  <param name="$(arg camera)/color_backlight_compensation"                      type="int" value="$(arg color_backlight_compensation)" />
-  <param name="$(arg camera)/color_brightness"                                  type="int" value="$(arg color_brightness)" />
-  <param name="$(arg camera)/color_contrast"                                    type="int" value="$(arg color_contrast)" />
-  <param name="$(arg camera)/color_gain"                                        type="int" value="$(arg color_gain)" />
-  <param name="$(arg camera)/color_gamma"                                       type="int" value="$(arg color_gamma)" />
-  <param name="$(arg camera)/color_hue"                                         type="int" value="$(arg color_hue)" />
-  <param name="$(arg camera)/color_saturation"                                  type="int" value="$(arg color_saturation)" />
-  <param name="$(arg camera)/color_sharpness"                                   type="int" value="$(arg color_sharpness)" />
-  <param name="$(arg camera)/color_enable_auto_white_balance"                   type="int" value="$(arg color_enable_auto_white_balance)" />
-  <param name="$(arg camera)/color_white_balance"                               type="int" value="$(arg color_white_balance)" />
-  <param name="$(arg camera)/r200_lr_gain"                                      type="int" value="$(arg r200_lr_gain)" />
-  <param name="$(arg camera)/r200_emitter_enabled"                              type="bool" value="$(arg r200_emitter_enabled)" />
-  <param name="$(arg camera)/r200_lr_exposure"                                  type="int" value="$(arg r200_lr_exposure)" />
-  <param name="$(arg camera)/r200_depth_units"                                  type="int" value="$(arg r200_depth_units)" />
-  <param name="$(arg camera)/r200_depth_clamp_min"                              type="int" value="$(arg r200_depth_clamp_min)" />
-  <param name="$(arg camera)/r200_depth_clamp_max"                              type="int" value="$(arg r200_depth_clamp_max)" />
-  <param name="$(arg camera)/r200_depth_control_estimate_median_decrement"      type="int" value="$(arg r200_depth_control_estimate_median_decrement)" />
-  <param name="$(arg camera)/r200_depth_control_estimate_median_increment"      type="int" value="$(arg r200_depth_control_estimate_median_increment)" />
-  <param name="$(arg camera)/r200_depth_control_median_threshold"               type="int" value="$(arg r200_depth_control_median_threshold)" />
-  <param name="$(arg camera)/r200_depth_control_score_minimum_threshold"        type="int" value="$(arg r200_depth_control_score_minimum_threshold)" />
-  <param name="$(arg camera)/r200_depth_control_score_maximum_threshold"        type="int" value="$(arg r200_depth_control_score_maximum_threshold)" />
-  <param name="$(arg camera)/r200_depth_control_texture_count_threshold"        type="int" value="$(arg r200_depth_control_texture_count_threshold)" />
-  <param name="$(arg camera)/r200_depth_control_texture_difference_threshold"   type="int" value="$(arg r200_depth_control_texture_difference_threshold)" />
-  <param name="$(arg camera)/r200_depth_control_second_peak_threshold"          type="int" value="$(arg r200_depth_control_second_peak_threshold)" />
-  <param name="$(arg camera)/r200_depth_control_neighbor_threshold"             type="int" value="$(arg r200_depth_control_neighbor_threshold)" />
-  <param name="$(arg camera)/r200_depth_control_lr_threshold"                   type="int" value="$(arg r200_depth_control_lr_threshold)" />
+  <param name="$(arg camera)/driver/mode"                                              type="str"  value="$(arg mode)" />
+  <param name="$(arg camera)/driver/color_backlight_compensation"                      type="int" value="$(arg color_backlight_compensation)" />
+  <param name="$(arg camera)/driver/color_brightness"                                  type="int" value="$(arg color_brightness)" />
+  <param name="$(arg camera)/driver/color_contrast"                                    type="int" value="$(arg color_contrast)" />
+  <param name="$(arg camera)/driver/color_gain"                                        type="int" value="$(arg color_gain)" />
+  <param name="$(arg camera)/driver/color_gamma"                                       type="int" value="$(arg color_gamma)" />
+  <param name="$(arg camera)/driver/color_hue"                                         type="int" value="$(arg color_hue)" />
+  <param name="$(arg camera)/driver/color_saturation"                                  type="int" value="$(arg color_saturation)" />
+  <param name="$(arg camera)/driver/color_sharpness"                                   type="int" value="$(arg color_sharpness)" />
+  <param name="$(arg camera)/driver/color_enable_auto_white_balance"                   type="int" value="$(arg color_enable_auto_white_balance)" />
+  <param name="$(arg camera)/driver/color_white_balance"                               type="int" value="$(arg color_white_balance)" />
+  <param name="$(arg camera)/driver/r200_lr_gain"                                      type="int" value="$(arg r200_lr_gain)" />
+  <param name="$(arg camera)/driver/r200_emitter_enabled"                              type="bool" value="$(arg r200_emitter_enabled)" />
+  <param name="$(arg camera)/driver/r200_lr_exposure"                                  type="int" value="$(arg r200_lr_exposure)" />
+  <param name="$(arg camera)/driver/r200_depth_units"                                  type="int" value="$(arg r200_depth_units)" />
+  <param name="$(arg camera)/driver/r200_depth_clamp_min"                              type="int" value="$(arg r200_depth_clamp_min)" />
+  <param name="$(arg camera)/driver/r200_depth_clamp_max"                              type="int" value="$(arg r200_depth_clamp_max)" />
+  <param name="$(arg camera)/driver/r200_depth_control_estimate_median_decrement"      type="int" value="$(arg r200_depth_control_estimate_median_decrement)" />
+  <param name="$(arg camera)/driver/r200_depth_control_estimate_median_increment"      type="int" value="$(arg r200_depth_control_estimate_median_increment)" />
+  <param name="$(arg camera)/driver/r200_depth_control_median_threshold"               type="int" value="$(arg r200_depth_control_median_threshold)" />
+  <param name="$(arg camera)/driver/r200_depth_control_score_minimum_threshold"        type="int" value="$(arg r200_depth_control_score_minimum_threshold)" />
+  <param name="$(arg camera)/driver/r200_depth_control_score_maximum_threshold"        type="int" value="$(arg r200_depth_control_score_maximum_threshold)" />
+  <param name="$(arg camera)/driver/r200_depth_control_texture_count_threshold"        type="int" value="$(arg r200_depth_control_texture_count_threshold)" />
+  <param name="$(arg camera)/driver/r200_depth_control_texture_difference_threshold"   type="int" value="$(arg r200_depth_control_texture_difference_threshold)" />
+  <param name="$(arg camera)/driver/r200_depth_control_second_peak_threshold"          type="int" value="$(arg r200_depth_control_second_peak_threshold)" />
+  <param name="$(arg camera)/driver/r200_depth_control_neighbor_threshold"             type="int" value="$(arg r200_depth_control_neighbor_threshold)" />
+  <param name="$(arg camera)/driver/r200_depth_control_lr_threshold"                   type="int" value="$(arg r200_depth_control_lr_threshold)" />
 
-  <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>
-
-  <include file="$(find realsense_camera)/launch/includes/nodelet.launch.xml">
-    <arg name="manager"      value="$(arg manager)" />
-    <arg name="camera"       value="$(arg camera)" />
-    <arg name="camera_type"  value="$(arg camera_type)" />
-    <arg name="serial_no"    value="$(arg serial_no)" />
-    <arg name="usb_port_id"  value="$(arg usb_port_id)" />
+  <include file="$(find realsense_camera)/launch/r200_nodelet_default.launch">
+    <arg name="camera"      value="$(arg camera)" />
+    <arg name="camera_type" value="$(arg camera_type)" />
+    <arg name="serial_no"   value="$(arg serial_no)" />
+    <arg name="usb_port_id" value="$(arg usb_port_id)" />
   </include>
 
   <!-- Start test -->

--- a/realsense_camera/test/r200_nodelet_disable_color.test
+++ b/realsense_camera/test/r200_nodelet_disable_color.test
@@ -4,7 +4,7 @@
   <arg name="enable_color" value="false" />
 
   <!-- Start camera -->
-  <param name="$(arg camera)/enable_color" type="bool" value="$(arg enable_color)" />
+  <param name="$(arg camera)/driver/enable_color" type="bool" value="$(arg enable_color)" />
   <include file="$(find realsense_camera)/launch/r200_nodelet_default.launch">
     <arg name="camera"      value="$(arg camera)" />
     <arg name="camera_type" value="$(arg camera_type)" />

--- a/realsense_camera/test/r200_nodelet_disable_depth.test
+++ b/realsense_camera/test/r200_nodelet_disable_depth.test
@@ -4,7 +4,7 @@
   <arg name="enable_depth" value="false" />
 
   <!-- Start camera -->
-  <param name="$(arg camera)/enable_depth" type="bool" value="$(arg enable_depth)" />
+  <param name="$(arg camera)/driver/enable_depth" type="bool" value="$(arg enable_depth)" />
   <include file="$(find realsense_camera)/launch/r200_nodelet_default.launch">
     <arg name="camera"      value="$(arg camera)" />
     <arg name="camera_type" value="$(arg camera_type)" />

--- a/realsense_camera/test/sr300_nodelet_camera_options.test
+++ b/realsense_camera/test/sr300_nodelet_camera_options.test
@@ -1,5 +1,4 @@
 <launch>
-  <arg name="manager"      value="nodelet_manager" />
   <arg name="camera"       default="camera" />
   <arg name="camera_type"  default="SR300" /> <!-- Type of camera -->
   <arg name="serial_no"    default="" />
@@ -32,41 +31,38 @@
   <arg name="sr300_auto_range_upper_threshold"                default="1250"/>
   <arg name="sr300_auto_range_lower_threshold"                default="650"/>
 
-  <param name="$(arg camera)/mode"                            type="str"  value="$(arg mode)" />
-  <param name="$(arg camera)/color_backlight_compensation"    type="int" value="$(arg color_backlight_compensation)" />
-  <param name="$(arg camera)/color_brightness"                type="int" value="$(arg color_brightness)" />
-  <param name="$(arg camera)/color_contrast"                  type="int" value="$(arg color_contrast)" />
-  <param name="$(arg camera)/color_gain"                      type="int" value="$(arg color_gain)" />
-  <param name="$(arg camera)/color_gamma"                     type="int" value="$(arg color_gamma)" />
-  <param name="$(arg camera)/color_hue"                       type="int" value="$(arg color_hue)" />
-  <param name="$(arg camera)/color_saturation"                type="int" value="$(arg color_saturation)" />
-  <param name="$(arg camera)/color_sharpness"                 type="int" value="$(arg color_sharpness)" />
-  <param name="$(arg camera)/color_enable_auto_white_balance" type="int" value="$(arg color_enable_auto_white_balance)" />
-  <param name="$(arg camera)/color_white_balance"             type="int" value="$(arg color_white_balance)" />
-  <param name="$(arg camera)/f200_laser_power"                type="int" value="$(arg f200_laser_power)" />
-  <param name="$(arg camera)/f200_accuracy"                   type="int" value="$(arg f200_accuracy)" />
-  <param name="$(arg camera)/f200_motion_range"               type="int" value="$(arg f200_motion_range)" />
-  <param name="$(arg camera)/f200_filter_option"              type="int" value="$(arg f200_filter_option)" />
-  <param name="$(arg camera)/f200_confidence_threshold"       type="int" value="$(arg f200_confidence_threshold)" />
-  <param name="$(arg camera)/sr300_auto_range_enable_motion_versus_range" type="int" value="$(arg sr300_auto_range_enable_motion_versus_range)"/>
-  <param name="$(arg camera)/sr300_auto_range_enable_laser"               type="int" value="$(arg sr300_auto_range_enable_laser)"/>
-  <param name="$(arg camera)/sr300_auto_range_min_motion_versus_range"    type="int" value="$(arg sr300_auto_range_min_motion_versus_range)"/>
-  <param name="$(arg camera)/sr300_auto_range_max_motion_versus_range"    type="int" value="$(arg sr300_auto_range_max_motion_versus_range)"/>
-  <param name="$(arg camera)/sr300_auto_range_start_motion_versus_range"  type="int" value="$(arg sr300_auto_range_start_motion_versus_range)"/>
-  <param name="$(arg camera)/sr300_auto_range_min_laser"                  type="int" value="$(arg sr300_auto_range_min_laser)"/>
-  <param name="$(arg camera)/sr300_auto_range_max_laser"                  type="int" value="$(arg sr300_auto_range_max_laser)"/>
-  <param name="$(arg camera)/sr300_auto_range_start_laser"                type="int" value="$(arg sr300_auto_range_start_laser)"/>
-  <param name="$(arg camera)/sr300_auto_range_upper_threshold"            type="int" value="$(arg sr300_auto_range_upper_threshold)"/>
-  <param name="$(arg camera)/sr300_auto_range_lower_threshold"            type="int" value="$(arg sr300_auto_range_lower_threshold)"/>
+  <param name="$(arg camera)/driver/mode"                            type="str"  value="$(arg mode)" />
+  <param name="$(arg camera)/driver/color_backlight_compensation"    type="int" value="$(arg color_backlight_compensation)" />
+  <param name="$(arg camera)/driver/color_brightness"                type="int" value="$(arg color_brightness)" />
+  <param name="$(arg camera)/driver/color_contrast"                  type="int" value="$(arg color_contrast)" />
+  <param name="$(arg camera)/driver/color_gain"                      type="int" value="$(arg color_gain)" />
+  <param name="$(arg camera)/driver/color_gamma"                     type="int" value="$(arg color_gamma)" />
+  <param name="$(arg camera)/driver/color_hue"                       type="int" value="$(arg color_hue)" />
+  <param name="$(arg camera)/driver/color_saturation"                type="int" value="$(arg color_saturation)" />
+  <param name="$(arg camera)/driver/color_sharpness"                 type="int" value="$(arg color_sharpness)" />
+  <param name="$(arg camera)/driver/color_enable_auto_white_balance" type="int" value="$(arg color_enable_auto_white_balance)" />
+  <param name="$(arg camera)/driver/color_white_balance"             type="int" value="$(arg color_white_balance)" />
+  <param name="$(arg camera)/driver/f200_laser_power"                type="int" value="$(arg f200_laser_power)" />
+  <param name="$(arg camera)/driver/f200_accuracy"                   type="int" value="$(arg f200_accuracy)" />
+  <param name="$(arg camera)/driver/f200_motion_range"               type="int" value="$(arg f200_motion_range)" />
+  <param name="$(arg camera)/driver/f200_filter_option"              type="int" value="$(arg f200_filter_option)" />
+  <param name="$(arg camera)/driver/f200_confidence_threshold"       type="int" value="$(arg f200_confidence_threshold)" />
+  <param name="$(arg camera)/driver/sr300_auto_range_enable_motion_versus_range" type="int" value="$(arg sr300_auto_range_enable_motion_versus_range)"/>
+  <param name="$(arg camera)/driver/sr300_auto_range_enable_laser"               type="int" value="$(arg sr300_auto_range_enable_laser)"/>
+  <param name="$(arg camera)/driver/sr300_auto_range_min_motion_versus_range"    type="int" value="$(arg sr300_auto_range_min_motion_versus_range)"/>
+  <param name="$(arg camera)/driver/sr300_auto_range_max_motion_versus_range"    type="int" value="$(arg sr300_auto_range_max_motion_versus_range)"/>
+  <param name="$(arg camera)/driver/sr300_auto_range_start_motion_versus_range"  type="int" value="$(arg sr300_auto_range_start_motion_versus_range)"/>
+  <param name="$(arg camera)/driver/sr300_auto_range_min_laser"                  type="int" value="$(arg sr300_auto_range_min_laser)"/>
+  <param name="$(arg camera)/driver/sr300_auto_range_max_laser"                  type="int" value="$(arg sr300_auto_range_max_laser)"/>
+  <param name="$(arg camera)/driver/sr300_auto_range_start_laser"                type="int" value="$(arg sr300_auto_range_start_laser)"/>
+  <param name="$(arg camera)/driver/sr300_auto_range_upper_threshold"            type="int" value="$(arg sr300_auto_range_upper_threshold)"/>
+  <param name="$(arg camera)/driver/sr300_auto_range_lower_threshold"            type="int" value="$(arg sr300_auto_range_lower_threshold)"/>
 
-  <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>
-
-  <include file="$(find realsense_camera)/launch/includes/nodelet.launch.xml">
-    <arg name="manager"      value="$(arg manager)" />
-    <arg name="camera"       value="$(arg camera)" />
-    <arg name="camera_type"  value="$(arg camera_type)" />
-    <arg name="serial_no"    value="$(arg serial_no)" />
-    <arg name="usb_port_id"  value="$(arg usb_port_id)" />
+  <include file="$(find realsense_camera)/launch/sr300_nodelet_default.launch">
+    <arg name="camera"      value="$(arg camera)" />
+    <arg name="camera_type" value="$(arg camera_type)" />
+    <arg name="serial_no"   value="$(arg serial_no)" />
+    <arg name="usb_port_id" value="$(arg usb_port_id)" />
   </include>
 
   <!-- Start test -->


### PR DESCRIPTION
This PR incorporates @tfoote's change to use NodeHandles to correctly publish topic names using namespaces, allowing for easier remapping of topics.

This resulted in an overall change to the topic names, where the leading "camera" namespace was no longer erroneously hardcoded in the code.  To accommodate this, the default launch files have been updated throughout to use a group namespace to properly handle camera name remapping and multiple camera support.  Unit tests have been updated accordingly.

This change brings our package more in line with the standards and conventions used by the other 3D sensor packages.

Note: This PR incorporates changes in PR #96, and thus trumps that PR.
