### PR TITLE
Update RGBD launch files.

### DIFF
--- a/realsense_camera/launch/includes/nodelet_rgbd.launch.xml
+++ b/realsense_camera/launch/includes/nodelet_rgbd.launch.xml
@@ -7,9 +7,6 @@
     <arg name="depth"               default="depth" />
     <arg name="rgb"                 default="rgb" />
     <arg name="ir"                  default="ir" />
-    <arg name="depth_processing"    default="" />
-    <arg name="rgb_processing"      default="" />
-    <arg name="ir_processing"       default="" />
 <!-- rgbd_launch -->
 
 <!-- realsense_camera -->
@@ -25,9 +22,10 @@
     <arg name="color_fps"           default="" />
     <arg name="ir2"                 default="ir2" />
 
-    <arg name="enable_ir"           value="$(arg ir_processing)" />
-    <arg name="enable_ir2"          value="$(arg ir_processing)" />
-    <arg name="enable_depth"        value="$(arg depth_processing)" />
+    <arg name="enable_depth"        default="true" />
+    <arg name="enable_color"        default="true" />
+    <arg name="enable_ir"           default="true" />
+    <arg name="enable_ir2"          default="true" />
 
      <!-- "enable_pointcloud" is set to false by default because rgbd_launch uses standard ROS packages
           to generate point clouds. -->
@@ -40,7 +38,7 @@
         <param name="usb_port_id"             type="str"  value="$(arg usb_port_id)" />
         <param name="camera_type"             type="str"  value="$(arg camera_type)" />
         <param name="enable_depth"            type="bool" value="$(arg enable_depth)" />
-        <param name="enable_color"            type="bool" value="$(arg rgb_processing)" />
+        <param name="enable_color"            type="bool" value="$(arg enable_color)" />
         <param name="enable_ir"               type="bool" value="$(arg enable_ir)" />
         <param name="enable_ir2"              type="bool" value="$(arg enable_ir2)" />
         <param name="enable_pointcloud"       type="bool" value="$(arg enable_pointcloud)" />

--- a/realsense_camera/launch/r200_nodelet_rgbd.launch
+++ b/realsense_camera/launch/r200_nodelet_rgbd.launch
@@ -78,9 +78,6 @@
       <arg name="depth"                     value="$(arg depth)" />
       <arg name="rgb"                       value="$(arg rgb)" />
       <arg name="ir"                        value="$(arg ir)" />
-      <arg name="depth_processing"          value="$(arg depth_processing)" />
-      <arg name="rgb_processing"            value="$(arg rgb_processing)" />
-      <arg name="ir_processing"             value="$(arg ir_processing)" />
       <arg name="publish_tf"                value="$(arg publish_tf)" />
       <arg name="mode"                      value="$(arg mode)" />
       <arg name="depth_width"               value="$(arg depth_width)" />

--- a/realsense_camera/launch/sr300_nodelet_rgbd.launch
+++ b/realsense_camera/launch/sr300_nodelet_rgbd.launch
@@ -77,9 +77,6 @@
       <arg name="depth"                     value="$(arg depth)" />
       <arg name="rgb"                       value="$(arg rgb)" />
       <arg name="ir"                        value="$(arg ir)" />
-      <arg name="depth_processing"          value="$(arg depth_processing)" />
-      <arg name="rgb_processing"            value="$(arg rgb_processing)" />
-      <arg name="ir_processing"             value="$(arg ir_processing)" />
       <arg name="publish_tf"                value="$(arg publish_tf)" />
       <arg name="mode"                      value="$(arg mode)" />
       <arg name="depth_width"               value="$(arg depth_width)" />


### PR DESCRIPTION
Changes proposed in this pull request:

Modify the r200/sr300 RGBD-style launch files
to no longer use the RGBD depth/ir/rgb_processing
flags to control whether the corresponding stream
is also enabled. For example, now turning off
RGBD depth *processing* will no longer disable
the depth stream itself.