### PR TITLE
Enable roslint for Python Code

### DIFF
--- a/realsense_camera/CMakeLists.txt
+++ b/realsense_camera/CMakeLists.txt
@@ -59,6 +59,7 @@ generate_dynamic_reconfigure_options(
 
 # ROS Lint the code
 roslint_cpp()
+roslint_python()
 roslint_add_test()
 
 #################################


### PR DESCRIPTION
The project does not currently contain Python code, but enable
to ensure any new code is linted. Good as this project is being
used as a template for other ROS projects.