### PR TITLE
build with librealsense 2.16

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -51,6 +51,15 @@ namespace realsense2_camera
     };
     typedef std::pair<image_transport::Publisher, std::shared_ptr<FrequencyDiagnostics>> ImagePublisherWithFrequencyDiagnostics;
 
+	class PipelineSyncer : public rs2::asynchronous_syncer
+	{
+	public: 
+		void operator()(rs2::frame f) const
+		{
+			invoke(std::move(f));
+		}
+	};
+
     class BaseRealSenseNode : public InterfaceRealSenseNode
     {
     public:
@@ -160,7 +169,7 @@ namespace realsense2_camera
         bool _align_depth;
         bool _sync_frames;
         bool _pointcloud;
-        rs2::asynchronous_syncer _syncer;
+		PipelineSyncer _syncer;
 
         std::map<stream_index_pair, cv::Mat> _depth_aligned_image;
         std::map<stream_index_pair, std::string> _depth_aligned_encoding;


### PR DESCRIPTION
in librealsense version 2.16, operator() was removed from class asynchronous_syncer.
This pull request present a wrapping class that provides the missing operator.
