### PR TITLE
use locations of realsense2 lib

### DIFF
--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -55,6 +55,7 @@ generate_messages(
 include_directories(
     include
     ${catkin_INCLUDE_DIRS}
+    ${realsense_INCLUDE_DIR}
     )
 
 # Generate dynamic reconfigure options from .cfg files
@@ -68,7 +69,7 @@ generate_dynamic_reconfigure_options(
 # RealSense ROS Node
 catkin_package(
     LIBRARIES ${PROJECT_NAME}
-    CATKIN_DEPENDS message_runtime roscpp sensor_msgs std_msgs librealsense2
+    CATKIN_DEPENDS message_runtime roscpp sensor_msgs std_msgs
     nodelet
     cv_bridge
     image_transport
@@ -95,7 +96,7 @@ add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
 
 
 target_link_libraries(${PROJECT_NAME}
-    realsense2
+    ${realsense2_LIBRARY}
     ${catkin_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
     )


### PR DESCRIPTION
When `find_packaging` the realsense lib, cmake should also use the corresponding include dirs and libraries instead of relying on finding them in standard pathes.