### PR TITLE
Git ignore QT Creator *.workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ msg/_*.py
 
 # qcreator stuff
 CMakeLists.txt.user
+*.workspace
 
 srv/_*.py
 *.pcd


### PR DESCRIPTION
**Please ensure the above *guidelines for contributing* are met.**

Fixes Issue: #

Changes proposed in this pull request:
- git ignores QT Creator *.workspace files, used by ROS QT Creator plugin
-
-


