### PR TITLE
Start IMU in startCamera

### DIFF
--- a/realsense_camera/include/realsense_camera/base_nodelet.h
+++ b/realsense_camera/include/realsense_camera/base_nodelet.h
@@ -138,6 +138,7 @@ protected:
   tf::TransformBroadcaster dynamic_tf_broadcaster_;
   rs_extrinsics color2depth_extrinsic_;  // color frame is base frame
   rs_extrinsics color2ir_extrinsic_;     // color frame is base frame
+  rs_source rs_source_ = RS_SOURCE_VIDEO;
 
   struct CameraOptions
   {

--- a/realsense_camera/include/realsense_camera/zr300_nodelet.h
+++ b/realsense_camera/include/realsense_camera/zr300_nodelet.h
@@ -87,7 +87,8 @@ protected:
   void getCameraExtrinsics();
   void publishStaticTransforms();
   void publishDynamicTransforms();
-  void prepareIMU();
+  void publishIMU();
+  void setStreams();
   void setIMUCallbacks();
   void setFrameCallbacks();
   std::function<void(rs::frame f)> fisheye_frame_handler_, ir2_frame_handler_;

--- a/realsense_camera/src/base_nodelet.cpp
+++ b/realsense_camera/src/base_nodelet.cpp
@@ -723,7 +723,15 @@ namespace realsense_camera
       ROS_INFO_STREAM(nodelet_name_ << " - Starting camera");
       // Set up the callbacks for each stream
       setFrameCallbacks();
-      rs_device_->start(rs_source_);
+      try
+      {
+        rs_device_->start(rs_source_);
+      }
+      catch (std::runtime_error & e)
+      {
+    	  ROS_ERROR_STREAM(nodelet_name_ << " - Couldn't start camera -- " << e.what());
+    	  ros::shutdown();
+      }
       camera_start_ts_ = ros::Time::now();
       return "Camera Started Successfully";
     }
@@ -738,7 +746,15 @@ namespace realsense_camera
     if (rs_is_device_streaming(rs_device_, 0) == 1)
     {
       ROS_INFO_STREAM(nodelet_name_ << " - Stopping camera");
-      rs_device_->stop(rs_source_);
+      try
+      {
+        rs_device_->stop(rs_source_);
+      }
+      catch (std::runtime_error & e)
+      {
+    	  ROS_ERROR_STREAM(nodelet_name_ << " - Couldn't stop camera -- " << e.what());
+    	  ros::shutdown();
+      }
       return "Camera Stopped Successfully";
     }
     return "Camera is already Stopped";

--- a/realsense_camera/src/base_nodelet.cpp
+++ b/realsense_camera/src/base_nodelet.cpp
@@ -723,8 +723,7 @@ namespace realsense_camera
       ROS_INFO_STREAM(nodelet_name_ << " - Starting camera");
       // Set up the callbacks for each stream
       setFrameCallbacks();
-      rs_start_device(rs_device_, &rs_error_);
-      checkError();
+      rs_device_->start(rs_source_);
       camera_start_ts_ = ros::Time::now();
       return "Camera Started Successfully";
     }
@@ -739,8 +738,7 @@ namespace realsense_camera
     if (rs_is_device_streaming(rs_device_, 0) == 1)
     {
       ROS_INFO_STREAM(nodelet_name_ << " - Stopping camera");
-      rs_stop_device(rs_device_, 0);
-      checkError();
+      rs_device_->stop(rs_source_);
       return "Camera Stopped Successfully";
     }
     return "Camera is already Stopped";

--- a/realsense_camera/src/base_nodelet.cpp
+++ b/realsense_camera/src/base_nodelet.cpp
@@ -729,8 +729,8 @@ namespace realsense_camera
       }
       catch (std::runtime_error & e)
       {
-    	  ROS_ERROR_STREAM(nodelet_name_ << " - Couldn't start camera -- " << e.what());
-    	  ros::shutdown();
+        ROS_ERROR_STREAM(nodelet_name_ << " - Couldn't start camera -- " << e.what());
+        ros::shutdown();
       }
       camera_start_ts_ = ros::Time::now();
       return "Camera Started Successfully";
@@ -752,8 +752,8 @@ namespace realsense_camera
       }
       catch (std::runtime_error & e)
       {
-    	  ROS_ERROR_STREAM(nodelet_name_ << " - Couldn't stop camera -- " << e.what());
-    	  ros::shutdown();
+        ROS_ERROR_STREAM(nodelet_name_ << " - Couldn't stop camera -- " << e.what());
+        ros::shutdown();
       }
       return "Camera Stopped Successfully";
     }

--- a/realsense_camera/src/zr300_nodelet.cpp
+++ b/realsense_camera/src/zr300_nodelet.cpp
@@ -569,7 +569,7 @@ namespace realsense_camera
     rs_enable_motion_tracking_cpp(rs_device_, new rs::motion_callback(motion_handler_),
         new rs::timestamp_callback(timestamp_handler_), &rs_error_);
     checkError();
-    rs_source_ = RS_SOURCE_ALL; // overrides default to enable motion tracking
+    rs_source_ = RS_SOURCE_ALL;  // overrides default to enable motion tracking
   }
 
   /*


### PR DESCRIPTION
**Please ensure the above *guidelines for contributing* are met.**

Fixes Issue: #

Changes proposed in this pull request:
- This fixes the try_for_lock timeout error that sometimes occurs for ZR300 on some systems
- It changes the way the IMU is started for ZR300 to start IMU and streams using device->start(rs_source::RS_SOURCE_ALL)
- This removes the call to rs_start_source(...) for the IMU
- Doing so also aligns the camera and IMU timestamps


