### PR TITLE
remove librealsense2 depend as unused

### DIFF
--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -68,7 +68,7 @@ generate_dynamic_reconfigure_options(
 # RealSense ROS Node
 catkin_package(
     LIBRARIES ${PROJECT_NAME}
-    CATKIN_DEPENDS message_runtime roscpp sensor_msgs std_msgs librealsense2
+    CATKIN_DEPENDS message_runtime roscpp sensor_msgs std_msgs
     nodelet
     cv_bridge
     image_transport

--- a/realsense2_camera/package.xml
+++ b/realsense2_camera/package.xml
@@ -24,7 +24,6 @@
   <build_depend>tf</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>diagnostic_updater</build_depend>
-  <build_depend>librealsense2</build_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>nodelet</run_depend>  
@@ -36,7 +35,6 @@
   <run_depend>tf</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>diagnostic_updater</run_depend>
-  <run_depend>librealsense2</run_depend>
   <export>
     <nodelet plugin="${prefix}/nodelet_plugins.xml" />
   </export>


### PR DESCRIPTION
Ref to commit-id (785ee8) Align ROS wrapper to the new Librealsense API.
librealsense2 depend should be removed, it is not required and no librealsense2 ros package exist now.
cmake checking will fail for some builds.

Signed-off-by: Chris Ye <chris.ye@intel.com>