### PR TITLE
Make generated headers includable by other packages

### DIFF
--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -68,11 +68,13 @@ generate_dynamic_reconfigure_options(
 # RealSense ROS Node
 catkin_package(
     LIBRARIES ${PROJECT_NAME}
-    CATKIN_DEPENDS message_runtime roscpp sensor_msgs std_msgs librealsense2
-    nodelet
-    cv_bridge
-    image_transport
-    dynamic_reconfigure
+    CATKIN_DEPENDS 
+        message_runtime roscpp sensor_msgs std_msgs
+        nodelet cv_bridge image_transport dynamic_reconfigure
+    DEPENDS
+        librealsense2
+    INCLUDE_DIRS 
+        ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DESTINATION}/
     )
 
 add_library(${PROJECT_NAME}
@@ -109,6 +111,12 @@ install(TARGETS ${PROJECT_NAME}
 
 # Install header files
 install(DIRECTORY include/
+    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+    )
+
+# Install generated header files (messages & dynamic reconfigure definitions)
+install(
+    DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DESTINATION}/
     DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
     )
 


### PR DESCRIPTION
Other packages may need to use headers generated by this package. For
example, to use the dynamic_reconfigure::Client to modify dynamic
reconfigure parameters exposed by the realsense camera manager we need
the `rsXXX_paramsConfig.h` files.

This change updates the `catkin_package` call to better specify exported
libraris and header file requirements as well as adding an install rule
for the headers.