### PR TITLE
Changed fisheye_strobe and fisheye_external_trigger to static params

### DIFF
--- a/realsense_camera/cfg/zr300_params.cfg
+++ b/realsense_camera/cfg/zr300_params.cfg
@@ -71,8 +71,6 @@ r200_depth_control.add("r200_dc_lr_threshold",
 
 gen.add("fisheye_exposure",                                int_t,    0,     "Fisheye Exposure",                           40,        40,     331)
 gen.add("fisheye_gain",                                    int_t,    0,     "Fisheye Gain",                               0,         0,      2047)
-gen.add("fisheye_strobe",                                  int_t,    0,     "Fisheye Strobe",                             0,         0,      1)
-gen.add("fisheye_external_trigger",                        int_t,    0,     "Fisheye External Trigger",                   0,         0,      1)
 gen.add("fisheye_enable_auto_exposure",                    int_t,    0,     "Fisheye Enable Auto Exposure",               1,         0,      1)
 gen.add("fisheye_auto_exposure_mode",                      int_t,    0,     "Fisheye Auto Exposure Mode",                 0,         0,      2)
 gen.add("fisheye_auto_exposure_antiflicker_rate",          int_t,    0,     "Fisheye Auto Exposure Antiflicker Rate",     60,        50,     60)

--- a/realsense_camera/launch/zr300_nodelet_default.launch
+++ b/realsense_camera/launch/zr300_nodelet_default.launch
@@ -11,10 +11,14 @@
   <arg name="mode"              default="manual" />
   <arg name="color_fps"         default="30" />
   <arg name="fisheye_fps"       default="30" />
+  <arg name="fisheye_strobe"    default="1" />
+  <arg name="fisheye_external_trigger"    default="1" />
 
   <param name="$(arg camera)/driver/mode"              type="str"  value="$(arg mode)" />
   <param name="$(arg camera)/driver/color_fps"         type="int"  value="$(arg color_fps)" />
   <param name="$(arg camera)/driver/fisheye_fps"       type="int"  value="$(arg fisheye_fps)" />
+  <param name="$(arg camera)/driver/fisheye_strobe"    type="int"  value="$(arg fisheye_strobe)" />
+  <param name="$(arg camera)/driver/fisheye_external_trigger"    type="int"  value="$(arg fisheye_external_trigger)" />
   <!-- Refer to the Wiki http://wiki.ros.org/realsense_camera for list of supported parameters -->
 
   <group ns="$(arg camera)">

--- a/realsense_camera/src/base_nodelet.cpp
+++ b/realsense_camera/src/base_nodelet.cpp
@@ -568,7 +568,7 @@ namespace realsense_camera
           {
             opt_val = val;
           }
-          ROS_DEBUG_STREAM(nodelet_name_ << " - " << opt_name << " = " << opt_val);
+          ROS_INFO_STREAM(nodelet_name_ << " - Setting camera option " << opt_name << " = " << opt_val);
           rs_set_device_option(rs_device_, o.opt, opt_val, &rs_error_);
           checkError();
         }

--- a/realsense_camera/src/zr300_nodelet.cpp
+++ b/realsense_camera/src/zr300_nodelet.cpp
@@ -498,8 +498,6 @@ namespace realsense_camera
     rs_set_device_option(rs_device_, RS_OPTION_FISHEYE_EXPOSURE,
         config.fisheye_exposure, 0);
     rs_set_device_option(rs_device_, RS_OPTION_FISHEYE_GAIN, config.fisheye_gain, 0);
-    rs_set_device_option(rs_device_, RS_OPTION_FISHEYE_STROBE, config.fisheye_strobe, 0);
-    rs_set_device_option(rs_device_, RS_OPTION_FISHEYE_EXTERNAL_TRIGGER, config.fisheye_external_trigger, 0);
     rs_set_device_option(rs_device_, RS_OPTION_FISHEYE_ENABLE_AUTO_EXPOSURE, config.fisheye_enable_auto_exposure, 0);
     rs_set_device_option(rs_device_, RS_OPTION_FISHEYE_AUTO_EXPOSURE_MODE, config.fisheye_auto_exposure_mode, 0);
     rs_set_device_option(rs_device_, RS_OPTION_FISHEYE_AUTO_EXPOSURE_ANTIFLICKER_RATE,


### PR DESCRIPTION
Changes proposed in this pull request:
- Sets the fisheye_strobe and fisheye_external_trigger values as static params instead of dynamic
- Adds a ROS_INFO_STREAM message for any params set statically, was ROS_DEBUG_STREAM before