### PR TITLE
Fixes mutex lock and adds ZR300 destructor

### DIFF
--- a/realsense_camera/include/realsense_camera/base_nodelet.h
+++ b/realsense_camera/include/realsense_camera/base_nodelet.h
@@ -134,7 +134,7 @@ namespace realsense_camera
     bool enable_tf_;
     const uint16_t *image_depth16_;
     cv::Mat cvWrapper_;
-    boost::mutex frame_mutex_[STREAM_COUNT];
+    std::mutex frame_mutex_[STREAM_COUNT];
 
     struct CameraOptions
     {

--- a/realsense_camera/include/realsense_camera/zr300_nodelet.h
+++ b/realsense_camera/include/realsense_camera/zr300_nodelet.h
@@ -66,7 +66,7 @@ namespace realsense_camera
     boost::shared_ptr<boost::thread> imu_thread_;
     std::function<void(rs::motion_data)> motion_handler_;
     std::function<void(rs::timestamp_data)> timestamp_handler_;
-    boost::mutex imu_mutex_;
+    std::mutex imu_mutex_;
 
     // Member Functions.
     void getParameters();

--- a/realsense_camera/include/realsense_camera/zr300_nodelet.h
+++ b/realsense_camera/include/realsense_camera/zr300_nodelet.h
@@ -46,6 +46,7 @@ namespace realsense_camera
   {
   public:
 
+    ~ZR300Nodelet();
     void onInit();
 
   protected:
@@ -83,6 +84,7 @@ namespace realsense_camera
     void setIMUCallbacks();
     void setFrameCallbacks();
     std::function<void(rs::frame f)> fisheye_frame_handler_, ir2_frame_handler_;
+    void stopIMU();
 
   };
 }

--- a/realsense_camera/src/base_nodelet.cpp
+++ b/realsense_camera/src/base_nodelet.cpp
@@ -788,7 +788,7 @@ namespace realsense_camera
   void BaseNodelet::publishTopic(rs_stream stream_index, rs::frame &frame) try
   {
     // mutex to ensure only one frame per stream is processed at a time
-    boost::mutex::scoped_lock lock(frame_mutex_[stream_index]);
+    std::unique_lock<std::mutex> lock(frame_mutex_[stream_index]);
 
     double frame_ts = frame.get_timestamp();
     if (ts_[stream_index] != frame_ts) // Publish frames only if its not duplicate

--- a/realsense_camera/src/zr300_nodelet.cpp
+++ b/realsense_camera/src/zr300_nodelet.cpp
@@ -35,6 +35,16 @@ PLUGINLIB_EXPORT_CLASS (realsense_camera::ZR300Nodelet, nodelet::Nodelet)
 namespace realsense_camera
 {
   /*
+   * Nodelet Destructor.
+   */
+  ZR300Nodelet::~ZR300Nodelet()
+  {
+    stopIMU();
+    // clean up imu thread
+    imu_thread_->join();
+  }
+
+  /*
    * Initialize the nodelet.
    */
   void ZR300Nodelet::onInit()
@@ -544,11 +554,7 @@ namespace realsense_camera
         }
       }
     }
-
-    rs_stop_source(rs_device_, (rs_source)rs::source::motion_data, &rs_error_);
-    checkError();
-    rs_disable_motion_tracking(rs_device_, &rs_error_);
-    checkError();
+    stopIMU();
   }
 
   /*
@@ -762,6 +768,17 @@ namespace realsense_camera
     imu2imuo_msg.transform.rotation.w = q_imu2imuo.getW();
     static_tf_broadcaster_.sendTransform(imu2imuo_msg);
 
+  }
+
+  /*
+   * Stop the IMU and motion tracking
+   */
+  void ZR300Nodelet::stopIMU()
+  {
+    rs_stop_source(rs_device_, (rs_source)rs::source::motion_data, &rs_error_);
+    checkError();
+    rs_disable_motion_tracking(rs_device_, &rs_error_);
+    checkError();
   }
 }  // end namespace
 

--- a/realsense_camera/src/zr300_nodelet.cpp
+++ b/realsense_camera/src/zr300_nodelet.cpp
@@ -511,7 +511,8 @@ namespace realsense_camera
     {
       if (imu_publisher_.getNumSubscribers() > 0)
       {
-        boost::mutex::scoped_lock lock(imu_mutex_);
+        std::unique_lock<std::mutex> lock(imu_mutex_);
+
         if (prev_imu_ts_ != imu_ts_)
         {
           sensor_msgs::Imu imu_msg = sensor_msgs::Imu();
@@ -557,37 +558,37 @@ namespace realsense_camera
   {
     motion_handler_ = [&](rs::motion_data entry)
     {
-    	boost::mutex::scoped_lock lock(imu_mutex_);
+      std::unique_lock<std::mutex> lock(imu_mutex_);
 
-        if (entry.timestamp_data.source_id == RS_EVENT_IMU_GYRO)
+      if (entry.timestamp_data.source_id == RS_EVENT_IMU_GYRO)
+      {
+        for (int i = 0; i < 3; ++i)
         {
-          for (int i = 0; i < 3; ++i)
-          {
-            imu_angular_vel_[i] = entry.axes[i];
-            imu_linear_accel_[i] = 0.0;
-          }
-          imu_angular_vel_cov_[0] = 0.0;
-          imu_linear_accel_cov_[0] = -1.0;
+          imu_angular_vel_[i] = entry.axes[i];
+          imu_linear_accel_[i] = 0.0;
         }
-        else if (entry.timestamp_data.source_id == RS_EVENT_IMU_ACCEL)
+        imu_angular_vel_cov_[0] = 0.0;
+        imu_linear_accel_cov_[0] = -1.0;
+      }
+      else if (entry.timestamp_data.source_id == RS_EVENT_IMU_ACCEL)
+      {
+        for (int i = 0; i < 3; ++i)
         {
-          for (int i = 0; i < 3; ++i)
-          {
-            imu_angular_vel_[i] = 0.0;
-            imu_linear_accel_[i] = entry.axes[i];
-          }
-          imu_angular_vel_cov_[0] = -1.0;
-          imu_linear_accel_cov_[0] = 0.0;
+          imu_angular_vel_[i] = 0.0;
+          imu_linear_accel_[i] = entry.axes[i];
         }
-        imu_ts_ = (double) entry.timestamp_data.timestamp;
+        imu_angular_vel_cov_[0] = -1.0;
+        imu_linear_accel_cov_[0] = 0.0;
+      }
+      imu_ts_ = (double) entry.timestamp_data.timestamp;
 
-        ROS_DEBUG_STREAM(" - Motion,\t host time " << imu_ts_
-            << "\ttimestamp: " << std::setprecision(8) << (double)entry.timestamp_data.timestamp*IMU_UNITS_TO_MSEC
-            << "\tsource: " << (rs::event)entry.timestamp_data.source_id
-            << "\tframe_num: " << entry.timestamp_data.frame_number
-            << "\tx: " << std::setprecision(5) <<  entry.axes[0]
-            << "\ty: " << entry.axes[1]
-            << "\tz: " << entry.axes[2]);
+      ROS_DEBUG_STREAM(" - Motion,\t host time " << imu_ts_
+          << "\ttimestamp: " << std::setprecision(8) << (double)entry.timestamp_data.timestamp*IMU_UNITS_TO_MSEC
+          << "\tsource: " << (rs::event)entry.timestamp_data.source_id
+          << "\tframe_num: " << entry.timestamp_data.frame_number
+          << "\tx: " << std::setprecision(5) <<  entry.axes[0]
+          << "\ty: " << entry.axes[1]
+          << "\tz: " << entry.axes[2]);
     };
 
     // Get timestamp that syncs all sensors.


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixes boost: mutex lock failed in pthread_mutex_lock: invalid argument caused on ZR300 when ^C is done
- Adds a destructor to ZR300 to clean up the IMU thread, not a known issue but a potential one


