### PR TITLE
Fix coordinate system transforms so that the pointcloud aligns with camera view

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -87,7 +87,7 @@ namespace realsense2_camera
         void setupPublishers();
         void setupStreams();
         void updateStreamCalibData(const rs2::video_stream_profile& video_profile);
-        Eigen::Quaternionf rotationMatrixToQuaternion(const float rotation[3]) const;
+        tf::Quaternion rotationMatrixToQuaternion(const float rotation[3]) const;
         void publish_static_tf(const ros::Time& t,
                                const float3& trans,
                                const quaternion& q,

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -123,8 +123,6 @@ namespace realsense2_camera
                         const rs2_extrinsics& from_to_other,
                         std::vector<uint8_t>& out_vec);
 
-        const rs2_extrinsics _i_ex{{1, 0, 0, 0, 1, 0, 0, 0, 1}, {0, 0, 0}};
-
         std::string _json_file_path;
         std::string _serial_no;
         float _depth_scale_meters;

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -907,9 +907,11 @@ void BaseRealSenseNode::updateStreamCalibData(const rs2::video_stream_profile& v
 Eigen::Quaternionf BaseRealSenseNode::rotationMatrixToQuaternion(const float rotation[3]) const
 {
     Eigen::Matrix3f m;
-    m << rotation[0], rotation[1], rotation[2],
-         rotation[3], rotation[4], rotation[5],
-         rotation[6], rotation[7], rotation[8];
+    // We need to be careful about the order, as RS2 rotation matrix is
+    // column-major, while Eigen::Matrix3f expects row-major.
+    m << rotation[0], rotation[3], rotation[6],
+         rotation[1], rotation[4], rotation[7],
+         rotation[2], rotation[5], rotation[8];
     Eigen::Quaternionf q(m);
     return q;
 }
@@ -966,7 +968,7 @@ void BaseRealSenseNode::publishStaticTransforms()
     if (_enable[COLOR])
     {
         // Transform base to color
-        auto& ex = (_align_depth)?(_i_ex):(getRsExtrinsics(DEPTH, COLOR));
+        auto& ex = (_align_depth)?(_i_ex):(getRsExtrinsics(COLOR, DEPTH));
         auto Q = rotationMatrixToQuaternion(ex.rotation);
 
         float3 trans{ex.translation[0], ex.translation[1], ex.translation[2]};
@@ -986,7 +988,7 @@ void BaseRealSenseNode::publishStaticTransforms()
 
     if (_enable[INFRA1])
     {
-        auto& ex = (_align_depth)?(_i_ex):(getRsExtrinsics(DEPTH, INFRA1));
+        auto& ex = (_align_depth)?(_i_ex):(getRsExtrinsics(INFRA1, DEPTH));
         auto Q = rotationMatrixToQuaternion(ex.rotation);
 
         // Transform base to infra1
@@ -1007,7 +1009,7 @@ void BaseRealSenseNode::publishStaticTransforms()
 
     if (_enable[INFRA2])
     {
-        auto& ex = (_align_depth)?(_i_ex):(getRsExtrinsics(DEPTH, INFRA2));
+        auto& ex = (_align_depth)?(_i_ex):(getRsExtrinsics(INFRA2, DEPTH));
         auto Q = rotationMatrixToQuaternion(ex.rotation);
 
         // Transform base to infra2
@@ -1028,7 +1030,7 @@ void BaseRealSenseNode::publishStaticTransforms()
 
     if (_enable[FISHEYE])
     {
-        auto& ex = (_align_depth)?(_i_ex):(getRsExtrinsics(DEPTH, FISHEYE));
+        auto& ex = (_align_depth)?(_i_ex):(getRsExtrinsics(FISHEYE, DEPTH));
         auto Q = rotationMatrixToQuaternion(ex.rotation);
 
         // Transform base to infra2

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -904,7 +904,7 @@ void BaseRealSenseNode::updateStreamCalibData(const rs2::video_stream_profile& v
     }
 }
 
-Eigen::Quaternionf BaseRealSenseNode::rotationMatrixToQuaternion(const float rotation[3]) const
+tf::Quaternion BaseRealSenseNode::rotationMatrixToQuaternion(const float rotation[3]) const
 {
     Eigen::Matrix3f m;
     // We need to be careful about the order, as RS2 rotation matrix is
@@ -913,7 +913,7 @@ Eigen::Quaternionf BaseRealSenseNode::rotationMatrixToQuaternion(const float rot
          rotation[1], rotation[4], rotation[7],
          rotation[2], rotation[5], rotation[8];
     Eigen::Quaternionf q(m);
-    return q;
+    return tf::Quaternion(q.x(), q.y(), q.z(), q.w());
 }
 
 void BaseRealSenseNode::publish_static_tf(const ros::Time& t,
@@ -970,9 +970,10 @@ void BaseRealSenseNode::publishStaticTransforms()
         // Transform base to color
         const auto& ex = getRsExtrinsics(COLOR, DEPTH);
         auto Q = rotationMatrixToQuaternion(ex.rotation);
+        Q = quaternion_optical * Q * quaternion_optical.inverse();
 
         float3 trans{ex.translation[0], ex.translation[1], ex.translation[2]};
-        quaternion q1{Q.x(), Q.y(), Q.z(), Q.w()};
+        quaternion q1{Q.getX(), Q.getY(), Q.getZ(), Q.getW()};
         publish_static_tf(transform_ts_, trans, q1, _base_frame_id, _frame_id[COLOR]);
 
         // Transform color frame to color optical frame
@@ -990,10 +991,11 @@ void BaseRealSenseNode::publishStaticTransforms()
     {
         const auto& ex = getRsExtrinsics(INFRA1, DEPTH);
         auto Q = rotationMatrixToQuaternion(ex.rotation);
+        Q = quaternion_optical * Q * quaternion_optical.inverse();
 
         // Transform base to infra1
         float3 trans{ex.translation[0], ex.translation[1], ex.translation[2]};
-        quaternion q1{Q.x(), Q.y(), Q.z(), Q.w()};
+        quaternion q1{Q.getX(), Q.getY(), Q.getZ(), Q.getW()};
         publish_static_tf(transform_ts_, trans, q1, _base_frame_id, _frame_id[INFRA1]);
 
         // Transform infra1 frame to infra1 optical frame
@@ -1011,10 +1013,11 @@ void BaseRealSenseNode::publishStaticTransforms()
     {
         const auto& ex = getRsExtrinsics(INFRA2, DEPTH);
         auto Q = rotationMatrixToQuaternion(ex.rotation);
+        Q = quaternion_optical * Q * quaternion_optical.inverse();
 
         // Transform base to infra2
         float3 trans{ex.translation[0], ex.translation[1], ex.translation[2]};
-        quaternion q1{Q.x(), Q.y(), Q.z(), Q.w()};
+        quaternion q1{Q.getX(), Q.getY(), Q.getZ(), Q.getW()};
         publish_static_tf(transform_ts_, trans, q1, _base_frame_id, _frame_id[INFRA2]);
 
         // Transform infra2 frame to infra1 optical frame
@@ -1032,10 +1035,11 @@ void BaseRealSenseNode::publishStaticTransforms()
     {
         const auto& ex = getRsExtrinsics(FISHEYE, DEPTH);
         auto Q = rotationMatrixToQuaternion(ex.rotation);
+        Q = quaternion_optical * Q * quaternion_optical.inverse();
 
         // Transform base to infra2
         float3 trans{ex.translation[0], ex.translation[1], ex.translation[2]};
-        quaternion q1{Q.x(), Q.y(), Q.z(), Q.w()};
+        quaternion q1{Q.getX(), Q.getY(), Q.getZ(), Q.getW()};
         publish_static_tf(transform_ts_, trans, q1, _base_frame_id, _frame_id[FISHEYE]);
 
         // Transform infra2 frame to infra1 optical frame

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -968,7 +968,7 @@ void BaseRealSenseNode::publishStaticTransforms()
     if (_enable[COLOR])
     {
         // Transform base to color
-        auto& ex = (_align_depth)?(_i_ex):(getRsExtrinsics(COLOR, DEPTH));
+        const auto& ex = getRsExtrinsics(COLOR, DEPTH);
         auto Q = rotationMatrixToQuaternion(ex.rotation);
 
         float3 trans{ex.translation[0], ex.translation[1], ex.translation[2]};
@@ -988,7 +988,7 @@ void BaseRealSenseNode::publishStaticTransforms()
 
     if (_enable[INFRA1])
     {
-        auto& ex = (_align_depth)?(_i_ex):(getRsExtrinsics(INFRA1, DEPTH));
+        const auto& ex = getRsExtrinsics(INFRA1, DEPTH);
         auto Q = rotationMatrixToQuaternion(ex.rotation);
 
         // Transform base to infra1
@@ -1009,7 +1009,7 @@ void BaseRealSenseNode::publishStaticTransforms()
 
     if (_enable[INFRA2])
     {
-        auto& ex = (_align_depth)?(_i_ex):(getRsExtrinsics(INFRA2, DEPTH));
+        const auto& ex = getRsExtrinsics(INFRA2, DEPTH);
         auto Q = rotationMatrixToQuaternion(ex.rotation);
 
         // Transform base to infra2
@@ -1030,7 +1030,7 @@ void BaseRealSenseNode::publishStaticTransforms()
 
     if (_enable[FISHEYE])
     {
-        auto& ex = (_align_depth)?(_i_ex):(getRsExtrinsics(FISHEYE, DEPTH));
+        const auto& ex = getRsExtrinsics(FISHEYE, DEPTH);
         auto Q = rotationMatrixToQuaternion(ex.rotation);
 
         // Transform base to infra2

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -771,10 +771,6 @@ void BaseRealSenseNode::setupStreams()
             static const char* frame_id = "depth_to_fisheye_extrinsics";
             auto ex = getRsExtrinsics(DEPTH, FISHEYE);
             _depth_to_other_extrinsics[FISHEYE] = ex;
-
-            if (_align_depth)
-                ex = _i_ex;
-
             _depth_to_other_extrinsics_publishers[FISHEYE].publish(rsExtrinsicsToMsg(ex, frame_id));
         }
 
@@ -784,10 +780,6 @@ void BaseRealSenseNode::setupStreams()
             static const char* frame_id = "depth_to_color_extrinsics";
             auto ex = getRsExtrinsics(DEPTH, COLOR);
             _depth_to_other_extrinsics[COLOR] = ex;
-
-            if (_align_depth)
-                ex = _i_ex;
-
             _depth_to_other_extrinsics_publishers[COLOR].publish(rsExtrinsicsToMsg(ex, frame_id));
         }
 
@@ -797,10 +789,6 @@ void BaseRealSenseNode::setupStreams()
             static const char* frame_id = "depth_to_infra1_extrinsics";
             auto ex = getRsExtrinsics(DEPTH, INFRA1);
             _depth_to_other_extrinsics[INFRA1] = ex;
-
-            if (_align_depth)
-                ex = _i_ex;
-
             _depth_to_other_extrinsics_publishers[INFRA1].publish(rsExtrinsicsToMsg(ex, frame_id));
         }
 
@@ -810,10 +798,6 @@ void BaseRealSenseNode::setupStreams()
             static const char* frame_id = "depth_to_infra2_extrinsics";
             auto ex = getRsExtrinsics(DEPTH, INFRA2);
             _depth_to_other_extrinsics[INFRA2] = ex;
-
-            if (_align_depth)
-                ex = _i_ex;
-
             _depth_to_other_extrinsics_publishers[INFRA2].publish(rsExtrinsicsToMsg(ex, frame_id));
         }
     }


### PR DESCRIPTION
Currently, the coordinate systems are off, which one can observe by doing:
- launch the RealSense node.
- open rviz.
- in rviz, add the PointCloud2 and a Camera for color/image_raw. If testing with objects close enough, reduce the "Size" in PointCloud2 or change "Style" to point.
- In the Camera window, we will see the pointcloud from the camera viewpoint. Since point colors are computed from color/image_row, the images should align up to floating point rounding errors. Before these patches, they clearly don't align. After them, they align.