### PR TITLE
Disable ZR300 rgb_processing

### DIFF
--- a/realsense_camera/launch/zr300_nodelet_rgbd.launch
+++ b/realsense_camera/launch/zr300_nodelet_rgbd.launch
@@ -1,4 +1,4 @@
-<!-- Sample launch file for using RealSense R200 camera with rgbd_launch -->
+<!-- Sample launch file for using RealSense ZR300 camera with rgbd_launch -->
 <launch>
 
   <!-- "camera" should be a user friendly string to uniquely identify the device namespace.
@@ -44,7 +44,7 @@
   <arg name="publish_tf"    default="true" />
 
   <!-- Processing Modules -->
-  <arg name="rgb_processing"                  default="true"/>
+  <arg name="rgb_processing"                  default="false"/>
   <arg name="ir_processing"                   default="true"/>
   <arg name="depth_processing"                default="true"/>
   <arg name="depth_registered_processing"     default="true"/>


### PR DESCRIPTION
Disable ZR300 rgb_processing because a rectified color stream is already provided by [Librealsense](https://github.com/intel-ros/realsense/blob/dadd3f95405ca5af2694488681231fbaf84de419/realsense_camera/src/sync_nodelet.cpp#L193).