### PR TITLE
Increase retry count for rgbd test

### DIFF
--- a/realsense_camera/test/r200_nodelet_rgbd.test
+++ b/realsense_camera/test/r200_nodelet_rgbd.test
@@ -9,5 +9,5 @@
   </include>
 
   <!-- Test -->
-  <test pkg="realsense_camera" type="tests_rgbd_topics" test-name="realsense_camera_test_rgbd" retry="3" />
+  <test pkg="realsense_camera" type="tests_rgbd_topics" test-name="realsense_camera_test_rgbd" retry="8" />
 </launch>


### PR DESCRIPTION
During one week observation on CI, rgdb test still failed randomly. It's about a 10% fail rate, not always failed at the same topic, but always in rgbd test. So increase the retry count for rgbd test to improve the stability.


