### PR TITLE
Fix the name of the alignment-related parameters when invoking the RealSenseNodeFactory.

### DIFF
--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -89,10 +89,10 @@
     <param name="accel_optical_frame_id"   type="str"  value="camera_accel_optical_frame"/>
     <param name="gyro_optical_frame_id"    type="str"  value="camera_gyro_optical_frame"/>
 
-    <param name="camera_aligned_depth_to_color_frame_id"   type="str"  value="camera_aligned_depth_to_color_frame"/>
-    <param name="camera_aligned_depth_to_infra1_frame_id"  type="str"  value="camera_aligned_depth_to_infra1_frame"/>
-    <param name="camera_aligned_depth_to_infra2_frame_id"  type="str"  value="camera_aligned_depth_to_infra2_frame"/>
-    <param name="camera_aligned_depth_to_fisheye_frame_id" type="str"  value="camera_aligned_depth_to_fisheye_frame"/>
+    <param name="aligned_depth_to_color_frame_id"   type="str"  value="camera_aligned_depth_to_color_frame"/>
+    <param name="aligned_depth_to_infra1_frame_id"  type="str"  value="camera_aligned_depth_to_infra1_frame"/>
+    <param name="aligned_depth_to_infra2_frame_id"  type="str"  value="camera_aligned_depth_to_infra2_frame"/>
+    <param name="aligned_depth_to_fisheye_frame_id" type="str"  value="camera_aligned_depth_to_fisheye_frame"/>
   </node>
 </launch>
 


### PR DESCRIPTION
The `nodelet.launch.xml` file uses the following parameter names when calling the `RealSenseNodeFactory`:
```
<param name="camera_aligned_depth_to_color_frame_id" .../>
<param name="camera_aligned_depth_to_infra1_frame_id" .../>
<param name="camera_aligned_depth_to_infra2_frame_id" .../>
<param name="camera_aligned_depth_to_fisheye_frame_id" .../>
```
However, in the `base_realsense_node.cpp` they are read like:

```
_pnh.param("aligned_depth_to_color_frame_id", ...);
_pnh.param("aligned_depth_to_infra1_frame_id", ...);
_pnh.param("aligned_depth_to_infra2_frame_id", ...);
_pnh.param("aligned_depth_to_fisheye_frame_id", ...);
```

