### PR TITLE
Make system wrapper function generic

### DIFF
--- a/realsense_camera/include/realsense_camera/base_nodelet.h
+++ b/realsense_camera/include/realsense_camera/base_nodelet.h
@@ -50,6 +50,7 @@
 
 #include <iostream>
 #include <boost/thread.hpp>
+#include <boost/algorithm/string/join.hpp>
 #include <thread>
 #include <cstdlib>
 #include <cctype>

--- a/realsense_camera/package.xml
+++ b/realsense_camera/package.xml
@@ -33,6 +33,7 @@
   <depend>sensor_msgs</depend>
   <depend>pcl_ros</depend>
   <depend>dynamic_reconfigure</depend>
+  <depend>boost</depend>
 
   <exec_depend>rgbd_launch</exec_depend>
 

--- a/realsense_camera/src/base_nodelet.cpp
+++ b/realsense_camera/src/base_nodelet.cpp
@@ -1135,7 +1135,8 @@ namespace realsense_camera
     if (pid == -1)
     { // failed to fork
         ROS_WARN_STREAM(nodelet_name_ <<
-            " - Failed to set dynamic_reconfigure dc preset via system:"
+            " - Failed to fork system command:"
+            << boost::algorithm::join(string_argv, " ")
             << strerror(errno));
     }
     else if (pid == 0)


### PR DESCRIPTION
Changes proposed in this pull request:
- Mark error message more generic for systemWrapper
- Add previously missing ROS dependency of boost