### PR TITLE
Fixing the length of an array argument in rotationMatrixToQuaternion

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -87,7 +87,7 @@ namespace realsense2_camera
         void setupPublishers();
         void setupStreams();
         void updateStreamCalibData(const rs2::video_stream_profile& video_profile);
-        Eigen::Quaternionf rotationMatrixToQuaternion(const float rotation[3]) const;
+        Eigen::Quaternionf rotationMatrixToQuaternion(const float rotation[9]) const;
         void publish_static_tf(const ros::Time& t,
                                const float3& trans,
                                const quaternion& q,

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -904,7 +904,7 @@ void BaseRealSenseNode::updateStreamCalibData(const rs2::video_stream_profile& v
     }
 }
 
-Eigen::Quaternionf BaseRealSenseNode::rotationMatrixToQuaternion(const float rotation[3]) const
+Eigen::Quaternionf BaseRealSenseNode::rotationMatrixToQuaternion(const float rotation[9]) const
 {
     Eigen::Matrix3f m;
     m << rotation[0], rotation[1], rotation[2],


### PR DESCRIPTION
The incoming argument for the coefficients of the rotation matrix was set to a dimension three float array but nine coefficients are used in the function.