### PR TITLE
Fix F200/SR300 tests for new default 30fps

### DIFF
--- a/realsense_camera/test/f200_nodelet_disable_color.test
+++ b/realsense_camera/test/f200_nodelet_disable_color.test
@@ -1,6 +1,16 @@
 <launch>
-  <arg name="camera_type"  value="F200" />
-  <include file="$(find realsense_camera)/test/r200_nodelet_disable_color.test">
+  <arg name="camera"       value="camera" />
+  <arg name="camera_type"  default="F200" />
+  <arg name="enable_color" value="false" />
+
+  <!-- Start camera -->
+  <param name="$(arg camera)/driver/enable_color" type="bool" value="$(arg enable_color)" />
+  <include file="$(find realsense_camera)/launch/f200_nodelet_default.launch">
+    <arg name="camera"      value="$(arg camera)" />
     <arg name="camera_type" value="$(arg camera_type)" />
   </include>
+
+  <!-- Start test -->
+  <test pkg="realsense_camera" type="tests_camera_core" test-name="realsense_camera_test"
+    args="camera_type $(arg camera_type) enable_color $(arg enable_color)" />
 </launch>

--- a/realsense_camera/test/f200_nodelet_disable_depth.test
+++ b/realsense_camera/test/f200_nodelet_disable_depth.test
@@ -1,6 +1,16 @@
 <launch>
-  <arg name="camera_type"  value="F200" />
-  <include file="$(find realsense_camera)/test/r200_nodelet_disable_depth.test">
+  <arg name="camera"       value="camera" />
+  <arg name="camera_type"  default="F200" />
+  <arg name="enable_depth" value="false" />
+
+  <!-- Start camera -->
+  <param name="$(arg camera)/driver/enable_depth" type="bool" value="$(arg enable_depth)" />
+  <include file="$(find realsense_camera)/launch/f200_nodelet_default.launch">
+    <arg name="camera"      value="$(arg camera)" />
     <arg name="camera_type" value="$(arg camera_type)" />
   </include>
+
+  <!-- Start test -->
+  <test pkg="realsense_camera" type="tests_camera_core" test-name="realsense_camera_test"
+    args="camera_type $(arg camera_type) enable_depth $(arg enable_depth)" />
 </launch>

--- a/realsense_camera/test/sr300_nodelet_disable_color.test
+++ b/realsense_camera/test/sr300_nodelet_disable_color.test
@@ -1,6 +1,16 @@
 <launch>
-  <arg name="camera_type"  value="SR300" />
-  <include file="$(find realsense_camera)/test/r200_nodelet_disable_color.test">
+  <arg name="camera"       value="camera" />
+  <arg name="camera_type"  default="SR300" />
+  <arg name="enable_color" value="false" />
+
+  <!-- Start camera -->
+  <param name="$(arg camera)/driver/enable_color" type="bool" value="$(arg enable_color)" />
+  <include file="$(find realsense_camera)/launch/sr300_nodelet_default.launch">
+    <arg name="camera"      value="$(arg camera)" />
     <arg name="camera_type" value="$(arg camera_type)" />
   </include>
+
+  <!-- Start test -->
+  <test pkg="realsense_camera" type="tests_camera_core" test-name="realsense_camera_test"
+    args="camera_type $(arg camera_type) enable_color $(arg enable_color)" />
 </launch>

--- a/realsense_camera/test/sr300_nodelet_disable_depth.test
+++ b/realsense_camera/test/sr300_nodelet_disable_depth.test
@@ -1,6 +1,16 @@
 <launch>
-  <arg name="camera_type"  value="SR300" />
-  <include file="$(find realsense_camera)/test/r200_nodelet_disable_depth.test">
+  <arg name="camera"       value="camera" />
+  <arg name="camera_type"  default="SR300" />
+  <arg name="enable_depth" value="false" />
+
+  <!-- Start camera -->
+  <param name="$(arg camera)/driver/enable_depth" type="bool" value="$(arg enable_depth)" />
+  <include file="$(find realsense_camera)/launch/sr300_nodelet_default.launch">
+    <arg name="camera"      value="$(arg camera)" />
     <arg name="camera_type" value="$(arg camera_type)" />
   </include>
+
+  <!-- Start test -->
+  <test pkg="realsense_camera" type="tests_camera_core" test-name="realsense_camera_test"
+    args="camera_type $(arg camera_type) enable_depth $(arg enable_depth)" />
 </launch>


### PR DESCRIPTION
The F200 and SR300 tests were attempting too much code reuse
by include the r200_nodelet_default.launch file.
When the Default launch files were changed to set 30fps as the new
default for the color stream, F200/SR300 also had to set new defaults
for the Depth stream to prevent using the invalid R200 depth default.
The R200 default file does NOT pass the depth_width and depth_height
to the nodelet so the override values were lost.