### PR TITLE
realsense-camera: don't ignore linker flags set by user

### DIFF
--- a/realsense_camera/CMakeLists.txt
+++ b/realsense_camera/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_CXX_FLAGS "-fPIE -fPIC -std=c++11 -O2 -D_FORTIFY_SOURCE=2 -fstack-prot
 # Flags executables
 set(CMAKE_EXE_LINKER_FLAGS "-pie -z noexecstack -z relro -z now")
 # Flags shared libraries
-set(CMAKE_SHARED_LINKER_FLAGS "-z noexecstack -z relro -z now")
+set(CMAKE_SHARED_LINKER_FLAGS "-z noexecstack -z relro -z now ${CMAKE_SHARED_LINKER_FLAGS}")
 
 find_package(catkin REQUIRED COMPONENTS
   librealsense


### PR DESCRIPTION
Yocto's bitbake sets global `LDFLAGS` that include the option `--hash-style=gnu`. If this option is ignored then bitbake's QA checks report that
```
QA Issue: No GNU_HASH in the elf binary: '/[...]/opt/ros/indigo/lib/librealsense_camera_nodelet.so' [ldflags]
```
The patch includes user defined linker flags to
`CMAKE_SHARED_LINKER_FLAGS` defined in the project's CMakeList.txt.
