### PR TITLE
Use shared timestamp for SR300/F200 cameras

### DIFF
--- a/realsense_camera/include/realsense_camera/base_nodelet.h
+++ b/realsense_camera/include/realsense_camera/base_nodelet.h
@@ -165,6 +165,7 @@ protected:
   virtual void disableStream(rs_stream stream_index);
   virtual std::string startCamera();
   virtual std::string stopCamera();
+  virtual ros::Time getTimestamp(rs_stream stream_index, double frame_ts);
   virtual void publishTopic(rs_stream stream_index, rs::frame &  frame);
   virtual void setImageData(rs_stream stream_index, rs::frame &  frame);
   virtual void publishPCTopic();

--- a/realsense_camera/include/realsense_camera/f200_nodelet.h
+++ b/realsense_camera/include/realsense_camera/f200_nodelet.h
@@ -49,8 +49,11 @@ public:
 protected:
   // Member Variables.
   boost::shared_ptr<dynamic_reconfigure::Server<realsense_camera::f200_paramsConfig>> dynamic_reconf_server_;
+  rs_stream fastest_stream_ = RS_STREAM_DEPTH;
 
   // Member Functions.
+  void setStreams();
+  ros::Time getTimestamp(rs_stream stream_index, double frame_ts);
   std::vector<std::string> setDynamicReconfServer();
   void startDynamicReconfCallback();
   void configCallback(realsense_camera::f200_paramsConfig &config, uint32_t level);

--- a/realsense_camera/include/realsense_camera/sr300_nodelet.h
+++ b/realsense_camera/include/realsense_camera/sr300_nodelet.h
@@ -50,8 +50,11 @@ public:
 protected:
   // Member Variables.
   boost::shared_ptr<dynamic_reconfigure::Server<realsense_camera::sr300_paramsConfig>> dynamic_reconf_server_;
+  rs_stream fastest_stream_ = RS_STREAM_DEPTH;
 
   // Member Functions.
+  void setStreams();
+  ros::Time getTimestamp(rs_stream stream_index, double frame_ts);
   std::vector<std::string> setDynamicReconfServer();
   void startDynamicReconfCallback();
   void configCallback(realsense_camera::sr300_paramsConfig &config, uint32_t level);

--- a/realsense_camera/src/base_nodelet.cpp
+++ b/realsense_camera/src/base_nodelet.cpp
@@ -827,6 +827,14 @@ namespace realsense_camera
   }
 
   /*
+   * Determine the timetamp for the publish topic.
+   */
+  ros::Time BaseNodelet::getTimestamp(rs_stream stream_index, double frame_ts)
+  {
+    return ros::Time(camera_start_ts_) + ros::Duration(frame_ts * 0.001);
+  }
+
+  /*
    * Publish topic.
    */
   void BaseNodelet::publishTopic(rs_stream stream_index, rs::frame &frame) try
@@ -846,7 +854,7 @@ namespace realsense_camera
                                 image_[stream_index]).toImageMsg();
         msg->header.frame_id = optical_frame_id_[stream_index];
         // Publish timestamp to synchronize frames.
-        msg->header.stamp = ros::Time(camera_start_ts_) + ros::Duration(frame_ts * 0.001);
+        msg->header.stamp = getTimestamp(stream_index, frame_ts);
         msg->width = image_[stream_index].cols;
         msg->height = image_[stream_index].rows;
         msg->is_bigendian = false;

--- a/realsense_camera/src/f200_nodelet.cpp
+++ b/realsense_camera/src/f200_nodelet.cpp
@@ -63,6 +63,41 @@ namespace realsense_camera
   }
 
   /*
+   * Determine fastest stream -- overrides base class
+   */
+  void F200Nodelet::setStreams()
+  {
+    // enable camera streams
+    BaseNodelet::setStreams();
+
+    // Find the fastest updating, enabled stream
+    fastest_stream_ = RS_STREAM_DEPTH;  // default to depth
+
+    if (fps_[RS_STREAM_COLOR] > fps_[RS_STREAM_DEPTH])
+    {
+      if (enable_[RS_STREAM_COLOR])
+      {
+        fastest_stream_ = RS_STREAM_COLOR;
+      }
+    }
+  }
+
+  /*
+   * Determine the timetamp for the publish topic. -- overrides base class
+   */
+  ros::Time F200Nodelet::getTimestamp(rs_stream stream_index, double frame_ts)
+  {
+    static ros::Time last_common_stamp = ros::Time::now();
+
+    if (stream_index == fastest_stream_)
+    {
+      last_common_stamp = ros::Time::now();
+    }
+
+    return last_common_stamp;
+  }
+
+  /*
    * Set Dynamic Reconfigure Server and return the dynamic params.
    */
   std::vector<std::string> F200Nodelet::setDynamicReconfServer()

--- a/realsense_camera/src/sr300_nodelet.cpp
+++ b/realsense_camera/src/sr300_nodelet.cpp
@@ -62,6 +62,41 @@ namespace realsense_camera
   }
 
   /*
+   * Determine fastest stream -- overrides base class
+   */
+  void SR300Nodelet::setStreams()
+  {
+    // enable camera streams
+    BaseNodelet::setStreams();
+
+    // Find the fastest updating, enabled stream
+    fastest_stream_ = RS_STREAM_DEPTH;  // default to depth
+
+    if (fps_[RS_STREAM_COLOR] > fps_[RS_STREAM_DEPTH])
+    {
+      if (enable_[RS_STREAM_COLOR])
+      {
+        fastest_stream_ = RS_STREAM_COLOR;
+      }
+    }
+  }
+
+  /*
+   * Determine the timetamp for the publish topic. -- overrides base class
+   */
+  ros::Time SR300Nodelet::getTimestamp(rs_stream stream_index, double frame_ts)
+  {
+    static ros::Time last_common_stamp = ros::Time::now();
+
+    if (stream_index == fastest_stream_)
+    {
+      last_common_stamp = ros::Time::now();
+    }
+
+    return last_common_stamp;
+  }
+
+  /*
    * Set Dynamic Reconfigure Server and return the dynamic params.
    */
   std::vector<std::string> SR300Nodelet::setDynamicReconfServer()


### PR DESCRIPTION
Due to camera hardware issues on the SR300 and F200, reverted back
to using a common timestamp updated by the fastest stream. This was the
old behaviour when rs_wait_for_frames was used prior to release 1.7.0.