### PR TITLE
Fixes librealsense CMake vars.

### DIFF
--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -94,8 +94,11 @@ add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
 
 
+target_include_directories(${PROJECT_NAME}
+  PRIVATE ${realsense_INCLUDE_DIR})
+
 target_link_libraries(${PROJECT_NAME}
-    realsense2
+    ${realsense2_LIBRARY}
     ${catkin_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
     )


### PR DESCRIPTION
If librealsense isn't installed system-wide, the library isn't found without using the vars found in `find_package(realsense2)`.