### PR TITLE
Making camera namespace configurable -- necessesity to launch multiple cameras

### DIFF
--- a/realsense2_camera/launch/demo_pointcloud.launch
+++ b/realsense2_camera/launch/demo_pointcloud.launch
@@ -1,8 +1,9 @@
 <launch>
   <arg name="serial_no"    default=""/>
   <arg name="json_file_path"  default=""/>
+  <arg name="camera" default="camera"/>
 
-  <group ns="camera">
+  <group ns="$(arg camera)">
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
       <arg name="serial_no"         value="$(arg serial_no)"/>
       <arg name="json_file_path"    value="$(arg json_file_path)"/>

--- a/realsense2_camera/launch/rs_aligned_depth.launch
+++ b/realsense2_camera/launch/rs_aligned_depth.launch
@@ -1,6 +1,7 @@
 <launch>
   <arg name="serial_no" default=""/>
   <arg name="json_file_path" default=""/>
+  <arg name="camera" default="camera"/>
 
   <arg name="fisheye_width"       default="640"/>
   <arg name="fisheye_height"      default="480"/>
@@ -36,7 +37,7 @@
   <arg name="align_depth"         default="true"/>
 
 
-  <group ns="camera">
+  <group ns="$(arg camera)">
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
       <arg name="serial_no"                value="$(arg serial_no)"/>
       <arg name="json_file_path"           value="$(arg json_file_path)"/>

--- a/realsense2_camera/launch/rs_camera.launch
+++ b/realsense2_camera/launch/rs_camera.launch
@@ -1,6 +1,7 @@
 <launch>
   <arg name="serial_no" default=""/>
   <arg name="json_file_path" default=""/>
+  <arg name="camera" default="camera"/>
 
   <arg name="fisheye_width"       default="640"/>
   <arg name="fisheye_height"      default="480"/>
@@ -35,7 +36,7 @@
   <arg name="enable_sync"         default="false"/>
   <arg name="align_depth"         default="false"/>
 
-  <group ns="camera">
+  <group ns="$(arg camera)">
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
       <arg name="serial_no"                value="$(arg serial_no)"/>
       <arg name="json_file_path"           value="$(arg json_file_path)"/>


### PR DESCRIPTION
This is needed when you want to launch multiple cameras with multiple launch files which is a common usecase.

This allows to specify the serial and camera ID for the serial to bringup a number of cameras.