### PR TITLE
Add Dynamic Transforms support -- multi-cam

### DIFF
--- a/realsense_camera/include/realsense_camera/constants.h
+++ b/realsense_camera/include/realsense_camera/constants.h
@@ -55,6 +55,7 @@ namespace realsense_camera
     const bool ENABLE_IMU = true;
     const bool ENABLE_PC = false;
     const bool ENABLE_TF = true;
+    const bool ENABLE_TF_DYNAMIC = false;
     const std::string DEFAULT_MODE = "preset";
     const std::string DEFAULT_BASE_FRAME_ID = "camera_link";
     const std::string DEFAULT_DEPTH_FRAME_ID = "camera_depth_frame";

--- a/realsense_camera/include/realsense_camera/r200_nodelet.h
+++ b/realsense_camera/include/realsense_camera/r200_nodelet.h
@@ -56,6 +56,8 @@ namespace realsense_camera
     };
     boost::shared_ptr<dynamic_reconfigure::Server<realsense_camera::r200_paramsConfig>> dynamic_reconf_server_;
 
+    rs_extrinsics color2ir2_extrinsic_; // color frame is base frame
+
     // Member Functions.
     void getParameters();
     void advertiseTopics();
@@ -64,7 +66,9 @@ namespace realsense_camera
     void setDynamicReconfigDepthControlPreset(int preset);
     std::string setDynamicReconfigDepthControlIndividuals();
     void configCallback(realsense_camera::r200_paramsConfig &config, uint32_t level);
+    void getCameraExtrinsics();
     void publishStaticTransforms();
+    void publishDynamicTransforms();
     void setFrameCallbacks();
     std::function<void(rs::frame f)> ir2_frame_handler_;
   };

--- a/realsense_camera/include/realsense_camera/zr300_nodelet.h
+++ b/realsense_camera/include/realsense_camera/zr300_nodelet.h
@@ -69,6 +69,10 @@ namespace realsense_camera
     std::function<void(rs::timestamp_data)> timestamp_handler_;
     std::mutex imu_mutex_;
 
+    rs_extrinsics color2ir2_extrinsic_; // color frame is base frame
+    rs_extrinsics color2fisheye_extrinsic_; // color frame is base frame
+    rs_extrinsics color2imu_extrinsic_; // color frame is base frame
+
     // Member Functions.
     void getParameters();
     void advertiseTopics();
@@ -79,13 +83,14 @@ namespace realsense_camera
     void setDynamicReconfigDepthControlPreset(int preset);
     std::string setDynamicReconfigDepthControlIndividuals();
     void configCallback(realsense_camera::zr300_paramsConfig &config, uint32_t level);
+    void getCameraExtrinsics();
     void publishStaticTransforms();
+    void publishDynamicTransforms();
     void prepareIMU();
     void setIMUCallbacks();
     void setFrameCallbacks();
     std::function<void(rs::frame f)> fisheye_frame_handler_, ir2_frame_handler_;
     void stopIMU();
-
   };
 }
 #endif

--- a/realsense_camera/launch/r200_nodelet_modify_params.launch
+++ b/realsense_camera/launch/r200_nodelet_modify_params.launch
@@ -14,6 +14,7 @@
   <arg name="enable_color"      default="true" />
   <arg name="enable_pointcloud" default="false" />
   <arg name="enable_tf"         default="true" />
+  <arg name="enable_tf_dynamic" default="false" />
   <arg name="mode"              default="manual" />
   <arg name="depth_width"       default="640" />
   <arg name="depth_height"      default="480" />
@@ -28,6 +29,7 @@
   <param name="$(arg camera)/driver/enable_color"      type="bool" value="$(arg enable_color)" />
   <param name="$(arg camera)/driver/enable_pointcloud" type="bool" value="$(arg enable_pointcloud)" />
   <param name="$(arg camera)/driver/enable_tf"         type="bool" value="$(arg enable_tf)" />
+  <param name="$(arg camera)/driver/enable_tf_dynamic" type="bool" value="$(arg enable_tf_dynamic)" />
   <param name="$(arg camera)/driver/mode"              type="str"  value="$(arg mode)" />
   <param name="$(arg camera)/driver/depth_width"       type="int"  value="$(arg depth_width)" />
   <param name="$(arg camera)/driver/depth_height"      type="int"  value="$(arg depth_height)" />

--- a/realsense_camera/src/base_nodelet.cpp
+++ b/realsense_camera/src/base_nodelet.cpp
@@ -41,7 +41,7 @@ namespace realsense_camera
    */
   BaseNodelet::~BaseNodelet()
   {
-    if (enable_tf_ == true && enable_tf_dynamic_ == false)
+    if (enable_tf_ == true && enable_tf_dynamic_ == true)
     {
       transform_thread_->join();
     }
@@ -96,7 +96,7 @@ namespace realsense_camera
     setStreams();
     startCamera();
 
-    // Start tranforms thread
+    // Start transforms thread
     if (enable_tf_ == true)
     {
       getCameraExtrinsics();


### PR DESCRIPTION
Fixes Issue: #120 

Due to a ROS bug which prevents publishing more than one static
transform in separate processes, enable the use of dynamic
camera transforms when needed for multiple camera support.

Static transforms are still the default.

See:
  ros/ros_comm#146
  ros/geometry2#181