### PR TITLE
Change color stream default to 30fps

### DIFF
--- a/realsense_camera/launch/f200_nodelet_default.launch
+++ b/realsense_camera/launch/f200_nodelet_default.launch
@@ -4,7 +4,20 @@
   <arg name="camera_type"  default="F200" /> <!-- Type of camera -->
   <arg name="serial_no"    default="" />
   <arg name="usb_port_id"  default="" /> <!-- USB "Bus#-Port#" -->
-  <arg name="manager"      value="$(arg camera)_nodelet_manager" />
+  <arg name="manager"      default="nodelet_manager" />
+
+  <!-- These 'arg' tags are just place-holders for passing values from test files.
+  The recommended way is to pass the values directly into the 'param' tags. -->
+  <arg name="mode"              default="manual" />
+  <arg name="depth_width"       default="640" />
+  <arg name="depth_height"      default="480" />
+  <arg name="color_fps"         default="30" />
+
+  <param name="$(arg camera)/driver/mode"              type="str"  value="$(arg mode)" />
+  <param name="$(arg camera)/driver/depth_width"       type="int"  value="$(arg depth_width)" />
+  <param name="$(arg camera)/driver/depth_height"      type="int"  value="$(arg depth_height)" />
+  <param name="$(arg camera)/driver/color_fps"         type="int"  value="$(arg color_fps)" />
+  <!-- Refer to the Wiki http://wiki.ros.org/realsense_camera for list of supported parameters -->
 
   <group ns="$(arg camera)">
     <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>

--- a/realsense_camera/launch/r200_nodelet_default.launch
+++ b/realsense_camera/launch/r200_nodelet_default.launch
@@ -4,7 +4,16 @@
   <arg name="camera_type"  default="R200" /> <!-- Type of camera -->
   <arg name="serial_no"    default="" />
   <arg name="usb_port_id"  default="" /> <!-- USB "Bus#-Port#" -->
-  <arg name="manager"      value="$(arg camera)_nodelet_manager" />
+  <arg name="manager"      default="nodelet_manager" />
+
+  <!-- These 'arg' tags are just place-holders for passing values from test files.
+  The recommended way is to pass the values directly into the 'param' tags. -->
+  <arg name="mode"              default="manual" />
+  <arg name="color_fps"         default="30" />
+
+  <param name="$(arg camera)/driver/mode"              type="str"  value="$(arg mode)" />
+  <param name="$(arg camera)/driver/color_fps"         type="int"  value="$(arg color_fps)" />
+  <!-- Refer to the Wiki http://wiki.ros.org/realsense_camera for list of supported parameters -->
 
   <group ns="$(arg camera)">
     <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>

--- a/realsense_camera/launch/r200_nodelet_modify_params.launch
+++ b/realsense_camera/launch/r200_nodelet_modify_params.launch
@@ -1,18 +1,18 @@
 <!-- Sample launch file for modifying the parameters of RealSense R200 camera -->
 <launch>
-  <arg name="manager"      value="nodelet_manager" />
   <arg name="camera"       default="camera" />
   <arg name="camera_type"  default="R200" /> <!-- Type of camera -->
   <arg name="serial_no"    default="" />
   <arg name="usb_port_id"  default="" /> <!-- USB "Bus#-Port#" -->
+  <arg name="manager"      default="nodelet_manager" />
 
   <!-- These 'arg' tags are just place-holders for passing values from test files.
   The recommended way is to pass the values directly into the 'param' tags. -->
   <arg name="enable_depth"      default="true" />
-  <arg name="enable_ir"         default="true" />
-  <arg name="enable_ir2"        default="true" />
+  <arg name="enable_ir"         default="false" />
+  <arg name="enable_ir2"        default="false" />
   <arg name="enable_color"      default="true" />
-  <arg name="enable_pointcloud" default="true" />
+  <arg name="enable_pointcloud" default="false" />
   <arg name="enable_tf"         default="true" />
   <arg name="mode"              default="manual" />
   <arg name="depth_width"       default="640" />
@@ -35,7 +35,7 @@
   <param name="$(arg camera)/driver/color_height"      type="int"  value="$(arg color_height)" />
   <param name="$(arg camera)/driver/depth_fps"         type="int"  value="$(arg depth_fps)" />
   <param name="$(arg camera)/driver/color_fps"         type="int"  value="$(arg color_fps)" />
-  <!-- Refer to the README file for list of supported parameters -->
+  <!-- Refer to the Wiki http://wiki.ros.org/realsense_camera for list of supported parameters -->
 
   <group ns="$(arg camera)">
     <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>

--- a/realsense_camera/launch/r200_nodelet_multiple_cameras.launch
+++ b/realsense_camera/launch/r200_nodelet_multiple_cameras.launch
@@ -17,7 +17,7 @@
        "camera" should be a user friendly string that follows the ROS Names convention. -->
   <group ns="$(arg camera1)">
     <include file="$(find realsense_camera)/launch/includes/nodelet.launch.xml">
-      <arg name="manager"      value="/$(arg manager)" />
+      <arg name="manager"      value="$(arg manager)" />
       <arg name="camera"       value="$(arg camera1)" />
       <arg name="camera_type"  value="$(arg camera1_camera_type)" />
       <arg name="serial_no"    value="$(arg camera1_serial_no)" />
@@ -27,7 +27,7 @@
 
   <group ns="$(arg camera2)">
     <include file="$(find realsense_camera)/launch/includes/nodelet.launch.xml">
-      <arg name="manager"      value="/$(arg manager)" />
+      <arg name="manager"      value="$(arg manager)" />
       <arg name="camera"       value="$(arg camera2)" />
       <arg name="camera_type"  value="$(arg camera2_camera_type)" />
       <arg name="serial_no"    value="$(arg camera2_serial_no)" />

--- a/realsense_camera/launch/sr300_nodelet_default.launch
+++ b/realsense_camera/launch/sr300_nodelet_default.launch
@@ -4,7 +4,20 @@
   <arg name="camera_type"  default="SR300" /> <!-- Type of camera -->
   <arg name="serial_no"    default="" />
   <arg name="usb_port_id"  default="" /> <!-- USB "Bus#-Port#" -->
-  <arg name="manager"      value="$(arg camera)_nodelet_manager" />
+  <arg name="manager"      default="nodelet_manager" />
+
+  <!-- These 'arg' tags are just place-holders for passing values from test files.
+  The recommended way is to pass the values directly into the 'param' tags. -->
+  <arg name="mode"              default="manual" />
+  <arg name="depth_width"       default="640" />
+  <arg name="depth_height"      default="480" />
+  <arg name="color_fps"         default="30" />
+
+  <param name="$(arg camera)/driver/mode"              type="str"  value="$(arg mode)" />
+  <param name="$(arg camera)/driver/depth_width"       type="int"  value="$(arg depth_width)" />
+  <param name="$(arg camera)/driver/depth_height"      type="int"  value="$(arg depth_height)" />
+  <param name="$(arg camera)/driver/color_fps"         type="int"  value="$(arg color_fps)" />
+  <!-- Refer to the Wiki http://wiki.ros.org/realsense_camera for list of supported parameters -->
 
   <group ns="$(arg camera)">
     <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>

--- a/realsense_camera/launch/zr300_nodelet_default.launch
+++ b/realsense_camera/launch/zr300_nodelet_default.launch
@@ -1,10 +1,21 @@
 <!-- Sample launch file for using RealSense ZR300 camera with default configurations -->
 <launch>
-  <arg name="manager"      value="nodelet_manager" />
   <arg name="camera"       default="camera" />
   <arg name="camera_type"  default="ZR300" /> <!-- Type of camera -->
   <arg name="serial_no"    default="" />
   <arg name="usb_port_id"  default="" /> <!-- USB "Bus#-Port#" -->
+  <arg name="manager"      default="nodelet_manager" />
+
+  <!-- These 'arg' tags are just place-holders for passing values from test files.
+  The recommended way is to pass the values directly into the 'param' tags. -->
+  <arg name="mode"              default="manual" />
+  <arg name="color_fps"         default="30" />
+  <arg name="fisheye_fps"       default="30" />
+
+  <param name="$(arg camera)/driver/mode"              type="str"  value="$(arg mode)" />
+  <param name="$(arg camera)/driver/color_fps"         type="int"  value="$(arg color_fps)" />
+  <param name="$(arg camera)/driver/fisheye_fps"       type="int"  value="$(arg fisheye_fps)" />
+  <!-- Refer to the Wiki http://wiki.ros.org/realsense_camera for list of supported parameters -->
 
   <group ns="$(arg camera)">
     <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>


### PR DESCRIPTION
Improve reliability of the camera by reducing the color stream
to 30fps by default. This will be the highest frame rate which will
be validate with VGA or higher resolutions for use with ROS.

Default files will no longer use the librealsense preset modes
as they will be depreciated in the future.