### PR TITLE
Do not register IR callback if stream disabled

### DIFF
--- a/realsense_camera/src/base_nodelet.cpp
+++ b/realsense_camera/src/base_nodelet.cpp
@@ -571,8 +571,14 @@ namespace realsense_camera
     rs_set_frame_callback_cpp(rs_device_, RS_STREAM_COLOR, new rs::frame_callback(color_frame_handler_), &rs_error_);
     checkError();
 
-    rs_set_frame_callback_cpp(rs_device_, RS_STREAM_INFRARED, new rs::frame_callback(ir_frame_handler_), &rs_error_);
-    checkError();
+    // Need to add this check due to a bug in librealsense which calls the IR callback
+    // if INFRARED stream is disable AND INFRARED2 stream is enabled
+    // https://github.com/IntelRealSense/librealsense/issues/393
+    if (enable_[RS_STREAM_INFRARED])
+    {
+      rs_set_frame_callback_cpp(rs_device_, RS_STREAM_INFRARED, new rs::frame_callback(ir_frame_handler_), &rs_error_);
+      checkError();
+    }
   }
 
   /*


### PR DESCRIPTION
Work around bug in librealsense where the callback for
IR is called even if the stream is disable if IR2 stream
is enabled.
See https://github.com/IntelRealSense/librealsense/issues/393