### PR TITLE
Generate Warning for non-validated camera firmware

### DIFF
--- a/realsense_camera/include/realsense_camera/base_nodelet.h
+++ b/realsense_camera/include/realsense_camera/base_nodelet.h
@@ -176,6 +176,8 @@ protected:
   virtual bool checkForSubscriber();
   virtual void wrappedSystem(std::vector<std::string> string_argv);
   virtual void setFrameCallbacks();
+  virtual std::string checkFirmwareValidation(std::string fw_type, std::string current_fw, std::string camera_name,
+        std::string camera_serial_number);
   std::function<void(rs::frame f)> depth_frame_handler_, color_frame_handler_, ir_frame_handler_;
 };
 }  // namespace realsense_camera

--- a/realsense_camera/include/realsense_camera/constants.h
+++ b/realsense_camera/include/realsense_camera/constants.h
@@ -30,6 +30,8 @@
 
 #include <iostream>
 #include <string>
+#include <utility>
+#include <map>
 
 #pragma once
 #ifndef REALSENSE_CAMERA_CONSTANTS_H
@@ -90,14 +92,16 @@ namespace realsense_camera
     // R200 Constants.
     // Indoor Range: 0.7m - 3.5m, Outdoor Range: 10m
     const float R200_MAX_Z = 10.0f;   // in meters
-
+    const std::string R200_CAMERA_FW_VERSION = "1.0.72.06";
     // F200 Constants.
     // Indoor Range: 0.2m – 1.0m, Outdoor Range: n/a
     const float F200_MAX_Z = 1.0f;    // in meters
+    const std::string F200_CAMERA_FW_VERSION = "2.60.0.0";
 
     // SR300 Constants.
     // Indoor Range: 0.2m – 1.5m, Outdoor Range: n/a
     const float SR300_MAX_Z = 1.5f;   // in meters
+    const std::string SR300_CAMERA_FW_VERSION = "3.10.10.0";
 
     // ZR300 Constants.
     // Indoor Range: 0.7m - 3.5m, Outdoor Range: 10m
@@ -114,5 +118,26 @@ namespace realsense_camera
     const std::string IMU_ACCEL = "IMU_ACCEL";
     const std::string IMU_GYRO = "IMU_GYRO";
     const double IMU_UNITS_TO_MSEC = 0.00003125;
+    const std::string ZR300_CAMERA_FW_VERSION = "2.0.71.26";
+    const std::string ZR300_ADAPTER_FW_VERSION = "1.28.0.0";
+    const std::string ZR300_MOTION_MODULE_FW_VERSION = "1.25.0.0";
+
+    // map the camera name to its validated firmware
+    typedef std::pair<std::string, std::string> stringpair;
+    const stringpair MAP_START_VALUES[] =
+    {
+      stringpair("Intel RealSense R200_camera", R200_CAMERA_FW_VERSION),
+      stringpair("Intel RealSense F200_camera", F200_CAMERA_FW_VERSION),
+      stringpair("Intel RealSense SR300_camera", SR300_CAMERA_FW_VERSION),
+      stringpair("Intel RealSense ZR300_camera", ZR300_CAMERA_FW_VERSION),
+      stringpair("Intel RealSense ZR300_adapter", ZR300_ADAPTER_FW_VERSION),
+      stringpair("Intel RealSense ZR300_motion_module", ZR300_MOTION_MODULE_FW_VERSION)
+    };
+
+    const int MAP_START_VALUES_SIZE = sizeof(MAP_START_VALUES) /
+          sizeof(MAP_START_VALUES[0]);
+
+    extern const std::map<std::string, std::string> CAMERA_NAME_TO_VALIDATED_FIRMWARE;
+
 }  // namespace realsense_camera
 #endif  // REALSENSE_CAMERA_CONSTANTS_H

--- a/realsense_camera/src/base_nodelet.cpp
+++ b/realsense_camera/src/base_nodelet.cpp
@@ -304,7 +304,7 @@ namespace realsense_camera
       }
       // print camera details
       detected_camera_msg = detected_camera_msg +
-            "\n\t\t\t\t - Serial No: " + camera_serial_number + ", USB Port ID: " +
+            "\n\t\t\t\t- Serial No: " + camera_serial_number + ", USB Port ID: " +
             rs_get_device_usb_port_id(rs_detected_device, &rs_error_) +
             ", Name: " + camera_name +
             ", Camera FW: " + camera_fw;
@@ -314,7 +314,7 @@ namespace realsense_camera
 
       if (!camera_warning_msg.empty())
       {
-        warning_msg = warning_msg + "\n\t\t\t\t-" + camera_warning_msg;
+        warning_msg = warning_msg + "\n\t\t\t\t- " + camera_warning_msg;
       }
 
       if (rs_supports(rs_detected_device, RS_CAPABILITIES_ADAPTER_BOARD, &rs_error_))
@@ -327,7 +327,7 @@ namespace realsense_camera
               camera_serial_number);
         if (!adapter_warning_msg.empty())
         {
-          warning_msg = warning_msg + "\n\t\t\t\t-" + adapter_warning_msg;
+          warning_msg = warning_msg + "\n\t\t\t\t- " + adapter_warning_msg;
         }
       }
 
@@ -341,7 +341,7 @@ namespace realsense_camera
               camera_serial_number);
         if (!motion_module_warning_msg.empty())
         {
-          warning_msg = warning_msg + "\n\t\t\t\t-" + motion_module_warning_msg;
+          warning_msg = warning_msg + "\n\t\t\t\t- " + motion_module_warning_msg;
         }
       }
       ROS_INFO_STREAM(nodelet_name_ + detected_camera_msg);

--- a/realsense_camera/src/base_nodelet.cpp
+++ b/realsense_camera/src/base_nodelet.cpp
@@ -1299,7 +1299,7 @@ namespace realsense_camera
     if (current_fw != validated_firmware)
     {
       warning_msg = camera_serial_number + "'s current " + fw_type + " firmware is " + current_fw +
-            ". Validated " + fw_type + " firmware is " + validated_firmware;
+            ", Validated " + fw_type + " firmware is " + validated_firmware;
     }
     return warning_msg;
   }


### PR DESCRIPTION
**Please ensure the above *guidelines for contributing* are met.**

Fixes Issue: #

Changes proposed in this pull request:
- Checks camera firmware version against the validated firmware version. 
- Prints warning if the camera firmware version is different from validated firmware version.
- For ZR300, also checks the adapter firmware and motion module firmware. 


