### PR TITLE
Revert to wait for frame for R200, F200, SR300 cameras

### DIFF
--- a/realsense_camera/CMakeLists.txt
+++ b/realsense_camera/CMakeLists.txt
@@ -83,7 +83,7 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
 )
 
-add_library(${PROJECT_NAME}_nodelet src/base_nodelet.cpp src/r200_nodelet.cpp src/f200_nodelet.cpp src/sr300_nodelet.cpp
+add_library(${PROJECT_NAME}_nodelet src/base_nodelet.cpp src/sync_nodelet.cpp src/r200_nodelet.cpp src/f200_nodelet.cpp src/sr300_nodelet.cpp
   src/zr300_nodelet.cpp)
 target_link_libraries(${PROJECT_NAME}_nodelet
   ${catkin_LIBRARIES}

--- a/realsense_camera/include/realsense_camera/base_nodelet.h
+++ b/realsense_camera/include/realsense_camera/base_nodelet.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- Copyright (c) 2016, Intel Corporation
+ Copyright (c) 2017, Intel Corporation
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without

--- a/realsense_camera/include/realsense_camera/base_nodelet.h
+++ b/realsense_camera/include/realsense_camera/base_nodelet.h
@@ -139,6 +139,8 @@ protected:
   rs_extrinsics color2depth_extrinsic_;  // color frame is base frame
   rs_extrinsics color2ir_extrinsic_;     // color frame is base frame
   rs_source rs_source_ = RS_SOURCE_VIDEO;
+  bool start_camera_ = true;
+  bool start_stop_srv_called_ = false;
 
   struct CameraOptions
   {

--- a/realsense_camera/include/realsense_camera/f200_nodelet.h
+++ b/realsense_camera/include/realsense_camera/f200_nodelet.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- Copyright (c) 2016, Intel Corporation
+ Copyright (c) 2017, Intel Corporation
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without

--- a/realsense_camera/include/realsense_camera/f200_nodelet.h
+++ b/realsense_camera/include/realsense_camera/f200_nodelet.h
@@ -37,11 +37,11 @@
 #include <dynamic_reconfigure/server.h>
 
 #include <realsense_camera/f200_paramsConfig.h>
-#include <realsense_camera/base_nodelet.h>
+#include <realsense_camera/sync_nodelet.h>
 
 namespace realsense_camera
 {
-class F200Nodelet: public realsense_camera::BaseNodelet
+class F200Nodelet: public realsense_camera::SyncNodelet
 {
 public:
   void onInit();

--- a/realsense_camera/include/realsense_camera/f200_nodelet.h
+++ b/realsense_camera/include/realsense_camera/f200_nodelet.h
@@ -53,7 +53,6 @@ protected:
 
   // Member Functions.
   void setStreams();
-  ros::Time getTimestamp(rs_stream stream_index, double frame_ts);
   std::vector<std::string> setDynamicReconfServer();
   void startDynamicReconfCallback();
   void configCallback(realsense_camera::f200_paramsConfig &config, uint32_t level);

--- a/realsense_camera/include/realsense_camera/r200_nodelet.h
+++ b/realsense_camera/include/realsense_camera/r200_nodelet.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- Copyright (c) 2016, Intel Corporation
+ Copyright (c) 2017, Intel Corporation
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without

--- a/realsense_camera/include/realsense_camera/r200_nodelet.h
+++ b/realsense_camera/include/realsense_camera/r200_nodelet.h
@@ -38,11 +38,11 @@
 #include <dynamic_reconfigure/server.h>
 
 #include <realsense_camera/r200_paramsConfig.h>
-#include <realsense_camera/base_nodelet.h>
+#include <realsense_camera/sync_nodelet.h>
 
 namespace realsense_camera
 {
-class R200Nodelet: public realsense_camera::BaseNodelet
+class R200Nodelet: public realsense_camera::SyncNodelet
 {
 public:
   void onInit();
@@ -71,8 +71,6 @@ protected:
   void getCameraExtrinsics();
   void publishStaticTransforms();
   void publishDynamicTransforms();
-  void setFrameCallbacks();
-  std::function<void(rs::frame f)> ir2_frame_handler_;
 };
 }  // namespace realsense_camera
 #endif  // REALSENSE_CAMERA_R200_NODELET_H

--- a/realsense_camera/include/realsense_camera/sr300_nodelet.h
+++ b/realsense_camera/include/realsense_camera/sr300_nodelet.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- Copyright (c) 2016, Intel Corporation
+ Copyright (c) 2017, Intel Corporation
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without

--- a/realsense_camera/include/realsense_camera/sr300_nodelet.h
+++ b/realsense_camera/include/realsense_camera/sr300_nodelet.h
@@ -54,7 +54,6 @@ protected:
 
   // Member Functions.
   void setStreams();
-  ros::Time getTimestamp(rs_stream stream_index, double frame_ts);
   std::vector<std::string> setDynamicReconfServer();
   void startDynamicReconfCallback();
   void configCallback(realsense_camera::sr300_paramsConfig &config, uint32_t level);

--- a/realsense_camera/include/realsense_camera/sr300_nodelet.h
+++ b/realsense_camera/include/realsense_camera/sr300_nodelet.h
@@ -38,11 +38,11 @@
 #include <dynamic_reconfigure/server.h>
 
 #include <realsense_camera/sr300_paramsConfig.h>
-#include <realsense_camera/base_nodelet.h>
+#include <realsense_camera/sync_nodelet.h>
 
 namespace realsense_camera
 {
-class SR300Nodelet: public realsense_camera::BaseNodelet
+class SR300Nodelet: public realsense_camera::SyncNodelet
 {
 public:
   void onInit();

--- a/realsense_camera/include/realsense_camera/sync_nodelet.h
+++ b/realsense_camera/include/realsense_camera/sync_nodelet.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- Copyright (c) 2016, Intel Corporation
+ Copyright (c) 2017, Intel Corporation
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without

--- a/realsense_camera/include/realsense_camera/sync_nodelet.h
+++ b/realsense_camera/include/realsense_camera/sync_nodelet.h
@@ -41,6 +41,7 @@ class SyncNodelet: public realsense_camera::BaseNodelet
 {
 public:
   // Interfaces.
+  virtual ~SyncNodelet();
   virtual void onInit();
 
 protected:

--- a/realsense_camera/include/realsense_camera/sync_nodelet.h
+++ b/realsense_camera/include/realsense_camera/sync_nodelet.h
@@ -46,6 +46,7 @@ public:
 protected:
   boost::shared_ptr<boost::thread> topic_thread_;
   bool duplicate_depth_color_ = false;
+  ros::Time topic_ts_;
 
   virtual void setFrameCallbacks() { }  // don't set callbacks!
   virtual void publishSyncTopics();

--- a/realsense_camera/include/realsense_camera/sync_nodelet.h
+++ b/realsense_camera/include/realsense_camera/sync_nodelet.h
@@ -1,0 +1,57 @@
+/******************************************************************************
+ Copyright (c) 2016, Intel Corporation
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ 3. Neither the name of the copyright holder nor the names of its contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+#pragma once
+#ifndef REALSENSE_CAMERA_SYNC_NODELET_H
+#define REALSENSE_CAMERA_SYNC_NODELET_H
+
+#include <realsense_camera/base_nodelet.h>
+#include <boost/thread.hpp>
+
+namespace realsense_camera
+{
+class SyncNodelet: public realsense_camera::BaseNodelet
+{
+public:
+  // Interfaces.
+  virtual void onInit();
+
+protected:
+   boost::shared_ptr<boost::thread> topic_thread_;
+   bool duplicate_depth_color_ = false;
+
+  virtual void setFrameCallbacks() { };  // don't set callbacks!
+  virtual void publishSyncTopics();
+  virtual void publishTopic(rs_stream stream_index);
+  virtual void setImageData(rs_stream stream_index);
+
+};
+}  // namespace realsense_camera
+#endif  // REALSENSE_CAMERA_SYNC_NODELET_H

--- a/realsense_camera/include/realsense_camera/sync_nodelet.h
+++ b/realsense_camera/include/realsense_camera/sync_nodelet.h
@@ -44,14 +44,13 @@ public:
   virtual void onInit();
 
 protected:
-   boost::shared_ptr<boost::thread> topic_thread_;
-   bool duplicate_depth_color_ = false;
+  boost::shared_ptr<boost::thread> topic_thread_;
+  bool duplicate_depth_color_ = false;
 
-  virtual void setFrameCallbacks() { };  // don't set callbacks!
+  virtual void setFrameCallbacks() { }  // don't set callbacks!
   virtual void publishSyncTopics();
   virtual void publishTopic(rs_stream stream_index);
   virtual void setImageData(rs_stream stream_index);
-
 };
 }  // namespace realsense_camera
 #endif  // REALSENSE_CAMERA_SYNC_NODELET_H

--- a/realsense_camera/src/base_nodelet.cpp
+++ b/realsense_camera/src/base_nodelet.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
- Copyright (c) 2016, Intel Corporation
+ Copyright (c) 2017, Intel Corporation
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without

--- a/realsense_camera/src/base_nodelet.cpp
+++ b/realsense_camera/src/base_nodelet.cpp
@@ -848,13 +848,6 @@ namespace realsense_camera
     {
       enable_[RS_STREAM_DEPTH] = true;
     }
-
-    if (enable_[RS_STREAM_DEPTH] != rs_is_stream_enabled(rs_device_, RS_STREAM_DEPTH, 0))
-    {
-      stopCamera();
-      setStreams();
-      startCamera();
-    }
   }
 
   /*

--- a/realsense_camera/src/base_nodelet.cpp
+++ b/realsense_camera/src/base_nodelet.cpp
@@ -456,7 +456,8 @@ namespace realsense_camera
 
     if (req.power_on == true)
     {
-      ROS_INFO_STREAM(nodelet_name_ << " - " << startCamera());
+      start_camera_ = true;
+      start_stop_srv_called_ = true;
     }
     else
     {
@@ -468,7 +469,8 @@ namespace realsense_camera
       {
         if (checkForSubscriber() == false)
         {
-          ROS_INFO_STREAM(nodelet_name_ << " - " << stopCamera());
+          start_camera_ = false;
+          start_stop_srv_called_ = true;
         }
         else
         {
@@ -478,8 +480,7 @@ namespace realsense_camera
       }
     }
     return res.success;
-  }
-
+}
 
   /*
    * Force Power Camera service
@@ -487,14 +488,8 @@ namespace realsense_camera
   bool BaseNodelet::forcePowerCameraService(realsense_camera::ForcePower::Request & req,
       realsense_camera::ForcePower::Response & res)
   {
-    if (req.power_on == true)
-    {
-      ROS_INFO_STREAM(nodelet_name_ << " - " << startCamera());
-    }
-    else
-    {
-      ROS_INFO_STREAM(nodelet_name_ << " - " << stopCamera());
-    }
+    start_camera_ = req.power_on;
+    start_stop_srv_called_ = true;
     return true;
   }
 

--- a/realsense_camera/src/f200_nodelet.cpp
+++ b/realsense_camera/src/f200_nodelet.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
- Copyright (c) 2016, Intel Corporation
+ Copyright (c) 2017, Intel Corporation
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without

--- a/realsense_camera/src/f200_nodelet.cpp
+++ b/realsense_camera/src/f200_nodelet.cpp
@@ -59,7 +59,7 @@ namespace realsense_camera
 
     max_z_ = F200_MAX_Z;
 
-    BaseNodelet::onInit();
+    SyncNodelet::onInit();
   }
 
   /*

--- a/realsense_camera/src/f200_nodelet.cpp
+++ b/realsense_camera/src/f200_nodelet.cpp
@@ -83,21 +83,6 @@ namespace realsense_camera
   }
 
   /*
-   * Determine the timestamp for the publish topic. -- overrides base class
-   */
-  ros::Time F200Nodelet::getTimestamp(rs_stream stream_index, double frame_ts)
-  {
-    static ros::Time last_common_stamp = ros::Time::now();
-
-    if (stream_index == fastest_stream_)
-    {
-      last_common_stamp = ros::Time::now();
-    }
-
-    return last_common_stamp;
-  }
-
-  /*
    * Set Dynamic Reconfigure Server and return the dynamic params.
    */
   std::vector<std::string> F200Nodelet::setDynamicReconfServer()

--- a/realsense_camera/src/r200_nodelet.cpp
+++ b/realsense_camera/src/r200_nodelet.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
- Copyright (c) 2016, Intel Corporation
+ Copyright (c) 2017, Intel Corporation
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without

--- a/realsense_camera/src/r200_nodelet.cpp
+++ b/realsense_camera/src/r200_nodelet.cpp
@@ -66,7 +66,7 @@ namespace realsense_camera
 
     max_z_ = R200_MAX_Z;
 
-    BaseNodelet::onInit();
+    SyncNodelet::onInit();
   }
 
   /*
@@ -415,23 +415,6 @@ namespace realsense_camera
         }
       }
     }
-  }
-
-  /*
-  * Set up the callbacks for the camera streams
-  */
-  void R200Nodelet::setFrameCallbacks()
-  {
-    // call base nodelet method
-    BaseNodelet::setFrameCallbacks();
-
-    ir2_frame_handler_ = [&](rs::frame  frame)  // NOLINT(build/c++11)
-    {
-      publishTopic(RS_STREAM_INFRARED2, frame);
-    };
-
-    rs_set_frame_callback_cpp(rs_device_, RS_STREAM_INFRARED2, new rs::frame_callback(ir2_frame_handler_), &rs_error_);
-    checkError();
   }
 
   /*

--- a/realsense_camera/src/sr300_nodelet.cpp
+++ b/realsense_camera/src/sr300_nodelet.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
- Copyright (c) 2016, Intel Corporation
+ Copyright (c) 2017, Intel Corporation
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without

--- a/realsense_camera/src/sr300_nodelet.cpp
+++ b/realsense_camera/src/sr300_nodelet.cpp
@@ -82,21 +82,6 @@ namespace realsense_camera
   }
 
   /*
-   * Determine the timestamp for the publish topic. -- overrides base class
-   */
-  ros::Time SR300Nodelet::getTimestamp(rs_stream stream_index, double frame_ts)
-  {
-    static ros::Time last_common_stamp = ros::Time::now();
-
-    if (stream_index == fastest_stream_)
-    {
-      last_common_stamp = ros::Time::now();
-    }
-
-    return last_common_stamp;
-  }
-
-  /*
    * Set Dynamic Reconfigure Server and return the dynamic params.
    */
   std::vector<std::string> SR300Nodelet::setDynamicReconfServer()

--- a/realsense_camera/src/sr300_nodelet.cpp
+++ b/realsense_camera/src/sr300_nodelet.cpp
@@ -58,7 +58,7 @@ namespace realsense_camera
 
     max_z_ = SR300_MAX_Z;
 
-    BaseNodelet::onInit();
+    SyncNodelet::onInit();
   }
 
   /*

--- a/realsense_camera/src/sync_nodelet.cpp
+++ b/realsense_camera/src/sync_nodelet.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
- Copyright (c) 2016, Intel Corporation
+ Copyright (c) 2017, Intel Corporation
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without

--- a/realsense_camera/src/sync_nodelet.cpp
+++ b/realsense_camera/src/sync_nodelet.cpp
@@ -1,0 +1,163 @@
+/******************************************************************************
+ Copyright (c) 2016, Intel Corporation
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ 3. Neither the name of the copyright holder nor the names of its contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+#include <realsense_camera/sync_nodelet.h>
+
+PLUGINLIB_EXPORT_CLASS(realsense_camera::SyncNodelet, nodelet::Nodelet)
+
+namespace realsense_camera
+{
+  /*
+   * Initialize the nodelet.
+   */
+  void SyncNodelet::onInit()
+  {
+    BaseNodelet::onInit();
+
+    // start thread to publish topics
+    topic_thread_ =
+            boost::shared_ptr <boost::thread>(new boost::thread (boost::bind(&SyncNodelet::publishSyncTopics, this)));
+  }
+
+  void SyncNodelet::publishSyncTopics() try
+  {
+    while (ros::ok())
+    {
+      if (rs_is_device_streaming(rs_device_, 0) == 1)
+      {
+        rs_wait_for_frames(rs_device_, &rs_error_);
+        checkError();
+
+        for (int stream=0; stream < STREAM_COUNT; stream++)
+        {
+          if (enable_[stream] == true)
+          {
+            publishTopic(static_cast<rs_stream>(stream));
+          }
+
+          if (pointcloud_publisher_.getNumSubscribers() > 0 &&
+              rs_is_stream_enabled(rs_device_, RS_STREAM_DEPTH, 0) == 1 && enable_pointcloud_ == true &&
+              (duplicate_depth_color_ == false)) // Skip publishing PointCloud if Depth and/or Color frame was duplicate
+          {
+            if (camera_publisher_[RS_STREAM_DEPTH].getNumSubscribers() <= 0)
+            {
+              setImageData(RS_STREAM_DEPTH);
+            }
+            if (camera_publisher_[RS_STREAM_COLOR].getNumSubscribers() <= 0)
+            {
+              setImageData(RS_STREAM_COLOR);
+            }
+            publishPCTopic();
+          }
+        }
+      }
+    }
+  }
+  catch(const rs::error & e)
+  {
+    ROS_ERROR_STREAM(nodelet_name_ << " - " << "RealSense error calling "
+        << e.get_failed_function() << "(" << e.get_failed_args() << "):\n    "
+        << e.what());
+    ros::shutdown();
+  }
+  catch(const std::exception & e)
+  {
+    ROS_ERROR_STREAM(nodelet_name_ << " - " << e.what());
+    ros::shutdown();
+  }
+  catch(...)
+  {
+    ROS_ERROR_STREAM(nodelet_name_ << " - Caught unknown expection...shutting down!");
+    ros::shutdown();
+  }
+
+  /*
+   * Publish topic.
+   */
+  void SyncNodelet::publishTopic(rs_stream stream_index)
+  {
+    // Publish stream only if there is at least one subscriber.
+    if (camera_publisher_[stream_index].getNumSubscribers() > 0 &&
+        rs_is_stream_enabled(rs_device_, (rs_stream) stream_index, 0) == 1)
+    {
+      double frame_ts = rs_get_frame_timestamp(rs_device_, (rs_stream) stream_index, 0);
+      if (ts_[stream_index] != frame_ts) // Publish frames only if its not duplicate
+      {
+        setImageData(stream_index);
+
+        sensor_msgs::ImagePtr msg = cv_bridge::CvImage(std_msgs::Header(),
+            encoding_[stream_index],
+            image_[stream_index]).toImageMsg();
+
+        msg->header.frame_id = optical_frame_id_[stream_index];
+        msg->header.stamp = getTimestamp(stream_index, frame_ts);; // Publish timestamp to synchronize frames.
+        msg->width = image_[stream_index].cols;
+        msg->height = image_[stream_index].rows;
+        msg->is_bigendian = false;
+        msg->step = step_[stream_index];
+
+        camera_info_ptr_[stream_index]->header.stamp = msg->header.stamp;
+        camera_publisher_[stream_index].publish (msg, camera_info_ptr_[stream_index]);
+      }
+      else
+      {
+        if ((stream_index == RS_STREAM_DEPTH) || (stream_index == RS_STREAM_COLOR))
+        {
+          duplicate_depth_color_ = true; // Set this flag to true if Depth and/or Color frame is duplicate
+        }
+      }
+      ts_[stream_index] = frame_ts;
+    }
+  }
+  void SyncNodelet::setImageData(rs_stream stream_index)
+    {
+      if (stream_index == RS_STREAM_DEPTH)
+      {
+        // fill depth buffer
+        image_depth16_ = reinterpret_cast<const uint16_t *>(rs_get_frame_data(rs_device_, stream_index, 0));
+        float depth_scale_meters = rs_get_device_depth_scale(rs_device_, &rs_error_);
+        if (depth_scale_meters == MILLIMETER_METERS)
+        {
+          image_[stream_index].data = (unsigned char *) image_depth16_;
+        }
+        else
+        {
+          cvWrapper_ = cv::Mat(image_[stream_index].size(), cv_type_[stream_index], (void *) image_depth16_,
+                step_[stream_index]);
+          cvWrapper_.convertTo(image_[stream_index], cv_type_[stream_index],
+                static_cast<double>(depth_scale_meters) / static_cast<double>(MILLIMETER_METERS));
+        }
+      }
+      else
+      {
+        image_[stream_index].data = (unsigned char *) (rs_get_frame_data(rs_device_, stream_index, 0));
+      }
+    }
+}  // namespace realsense_camera

--- a/realsense_camera/src/sync_nodelet.cpp
+++ b/realsense_camera/src/sync_nodelet.cpp
@@ -34,7 +34,6 @@ PLUGINLIB_EXPORT_CLASS(realsense_camera::SyncNodelet, nodelet::Nodelet)
 
 namespace realsense_camera
 {
-
   SyncNodelet::~SyncNodelet()
   {
     topic_thread_->join();
@@ -66,6 +65,7 @@ namespace realsense_camera
         {
           ROS_INFO_STREAM(nodelet_name_ << " - " << stopCamera());
         }
+
         start_stop_srv_called_ = false;
       }
 
@@ -99,10 +99,12 @@ namespace realsense_camera
           {
             setImageData(RS_STREAM_DEPTH);
           }
+
           if (camera_publisher_[RS_STREAM_COLOR].getNumSubscribers() <= 0)
           {
             setImageData(RS_STREAM_COLOR);
           }
+
           publishPCTopic();
         }
       }
@@ -161,9 +163,11 @@ namespace realsense_camera
           duplicate_depth_color_ = true;  // Set this flag to true if Depth and/or Color frame is duplicate
         }
       }
+
       ts_[stream_index] = frame_ts;
     }
   }
+
   void SyncNodelet::setImageData(rs_stream stream_index)
     {
       if (stream_index == RS_STREAM_DEPTH)

--- a/realsense_camera/src/sync_nodelet.cpp
+++ b/realsense_camera/src/sync_nodelet.cpp
@@ -54,6 +54,7 @@ namespace realsense_camera
       {
         rs_wait_for_frames(rs_device_, &rs_error_);
         checkError();
+        topic_ts_ = ros::Time::now();
 
         for (int stream=0; stream < STREAM_COUNT; stream++)
         {
@@ -117,7 +118,7 @@ namespace realsense_camera
             image_[stream_index]).toImageMsg();
 
         msg->header.frame_id = optical_frame_id_[stream_index];
-        msg->header.stamp = getTimestamp(stream_index, frame_ts);;  // Publish timestamp to synchronize frames.
+        msg->header.stamp = topic_ts_;  // Publish timestamp to synchronize frames.
         msg->width = image_[stream_index].cols;
         msg->height = image_[stream_index].rows;
         msg->is_bigendian = false;

--- a/realsense_camera/src/sync_nodelet.cpp
+++ b/realsense_camera/src/sync_nodelet.cpp
@@ -34,6 +34,12 @@ PLUGINLIB_EXPORT_CLASS(realsense_camera::SyncNodelet, nodelet::Nodelet)
 
 namespace realsense_camera
 {
+
+  SyncNodelet::~SyncNodelet()
+  {
+    topic_thread_->join();
+  }
+
   /*
    * Initialize the nodelet.
    */

--- a/realsense_camera/src/sync_nodelet.cpp
+++ b/realsense_camera/src/sync_nodelet.cpp
@@ -64,7 +64,7 @@ namespace realsense_camera
 
           if (pointcloud_publisher_.getNumSubscribers() > 0 &&
               rs_is_stream_enabled(rs_device_, RS_STREAM_DEPTH, 0) == 1 && enable_pointcloud_ == true &&
-              (duplicate_depth_color_ == false)) // Skip publishing PointCloud if Depth and/or Color frame was duplicate
+              (duplicate_depth_color_ == false))  // Skip publishing PointCloud if Depth or Color frame was duplicate
           {
             if (camera_publisher_[RS_STREAM_DEPTH].getNumSubscribers() <= 0)
             {
@@ -108,7 +108,7 @@ namespace realsense_camera
         rs_is_stream_enabled(rs_device_, (rs_stream) stream_index, 0) == 1)
     {
       double frame_ts = rs_get_frame_timestamp(rs_device_, (rs_stream) stream_index, 0);
-      if (ts_[stream_index] != frame_ts) // Publish frames only if its not duplicate
+      if (ts_[stream_index] != frame_ts)  // Publish frames only if its not duplicate
       {
         setImageData(stream_index);
 
@@ -117,20 +117,20 @@ namespace realsense_camera
             image_[stream_index]).toImageMsg();
 
         msg->header.frame_id = optical_frame_id_[stream_index];
-        msg->header.stamp = getTimestamp(stream_index, frame_ts);; // Publish timestamp to synchronize frames.
+        msg->header.stamp = getTimestamp(stream_index, frame_ts);;  // Publish timestamp to synchronize frames.
         msg->width = image_[stream_index].cols;
         msg->height = image_[stream_index].rows;
         msg->is_bigendian = false;
         msg->step = step_[stream_index];
 
         camera_info_ptr_[stream_index]->header.stamp = msg->header.stamp;
-        camera_publisher_[stream_index].publish (msg, camera_info_ptr_[stream_index]);
+        camera_publisher_[stream_index].publish(msg, camera_info_ptr_[stream_index]);
       }
       else
       {
         if ((stream_index == RS_STREAM_DEPTH) || (stream_index == RS_STREAM_COLOR))
         {
-          duplicate_depth_color_ = true; // Set this flag to true if Depth and/or Color frame is duplicate
+          duplicate_depth_color_ = true;  // Set this flag to true if Depth and/or Color frame is duplicate
         }
       }
       ts_[stream_index] = frame_ts;
@@ -149,8 +149,9 @@ namespace realsense_camera
         }
         else
         {
-          cvWrapper_ = cv::Mat(image_[stream_index].size(), cv_type_[stream_index], (void *) image_depth16_,
-                step_[stream_index]);
+          cvWrapper_ = cv::Mat(image_[stream_index].size(), cv_type_[stream_index],
+                               const_cast<void *>(reinterpret_cast<const void *>(image_depth16_)),
+                               step_[stream_index]);
           cvWrapper_.convertTo(image_[stream_index], cv_type_[stream_index],
                 static_cast<double>(depth_scale_meters) / static_cast<double>(MILLIMETER_METERS));
         }

--- a/realsense_camera/src/sync_nodelet.cpp
+++ b/realsense_camera/src/sync_nodelet.cpp
@@ -63,6 +63,13 @@ namespace realsense_camera
         start_stop_srv_called_ = false;
       }
 
+      if (enable_[RS_STREAM_DEPTH] != rs_is_stream_enabled(rs_device_, RS_STREAM_DEPTH, 0))
+      {
+        stopCamera();
+        setStreams();
+        startCamera();
+      }
+
       if (rs_is_device_streaming(rs_device_, 0) == 1)
       {
         rs_wait_for_frames(rs_device_, &rs_error_);

--- a/realsense_camera/src/zr300_nodelet.cpp
+++ b/realsense_camera/src/zr300_nodelet.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
- Copyright (c) 2016, Intel Corporation
+ Copyright (c) 2017, Intel Corporation
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without

--- a/realsense_camera/src/zr300_nodelet.cpp
+++ b/realsense_camera/src/zr300_nodelet.cpp
@@ -518,6 +518,19 @@ namespace realsense_camera
     prev_imu_ts_ = -1;
     while (ros::ok())
     {
+      if (start_stop_srv_called_ == true)
+      {
+        if (start_camera_ == true)
+        {
+          ROS_INFO_STREAM(nodelet_name_ << " - " << startCamera());
+        }
+        else
+        {
+          ROS_INFO_STREAM(nodelet_name_ << " - " << stopCamera());
+        }
+        start_stop_srv_called_ = false;
+      }
+
       if (imu_publisher_.getNumSubscribers() > 0)
       {
         std::unique_lock<std::mutex> lock(imu_mutex_);

--- a/realsense_camera/src/zr300_nodelet.cpp
+++ b/realsense_camera/src/zr300_nodelet.cpp
@@ -531,6 +531,13 @@ namespace realsense_camera
         start_stop_srv_called_ = false;
       }
 
+      if (enable_[RS_STREAM_DEPTH] != rs_is_stream_enabled(rs_device_, RS_STREAM_DEPTH, 0))
+      {
+        stopCamera();
+        setStreams();
+        startCamera();
+      }
+
       if (imu_publisher_.getNumSubscribers() > 0)
       {
         std::unique_lock<std::mutex> lock(imu_mutex_);


### PR DESCRIPTION
**Please ensure the above *guidelines for contributing* are met.**

Fixes Issue: #210, #207

Changes proposed in this pull request:
- Adds new synchronous base class which uses rs_wait_for_frames for use with the F200, SR300, and R200 cameras; this is to improve the reliability when running RGBD, which relies on synchronous color & depth streams


