### PR TITLE
Dynamic reconfigure of SR300 exposure controls

### DIFF
--- a/realsense_camera/cfg/f200_params.cfg
+++ b/realsense_camera/cfg/f200_params.cfg
@@ -20,7 +20,11 @@ gen.add("color_sharpness",                       int_t,    0,          "Sharpnes
 # Must be set only if color_enable_auto_white_balance is disabled
 gen.add("color_white_balance",                   int_t,    0,          "White Balance",                3200,      2500,   6500)
 
+# Must be set only if color_enable_auto_exposure is disabled
+gen.add("color_exposure",                        int_t,    0,          "Exposure",                     156,       39,     10000)
+
 gen.add("color_enable_auto_white_balance",       int_t,    0,          "Enable Auto White Balance",    1,         0,      1)
+gen.add("color_enable_auto_exposure",            int_t,    0,          "Enable Auto Exposure",         1,         0,      1) 
 gen.add("f200_laser_power",                      int_t,    0,          "Laser Power",                  16,        0,      16)
 gen.add("f200_accuracy",                         int_t,    0,          "Accuracy",                     2,         1,      3)
 gen.add("f200_motion_range",                     int_t,    0,          "Motion Range",                 1,         0,      100)

--- a/realsense_camera/cfg/r200_params.cfg
+++ b/realsense_camera/cfg/r200_params.cfg
@@ -20,7 +20,11 @@ gen.add("color_sharpness",                       int_t,    0,          "Sharpnes
 # Must be set only if color_enable_auto_white_balance is disabled
 gen.add("color_white_balance",                   int_t,    0,          "White Balance",                6500,      2000,   8000)
 
+# Must be set only if color_enable_auto_exposure is disabled
+gen.add("color_exposure",                        int_t,    0,          "Exposure",                     156,       39,     10000)
+
 gen.add("color_enable_auto_white_balance",       int_t,    0,          "Enable Auto White Balance",    1,         0,      1)
+gen.add("color_enable_auto_exposure",            int_t,    0,    	   "Enable Auto Exposure",         1,         0,      1)
 gen.add("r200_lr_auto_exposure_enabled",         int_t,    0,          "LR Auto Exposure Enabled",     0,         0,      1)
 gen.add("r200_lr_gain",                          int_t,    0,          "LR Gain",                      400,       100,    6399)
 

--- a/realsense_camera/cfg/sr300_params.cfg
+++ b/realsense_camera/cfg/sr300_params.cfg
@@ -22,6 +22,11 @@ gen.add("color_white_balance",                         int_t,  0,    "White Bala
 
 gen.add("color_enable_auto_white_balance",             int_t,  0,    "Enable Auto White Balance",    1,         0,      1)
 
+# Must be set only if color_enable_auto_exposure is disabled
+gen.add("color_exposure",                              int_t,  0,    "Exposure",                     156,       39,     10000)
+
+gen.add("color_enable_auto_exposure",                  int_t,  0,    "Enable Auto Exposure",         1,         0,      1)
+
 # Options common with F200
 gen.add("f200_laser_power",                            int_t,  0,    "Laser Power",                  16,        0,      16)
 gen.add("f200_accuracy",                               int_t,  0,    "Accuracy",                     1,         1,      3)

--- a/realsense_camera/src/f200_nodelet.cpp
+++ b/realsense_camera/src/f200_nodelet.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
- Copyright (c) 2016, Intel Corporation
+ Copyright (c) 2017, Intel Corporation
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -145,6 +145,12 @@ namespace realsense_camera
     rs_set_device_option(rs_device_, RS_OPTION_COLOR_HUE, config.color_hue, 0);
     rs_set_device_option(rs_device_, RS_OPTION_COLOR_SATURATION, config.color_saturation, 0);
     rs_set_device_option(rs_device_, RS_OPTION_COLOR_SHARPNESS, config.color_sharpness, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_COLOR_ENABLE_AUTO_EXPOSURE,
+    config.color_enable_auto_exposure, 0);
+    if (config.color_enable_auto_exposure == 0)
+    {
+      rs_set_device_option(rs_device_, RS_OPTION_COLOR_EXPOSURE, config.color_exposure, 0);
+    }
     rs_set_device_option(rs_device_, RS_OPTION_COLOR_ENABLE_AUTO_WHITE_BALANCE,
         config.color_enable_auto_white_balance, 0);
     if (config.color_enable_auto_white_balance == 0)

--- a/realsense_camera/src/r200_nodelet.cpp
+++ b/realsense_camera/src/r200_nodelet.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
- Copyright (c) 2016, Intel Corporation
+ Copyright (c) 2017, Intel Corporation
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -273,6 +273,12 @@ namespace realsense_camera
     rs_set_device_option(rs_device_, RS_OPTION_COLOR_HUE, config.color_hue, 0);
     rs_set_device_option(rs_device_, RS_OPTION_COLOR_SATURATION, config.color_saturation, 0);
     rs_set_device_option(rs_device_, RS_OPTION_COLOR_SHARPNESS, config.color_sharpness, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_COLOR_ENABLE_AUTO_EXPOSURE,
+    config.color_enable_auto_exposure, 0);
+    if (config.color_enable_auto_exposure == 0)
+    {
+      rs_set_device_option(rs_device_, RS_OPTION_COLOR_EXPOSURE, config.color_exposure, 0);
+    }
     rs_set_device_option(rs_device_, RS_OPTION_COLOR_ENABLE_AUTO_WHITE_BALANCE,
         config.color_enable_auto_white_balance, 0);
     if (config.color_enable_auto_white_balance == 0)

--- a/realsense_camera/src/sr300_nodelet.cpp
+++ b/realsense_camera/src/sr300_nodelet.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
- Copyright (c) 2016, Intel Corporation
+ Copyright (c) 2017, Intel Corporation
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without

--- a/realsense_camera/src/sr300_nodelet.cpp
+++ b/realsense_camera/src/sr300_nodelet.cpp
@@ -144,6 +144,12 @@ namespace realsense_camera
     rs_set_device_option(rs_device_, RS_OPTION_COLOR_HUE, config.color_hue, 0);
     rs_set_device_option(rs_device_, RS_OPTION_COLOR_SATURATION, config.color_saturation, 0);
     rs_set_device_option(rs_device_, RS_OPTION_COLOR_SHARPNESS, config.color_sharpness, 0);
+    rs_set_device_option(rs_device_, RS_OPTION_COLOR_ENABLE_AUTO_EXPOSURE,
+        config.color_enable_auto_exposure, 0);
+    if (config.color_enable_auto_exposure == 0)
+    {
+      rs_set_device_option(rs_device_, RS_OPTION_COLOR_EXPOSURE, config.color_exposure, 0);
+    }
     rs_set_device_option(rs_device_, RS_OPTION_COLOR_ENABLE_AUTO_WHITE_BALANCE,
         config.color_enable_auto_white_balance, 0);
     if (config.color_enable_auto_white_balance == 0)


### PR DESCRIPTION
Fixes Issue: #213 

Changes proposed in this pull request:
- Addition of dynamic_reconfigure parameters color_exposure and color_enable_auto_exposure with appropriate default, min and max values as specified by librealsense cpp-enumerated-devices output for the SR300
- RS_OPTION_COLOR_ENABLE_AUTO_EXPOSURE and RS_OPTION_COLOR_EXPOSURE setting in SR300Nodelet::configCallback based on white balance method.

Tested on following system:
```
| Version               | Your Configuration   |
|:--------------------- |:---------------------|
| Operating System      | Ubuntu 14.04.5 LTS   |
| Kernel                | 4.4.0-64-generic     |
| ROS                   | indigo               |
| ROS RealSense         | 1.7.1                |
| librealsense          | 1.12.1               |
| Camera Type-Firmware  | 3.17.0.0             |
```

Also tested on:
```
| Version               | Your Configuration       |
|:--------------------- |:-------------------------|
| Operating System      | Ubuntu 16.04.2 LTS       |
| Kernel                | 4.4.0-66-generic (built) |
|                       | 4.8.0-41-generic (ran)   |
| ROS                   | kinetic                  |
| ROS RealSense         | 1.7.1                    |
| librealsense          | 1.12.1                   |
| Camera Type-Firmware  | 3.17.0.0                 |
```