### PR TITLE
Add depth control preset option

### DIFF
--- a/realsense_camera/cfg/r200_params.cfg
+++ b/realsense_camera/cfg/r200_params.cfg
@@ -35,4 +35,40 @@ gen.add("r200_auto_exposure_bottom_edge",        int_t,    0,          "Auto Exp
 gen.add("r200_auto_exposure_left_edge",          int_t,    0,          "Auto Exposure Left Edge",      0,         0,      639)
 gen.add("r200_auto_exposure_right_edge",         int_t,    0,          "Auto Exposure Right Edge",     639,       0,      639)
 
+# Depth Control Grouping
+r200_depth_control = gen.add_group("R200 Depth Control")
+r200_dc_preset_enum = gen.enum(
+  [ gen.const("UNUSED",     int_t,  -1, "Individual Depth Control was changed"),
+    gen.const("Default",    int_t,  0,  "Default settings on chip. Similar to Medium. Best for Outdoors."),
+    gen.const("Off",        int_t,  1,  "Disable almost all hardware-based outlier removal."),
+    gen.const("Low",        int_t,  2,  "Lower number of outliers removed. Minimal false negatives."),
+    gen.const("Medium",     int_t,  3,  "Medium number of outliers removed. Balanced approach."),
+    gen.const("Optimized",  int_t,  4,  "Medium-High number of outliers removed. Derived optimization function."),
+    gen.const("High",       int_t,  5,  "Higher number of outliers removed. Minimal false positives.")],
+    "Depth Control Preset Choices")
+#                      Name
+#   Type      Level       Description                         Default   Min     Max     Method
+r200_depth_control.add("r200_dc_preset",
+    int_t,    64,         "R200 Depth Control Preset",        5,        -1,     5,      edit_method=r200_dc_preset_enum)
+r200_depth_control.add("r200_dc_estimate_median_decrement",
+    int_t,    32,         "Estimate Median Decrement",        5,        0,      255)
+r200_depth_control.add("r200_dc_estimate_median_increment",
+    int_t,    32,         "Estimate Median Increment",        5,        0,      255)
+r200_depth_control.add("r200_dc_median_threshold",
+    int_t,    32,         "Median Threshold",                 235,      0,      1023)
+r200_depth_control.add("r200_dc_score_minimum_threshold",
+    int_t,    32,         "Score Minimum Threshold",          27,       0,      1023)
+r200_depth_control.add("r200_dc_score_maximum_threshold",
+    int_t,    32,         "Score Maximum Threshold",          420,      0,      1023)
+r200_depth_control.add("r200_dc_texture_count_threshold",
+    int_t,    32,         "Texture Count Threshold",          8,        0,      31)
+r200_depth_control.add("r200_dc_texture_difference_threshold",
+    int_t,    32,         "Texture Difference Threshold",     80,       0,      1023)
+r200_depth_control.add("r200_dc_second_peak_threshold",
+    int_t,    32,         "Second Peak Threshold",            70,       0,      1023)
+r200_depth_control.add("r200_dc_neighbor_threshold",
+    int_t,    32,         "Neighbor Threshold",               90,       0,      1023)
+r200_depth_control.add("r200_dc_lr_threshold",
+    int_t,    32,         "LR Threshold",                     12,       0,      2047)
+
 exit(gen.generate(PACKAGE, "realsense_camera", "r200_params"))

--- a/realsense_camera/include/realsense_camera/r200_nodelet.h
+++ b/realsense_camera/include/realsense_camera/r200_nodelet.h
@@ -61,6 +61,8 @@ namespace realsense_camera
     void advertiseTopics();
     std::vector<std::string> setDynamicReconfServer();
     void startDynamicReconfCallback();
+    void setDynamicReconfigDepthControlPreset(int preset);
+    std::string setDynamicReconfigDepthControlIndividuals();
     void configCallback(realsense_camera::r200_paramsConfig &config, uint32_t level);
     void setStreams();
     void publishTopics();

--- a/realsense_camera/src/r200_nodelet.cpp
+++ b/realsense_camera/src/r200_nodelet.cpp
@@ -29,6 +29,8 @@
  *******************************************************************************/
 
 #include <realsense_camera/r200_nodelet.h>
+#include <cstdlib>
+#include <bitset>
 
 PLUGINLIB_EXPORT_CLASS (realsense_camera::R200Nodelet, nodelet::Nodelet)
 
@@ -114,11 +116,150 @@ namespace realsense_camera
   }
 
   /*
+   * Change the Depth Control Preset
+   */
+  void R200Nodelet::setDynamicReconfigDepthControlPreset(int preset)
+  {
+    // There is not a C++ API for dynamic reconfig so we need to use a system call
+    // Adding the sleep to ensure the current callback can end before we
+    // attempt the next callback from the system call.
+    std::string system_cmd = "(sleep 1 ; rosrun dynamic_reconfigure dynparam set "
+      + nodelet_name_ + " r200_dc_preset " + std::to_string(preset) + ")&";
+
+    int status = std::system(system_cmd.c_str());
+    if (status < 0)
+    {
+      ROS_WARN_STREAM(nodelet_name_ <<
+          " - Failed to set dynamic_reconfigure dc preset via system:"
+          << strerror(errno));
+    }
+    else
+    {
+      if (!WIFEXITED(status))
+      {
+        ROS_WARN_STREAM(nodelet_name_ <<
+            " - Failed to set dynamic_reconfigure dc preset via system");
+      }
+    }
+  }
+
+  /*
+   * Change the Depth Control Individual values
+   * GET ALL of the DC options from librealsense
+   * Call dynamic reconfig and set all 10 values as a set
+   */
+  std::string R200Nodelet::setDynamicReconfigDepthControlIndividuals()
+  {
+    std::string current_dc;
+    std::string option_value;
+
+    // There is not a C++ API for dynamic reconfig so we need to use a system call
+    // Adding the sleep to ensure the current callback can end before we
+    // attempt the next callback from the system call.
+    std::string system_cmd =
+      "(sleep 1 ; rosrun dynamic_reconfigure dynparam set ";
+    system_cmd += nodelet_name_ + " " +
+      "\"{" +
+      "'r200_dc_estimate_median_decrement':";
+    option_value =
+      std::to_string(static_cast<uint32_t>(rs_get_device_option(rs_device_,
+              RS_OPTION_R200_DEPTH_CONTROL_ESTIMATE_MEDIAN_DECREMENT, 0)));
+    current_dc += option_value + ":";
+    system_cmd += option_value +
+      ", 'r200_dc_estimate_median_increment':";
+    option_value =
+      std::to_string(static_cast<uint32_t>(rs_get_device_option(rs_device_,
+              RS_OPTION_R200_DEPTH_CONTROL_ESTIMATE_MEDIAN_INCREMENT, 0)));
+    current_dc += option_value + ":";
+    system_cmd += option_value +
+      ", 'r200_dc_median_threshold':";
+    option_value =
+      std::to_string(static_cast<uint32_t>(rs_get_device_option(rs_device_,
+              RS_OPTION_R200_DEPTH_CONTROL_MEDIAN_THRESHOLD, 0)));
+    current_dc += option_value + ":";
+    system_cmd += option_value +
+      ", 'r200_dc_score_minimum_threshold':";
+    option_value =
+      std::to_string(static_cast<uint32_t>(rs_get_device_option(rs_device_,
+              RS_OPTION_R200_DEPTH_CONTROL_SCORE_MINIMUM_THRESHOLD, 0)));
+    current_dc += option_value + ":";
+    system_cmd += option_value +
+      ", 'r200_dc_score_maximum_threshold':";
+    option_value =
+      std::to_string(static_cast<uint32_t>(rs_get_device_option(rs_device_,
+              RS_OPTION_R200_DEPTH_CONTROL_SCORE_MAXIMUM_THRESHOLD, 0)));
+    current_dc += option_value + ":";
+    system_cmd += option_value +
+      ", 'r200_dc_texture_count_threshold':";
+    option_value =
+      std::to_string(static_cast<uint32_t>(rs_get_device_option(rs_device_,
+              RS_OPTION_R200_DEPTH_CONTROL_TEXTURE_COUNT_THRESHOLD, 0)));
+    current_dc += option_value + ":";
+    system_cmd += option_value +
+      ", 'r200_dc_texture_difference_threshold':";
+    option_value =
+      std::to_string(static_cast<uint32_t>(rs_get_device_option(rs_device_,
+              RS_OPTION_R200_DEPTH_CONTROL_TEXTURE_DIFFERENCE_THRESHOLD, 0)));
+    current_dc += option_value + ":";
+    system_cmd += option_value +
+      ", 'r200_dc_second_peak_threshold':";
+    option_value =
+      std::to_string(static_cast<uint32_t>(rs_get_device_option(rs_device_,
+              RS_OPTION_R200_DEPTH_CONTROL_SECOND_PEAK_THRESHOLD, 0)));
+    current_dc += option_value + ":";
+    system_cmd += option_value +
+      ", 'r200_dc_neighbor_threshold':";
+    option_value =
+      std::to_string(static_cast<uint32_t>(rs_get_device_option(rs_device_,
+              RS_OPTION_R200_DEPTH_CONTROL_NEIGHBOR_THRESHOLD, 0)));
+    current_dc += option_value + ":";
+    system_cmd += option_value +
+      ", 'r200_dc_lr_threshold':";
+    option_value =
+      std::to_string(static_cast<uint32_t>(rs_get_device_option(rs_device_,
+              RS_OPTION_R200_DEPTH_CONTROL_LR_THRESHOLD, 0)));
+    current_dc += option_value;
+    system_cmd += option_value +
+      "}\")&";
+
+    ROS_DEBUG_STREAM(nodelet_name_ << " - Setting DC: " << system_cmd);
+
+    int status = std::system(system_cmd.c_str());
+    if (status < 0)
+    {
+      ROS_WARN_STREAM(nodelet_name_ <<
+          " - Failed to set dynamic_reconfigure dc manual via system:"
+          << strerror(errno));
+    }
+    else
+    {
+      if (!WIFEXITED(status))
+      {
+        ROS_WARN_STREAM(nodelet_name_ <<
+            " - Failed to set dynamic_reconfigure dc manual via system");
+      }
+    }
+
+    return current_dc;
+  }
+
+  /*
    * Get the dynamic param values.
    */
   void R200Nodelet::configCallback(realsense_camera::r200_paramsConfig &config, uint32_t level)
   {
+    // Save the dc_preset value as there is no getter API for this value
+    static int dc_preset = -2;
+    int previous_dc_preset = dc_preset;
+    // Save the last depth control preset values as a string
+    static std::string last_dc;
+
+    // level is the ORing of all levels which have a changed value
+    std::bitset<32> bit_level{level};
+
+
     ROS_INFO_STREAM(nodelet_name_ << " - Setting dynamic camera options");
+
     // Set flags
     if (config.enable_depth == false)
     {
@@ -185,6 +326,85 @@ namespace realsense_camera
       edge_values_[2] = config.r200_auto_exposure_right_edge;
       edge_values_[3] = config.r200_auto_exposure_bottom_edge;
       rs_set_device_options(rs_device_, edge_options_, 4, edge_values_, 0);
+    }
+
+    // Depth Control Group Settings
+    // NOTE: do NOT use the config.groups values as they are zero the first time called
+    if (bit_level.test(5)) // 2^5 = 32 : Individual Depth Control settings
+    {
+      std::string current_dc;
+
+      ROS_DEBUG_STREAM(nodelet_name_ << " - Setting Individual Depth Control");
+
+      rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_ESTIMATE_MEDIAN_DECREMENT,
+          config.r200_dc_estimate_median_decrement, 0);
+      current_dc += std::to_string(static_cast<uint32_t>(config.r200_dc_estimate_median_decrement)) + ":";
+      rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_ESTIMATE_MEDIAN_INCREMENT,
+          config.r200_dc_estimate_median_increment, 0);
+      current_dc += std::to_string(static_cast<uint32_t>(config.r200_dc_estimate_median_increment)) + ":";
+      rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_MEDIAN_THRESHOLD,
+          config.r200_dc_median_threshold, 0);
+      current_dc += std::to_string(static_cast<uint32_t>(config.r200_dc_median_threshold)) + ":";
+      rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_SCORE_MINIMUM_THRESHOLD,
+          config.r200_dc_score_minimum_threshold, 0);
+      current_dc += std::to_string(static_cast<uint32_t>(config.r200_dc_score_minimum_threshold)) + ":";
+      rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_SCORE_MAXIMUM_THRESHOLD,
+          config.r200_dc_score_maximum_threshold, 0);
+      current_dc += std::to_string(static_cast<uint32_t>(config.r200_dc_score_maximum_threshold)) + ":";
+      rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_TEXTURE_COUNT_THRESHOLD,
+          config.r200_dc_texture_count_threshold, 0);
+      current_dc += std::to_string(static_cast<uint32_t>(config.r200_dc_texture_count_threshold)) + ":";
+      rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_TEXTURE_DIFFERENCE_THRESHOLD,
+          config.r200_dc_texture_difference_threshold, 0);
+      current_dc += std::to_string(static_cast<uint32_t>(config.r200_dc_texture_difference_threshold)) + ":";
+      rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_SECOND_PEAK_THRESHOLD,
+          config.r200_dc_second_peak_threshold, 0);
+      current_dc += std::to_string(static_cast<uint32_t>(config.r200_dc_second_peak_threshold)) + ":";
+      rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_NEIGHBOR_THRESHOLD,
+          config.r200_dc_neighbor_threshold, 0);
+      current_dc += std::to_string(static_cast<uint32_t>(config.r200_dc_neighbor_threshold)) + ":";
+      rs_set_device_option(rs_device_, RS_OPTION_R200_DEPTH_CONTROL_LR_THRESHOLD,
+          config.r200_dc_lr_threshold, 0);
+      current_dc += std::to_string(static_cast<uint32_t>(config.r200_dc_lr_threshold));
+
+      // Preset also change in the same update callback?
+      if (bit_level.test(6)) // 2^6 = 64 : Depth Control Preset
+      {
+        dc_preset = config.r200_dc_preset;
+
+        if (previous_dc_preset != -2 && // not the first pass special case (-2)
+            dc_preset != -1) // not already set to unused (-1)
+        {
+          ROS_DEBUG_STREAM(nodelet_name_ << " - Forcing Depth Control Preset to Unused");
+          setDynamicReconfigDepthControlPreset(-1);
+        }
+      }
+      else
+      {
+        // Changing individual Depth Control params means preset is Unused/Invalid
+        // if the individual values are not the same as the preset values
+        if (dc_preset != -1 && current_dc != last_dc)
+        {
+          ROS_DEBUG_STREAM(nodelet_name_ << " - Setting Depth Control Preset to Unused");
+          setDynamicReconfigDepthControlPreset(-1);
+        }
+      }
+    }
+    else
+    { // Individual Depth Control not set
+      if (bit_level.test(6)) // 2^6 = 64 : Depth Control Preset
+      {
+        dc_preset = config.r200_dc_preset;
+
+        if (dc_preset != -1)
+        {
+          ROS_DEBUG_STREAM(nodelet_name_ << " - Set Depth Control Preset to " << dc_preset);
+          rs_apply_depth_control_preset(rs_device_, dc_preset);
+
+          // Save the preset value string
+          last_dc = setDynamicReconfigDepthControlIndividuals();
+        }
+      }
     }
   }
 

--- a/realsense_camera/test/r200_nodelet_camera_options.test
+++ b/realsense_camera/test/r200_nodelet_camera_options.test
@@ -22,16 +22,16 @@
   <arg name="r200_depth_units"                                default="1002" />
   <arg name="r200_depth_clamp_min"                            default="2" />
   <arg name="r200_depth_clamp_max"                            default="65532" />
-  <arg name="r200_depth_control_estimate_median_decrement"    default="6" />
-  <arg name="r200_depth_control_estimate_median_increment"    default="6" />
-  <arg name="r200_depth_control_median_threshold"             default="194" />
-  <arg name="r200_depth_control_score_minimum_threshold"      default="2" />
-  <arg name="r200_depth_control_score_maximum_threshold"      default="510" />
-  <arg name="r200_depth_control_texture_count_threshold"      default="4" />
-  <arg name="r200_depth_control_texture_difference_threshold" default="22" />
-  <arg name="r200_depth_control_second_peak_threshold"        default="26" />
-  <arg name="r200_depth_control_neighbor_threshold"           default="8" />
-  <arg name="r200_depth_control_lr_threshold"                 default="22" />
+  <arg name="r200_depth_control_estimate_median_decrement"    default="5" />
+  <arg name="r200_depth_control_estimate_median_increment"    default="5" />
+  <arg name="r200_depth_control_median_threshold"             default="235" />
+  <arg name="r200_depth_control_score_minimum_threshold"      default="27" />
+  <arg name="r200_depth_control_score_maximum_threshold"      default="420" />
+  <arg name="r200_depth_control_texture_count_threshold"      default="8" />
+  <arg name="r200_depth_control_texture_difference_threshold" default="80" />
+  <arg name="r200_depth_control_second_peak_threshold"        default="70" />
+  <arg name="r200_depth_control_neighbor_threshold"           default="90" />
+  <arg name="r200_depth_control_lr_threshold"                 default="12" />
 
   <param name="$(arg camera)/mode"                                              type="str"  value="$(arg mode)" />
   <param name="$(arg camera)/color_backlight_compensation"                      type="int" value="$(arg color_backlight_compensation)" />


### PR DESCRIPTION
Changes proposed in this pull request:
- add depth control preset to dynamic reconfigure options for r200
- add individual depth control options to dynamic reconfigure options for r200
- glue code to update individual options when preset select; also invalidate preset when individual option is changed
