### PR TITLE
fix off-by-one error in comparison of color_pixel and image_color sizes

### DIFF
--- a/realsense_camera/src/base_nodelet.cpp
+++ b/realsense_camera/src/base_nodelet.cpp
@@ -1012,8 +1012,8 @@ namespace realsense_camera
             rs_transform_point_to_point(color_point, &z_extrinsic, depth_point);
             rs_project_point_to_pixel(color_pixel, &color_intrinsic, color_point);
 
-            if (color_pixel[1] < 0.0f || color_pixel[1] > image_color.rows
-                || color_pixel[0] < 0.0f || color_pixel[0] > image_color.cols)
+            if (color_pixel[1] < 0.0f || color_pixel[1] >= image_color.rows
+                || color_pixel[0] < 0.0f || color_pixel[0] >= image_color.cols)
             {
               // For out of bounds color data, default to a shade of blue in order to visually distinguish holes.
               // This color value is same as the librealsense out of bounds color value.


### PR DESCRIPTION
This fixes an issue in #335.

The mapping of points to pixels can fall exactly on the boundary of the image size. In that case there will be out of bounds access to the color_data array which results in segmentation fault.

This patch makes sure this does not happen.