### PR TITLE
Overwrite all frame ids 

### DIFF
--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -43,6 +43,9 @@
   <arg name="enable_sync"         default="false"/>
   <arg name="align_depth"         default="false"/>
 
+  <arg name="camera"           default="camera"/>
+
+
   <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>
   <node pkg="nodelet" type="nodelet" name="realsense2_camera" args="load realsense2_camera/RealSenseNodeFactory $(arg manager)">
     <param name="serial_no"                type="str"  value="$(arg serial_no)"/>
@@ -81,18 +84,22 @@
     <param name="accel_fps"                type="int"  value="$(arg accel_fps)"/>
     <param name="enable_imu"               type="bool" value="$(arg enable_imu)"/>
 
-    <param name="depth_optical_frame_id"   type="str"  value="camera_depth_optical_frame"/>
-    <param name="infra1_optical_frame_id"  type="str"  value="camera_infra1_optical_frame"/>
-    <param name="infra2_optical_frame_id"  type="str"  value="camera_infra2_optical_frame"/>
-    <param name="color_optical_frame_id"   type="str"  value="camera_color_optical_frame"/>
-    <param name="fisheye_optical_frame_id" type="str"  value="camera_fisheye_optical_frame"/>
-    <param name="accel_optical_frame_id"   type="str"  value="camera_accel_optical_frame"/>
-    <param name="gyro_optical_frame_id"    type="str"  value="camera_gyro_optical_frame"/>
+    <param name="base_frame_id"            type="str" value="$(arg camera)_link"/>
+    <param name="depth_frame_id"           type="str"  value="$(arg camera)_depth_frame"/>
+    <param name="color_frame_id"           type="str"  value="$(arg camera)_color_frame"/>
+    
+    <param name="depth_optical_frame_id"   type="str"  value="$(arg camera)_depth_optical_frame"/>
+    <param name="infra1_optical_frame_id"  type="str"  value="$(arg camera)_infra1_optical_frame"/>
+    <param name="infra2_optical_frame_id"  type="str"  value="$(arg camera)_infra2_optical_frame"/>
+    <param name="color_optical_frame_id"   type="str"  value="$(arg camera)_color_optical_frame"/>
+    <param name="fisheye_optical_frame_id" type="str"  value="$(arg camera)_fisheye_optical_frame"/>
+    <param name="accel_optical_frame_id"   type="str"  value="$(arg camera)_accel_optical_frame"/>
+    <param name="gyro_optical_frame_id"    type="str"  value="$(arg camera)_gyro_optical_frame"/>
 
-    <param name="aligned_depth_to_color_frame_id"   type="str"  value="camera_aligned_depth_to_color_frame"/>
-    <param name="aligned_depth_to_infra1_frame_id"  type="str"  value="camera_aligned_depth_to_infra1_frame"/>
-    <param name="aligned_depth_to_infra2_frame_id"  type="str"  value="camera_aligned_depth_to_infra2_frame"/>
-    <param name="aligned_depth_to_fisheye_frame_id" type="str"  value="camera_aligned_depth_to_fisheye_frame"/>
+
+    <param name="camera_aligned_depth_to_color_frame_id"   type="str"  value="$(arg camera)_aligned_depth_to_color_frame"/>
+    <param name="camera_aligned_depth_to_infra1_frame_id"  type="str"  value="$(arg camera)_aligned_depth_to_infra1_frame"/>
+    <param name="camera_aligned_depth_to_infra2_frame_id"  type="str"  value="$(arg camera)_aligned_depth_to_infra2_frame"/>
+    <param name="camera_aligned_depth_to_fisheye_frame_id" type="str"  value="$(arg camera)_aligned_depth_to_fisheye_frame"/>
   </node>
 </launch>
-


### PR DESCRIPTION
Issue: 
We don't want to use camera_frame_x convention, because it causes lots of problems with multiple cameras and it reduces the flexibility. 

Solution: 
Adding a camera argument and replacing "camera" with camera argument. 