### PR TITLE
librealsense: Fix link when the system library is used

### DIFF
--- a/realsense_camera/CMakeLists.txt
+++ b/realsense_camera/CMakeLists.txt
@@ -102,6 +102,12 @@ add_library(${PROJECT_NAME}_nodelet src/base_nodelet.cpp src/sync_nodelet.cpp sr
 target_link_libraries(${PROJECT_NAME}_nodelet
   ${catkin_LIBRARIES}
 )
+if(USE_SYSTEM_LIBREALSENSE)
+  target_link_libraries(${PROJECT_NAME}_nodelet
+    ${realsense_LIBRARY}
+    )
+endif()
+
 add_dependencies(${PROJECT_NAME}_nodelet ${PROJECT_NAME}_generate_messages_cpp ${PROJECT_NAME}_gencfg)
 add_dependencies(${PROJECT_NAME}_nodelet ${catkin_EXPORTED_TARGETS})
 


### PR DESCRIPTION
Otherwise librealsense won't be listed as a dependency for the nodelet
that will fail to load due to undefined symbols.

Signed-off-by: Murilo Belluzzo <murilo.belluzzo@intel.com>

--
One can easily check the problem issuing 'ldd' on the nodelet .so. The following link has a complete description of how the problem was detected:
https://github.com/intel-aero/meta-intel-aero/issues/76
