### PR TITLE
Added retry in tests to avoid random failures

### DIFF
--- a/realsense_camera/test/f200_nodelet_camera_options.test
+++ b/realsense_camera/test/f200_nodelet_camera_options.test
@@ -62,5 +62,6 @@
     f200_accuracy $(arg f200_accuracy)
     f200_motion_range $(arg f200_motion_range)
     f200_filter_option $(arg f200_filter_option)
-    f200_confidence_threshold $(arg f200_confidence_threshold) "/>
+    f200_confidence_threshold $(arg f200_confidence_threshold) "
+    retry="3" />
 </launch>

--- a/realsense_camera/test/f200_nodelet_disable_color.test
+++ b/realsense_camera/test/f200_nodelet_disable_color.test
@@ -12,5 +12,6 @@
 
   <!-- Start test -->
   <test pkg="realsense_camera" type="tests_camera_core" test-name="realsense_camera_test"
-    args="camera_type $(arg camera_type) enable_color $(arg enable_color)" />
+    args="camera_type $(arg camera_type) enable_color $(arg enable_color)" 
+    retry="3" />
 </launch>

--- a/realsense_camera/test/f200_nodelet_disable_depth.test
+++ b/realsense_camera/test/f200_nodelet_disable_depth.test
@@ -12,5 +12,6 @@
 
   <!-- Start test -->
   <test pkg="realsense_camera" type="tests_camera_core" test-name="realsense_camera_test"
-    args="camera_type $(arg camera_type) enable_depth $(arg enable_depth)" />
+    args="camera_type $(arg camera_type) enable_depth $(arg enable_depth)"
+    retry="3" />
 </launch>

--- a/realsense_camera/test/r200_nodelet_camera_options.test
+++ b/realsense_camera/test/r200_nodelet_camera_options.test
@@ -95,5 +95,6 @@
     r200_depth_control_texture_difference_threshold $(arg r200_depth_control_texture_difference_threshold)
     r200_depth_control_second_peak_threshold $(arg r200_depth_control_second_peak_threshold)
     r200_depth_control_neighbor_threshold $(arg r200_depth_control_neighbor_threshold)
-    r200_depth_control_lr_threshold $(arg r200_depth_control_lr_threshold) "/>
+    r200_depth_control_lr_threshold $(arg r200_depth_control_lr_threshold) "
+    retry="3" />
 </launch>

--- a/realsense_camera/test/r200_nodelet_disable_color.test
+++ b/realsense_camera/test/r200_nodelet_disable_color.test
@@ -12,5 +12,6 @@
 
   <!-- Start test -->
   <test pkg="realsense_camera" type="tests_camera_core" test-name="realsense_camera_test"
-    args="camera_type $(arg camera_type) enable_color $(arg enable_color)" />
+    args="camera_type $(arg camera_type) enable_color $(arg enable_color)" 
+    retry="3" />
 </launch>

--- a/realsense_camera/test/r200_nodelet_disable_depth.test
+++ b/realsense_camera/test/r200_nodelet_disable_depth.test
@@ -12,5 +12,6 @@
 
   <!-- Start test -->
   <test pkg="realsense_camera" type="tests_camera_core" test-name="realsense_camera_test"
-    args="camera_type $(arg camera_type) enable_depth $(arg enable_depth)" />
+    args="camera_type $(arg camera_type) enable_depth $(arg enable_depth)" 
+    retry="3" />
 </launch>

--- a/realsense_camera/test/r200_nodelet_enable_ir.test
+++ b/realsense_camera/test/r200_nodelet_enable_ir.test
@@ -21,5 +21,6 @@
     args="camera_type $(arg camera_type) enable_color $(arg enable_color) 
       enable_depth $(arg enable_depth) 
       enable_ir $(arg enable_ir) 
-      enable_ir2 $(arg enable_ir2)" />
+      enable_ir2 $(arg enable_ir2)"
+      retry="3" />
 </launch>

--- a/realsense_camera/test/r200_nodelet_modify_params.test
+++ b/realsense_camera/test/r200_nodelet_modify_params.test
@@ -39,5 +39,6 @@
     depth_width $(arg depth_width)
     depth_height $(arg depth_height)
     color_width $(arg color_width)
-    color_height $(arg color_height)" />
+    color_height $(arg color_height)" 
+    retry="3" />
 </launch>

--- a/realsense_camera/test/r200_nodelet_resolution.test
+++ b/realsense_camera/test/r200_nodelet_resolution.test
@@ -29,5 +29,6 @@
     depth_width $(arg depth_width)
     depth_height $(arg depth_height)
     color_width $(arg color_width)
-    color_height $(arg color_height)" />
+    color_height $(arg color_height)"
+    retry="3" />
 </launch>

--- a/realsense_camera/test/r200_nodelet_rgbd.test
+++ b/realsense_camera/test/r200_nodelet_rgbd.test
@@ -9,5 +9,5 @@
   </include>
 
   <!-- Test -->
-  <test pkg="realsense_camera" type="tests_rgbd_topics" test-name="realsense_camera_test_rgbd" />
+  <test pkg="realsense_camera" type="tests_rgbd_topics" test-name="realsense_camera_test_rgbd" retry="3" />
 </launch>

--- a/realsense_camera/test/sr300_nodelet_camera_options.test
+++ b/realsense_camera/test/sr300_nodelet_camera_options.test
@@ -92,5 +92,6 @@
     sr300_auto_range_max_laser $(arg sr300_auto_range_max_laser)
     sr300_auto_range_start_laser $(arg sr300_auto_range_start_laser)
     sr300_auto_range_upper_threshold $(arg sr300_auto_range_upper_threshold)
-    sr300_auto_range_lower_threshold $(arg sr300_auto_range_lower_threshold)"/>
+    sr300_auto_range_lower_threshold $(arg sr300_auto_range_lower_threshold)"
+    retry="3" />
 </launch>

--- a/realsense_camera/test/sr300_nodelet_disable_color.test
+++ b/realsense_camera/test/sr300_nodelet_disable_color.test
@@ -12,5 +12,6 @@
 
   <!-- Start test -->
   <test pkg="realsense_camera" type="tests_camera_core" test-name="realsense_camera_test"
-    args="camera_type $(arg camera_type) enable_color $(arg enable_color)" />
+    args="camera_type $(arg camera_type) enable_color $(arg enable_color)"
+    retry="3" />
 </launch>

--- a/realsense_camera/test/sr300_nodelet_disable_depth.test
+++ b/realsense_camera/test/sr300_nodelet_disable_depth.test
@@ -12,5 +12,6 @@
 
   <!-- Start test -->
   <test pkg="realsense_camera" type="tests_camera_core" test-name="realsense_camera_test"
-    args="camera_type $(arg camera_type) enable_depth $(arg enable_depth)" />
+    args="camera_type $(arg camera_type) enable_depth $(arg enable_depth)"
+    retry="3" />
 </launch>

--- a/realsense_camera/test/zr300_nodelet_default.test
+++ b/realsense_camera/test/zr300_nodelet_default.test
@@ -14,5 +14,6 @@
   <test pkg="realsense_camera" type="tests_camera_core" test-name="realsense_camera_test"
     args="camera_type $(arg camera_type)
     enable_fisheye $(arg enable_fisheye)
-    enable_imu $(arg enable_imu)" />
+    enable_imu $(arg enable_imu)"
+    retry="3" />
 </launch>


### PR DESCRIPTION
Some random failures  were observed during unit tests in CI, so added retry="3" in tests to avoid these failures. Triggered 3 rounds of CI testing with this change, and got 100% passed. 