### PR TITLE
PR for hardware_reset during initialization

### DIFF
--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(realsense2_camera)
+add_compile_options(-std=c++11)
 
 option(BUILD_WITH_OPENMP "Use OpenMP" OFF)
 

--- a/realsense2_camera/include/realsense_node_factory.h
+++ b/realsense2_camera/include/realsense_node_factory.h
@@ -26,6 +26,9 @@
 #include <eigen3/Eigen/Geometry>
 #include <fstream>
 
+#include <mutex>
+#include <condition_variable>
+
 
 namespace realsense2_camera
 {

--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -109,42 +109,6 @@ void RealSenseNodeFactory::onInit()
             auto _device = pipe->get_active_profile().get_device();
             _realSenseNode = std::unique_ptr<BaseRealSenseNode>(new BaseRealSenseNode(nh, privateNh, _device, serial_no));
         }else{
-
-            auto list = _ctx.query_devices();
-            if (0 == list.size())
-            {
-                ROS_ERROR("No RealSense devices were found! Terminating RealSense Node...");
-                ros::shutdown();
-                exit(1);
-            }
-
-            bool found = false;
-            for (auto&& dev : list)
-            {
-                auto sn = dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
-                ROS_DEBUG_STREAM("Device with serial number " << sn << " was found.");
-                if (serial_no.empty())
-                {
-                    _device = dev;
-                    serial_no = sn;
-                    found = true;
-                    break;
-                }
-                else if (sn == serial_no)
-                {
-                    _device = dev;
-                    found = true;
-                    break;
-                }
-            }
-
-            if (!found)
-            {
-                ROS_FATAL_STREAM("The requested device with serial number " << serial_no << " is NOT found!");
-                ros::shutdown();
-                exit(1);
-            }
-
             ROS_INFO("Resetting device...");
             dev = getDevice(serial_no);
             dev.hardware_reset();

--- a/realsense_ros_camera/include/realsense_node_factory.h
+++ b/realsense_ros_camera/include/realsense_node_factory.h
@@ -65,6 +65,7 @@ namespace realsense_ros_camera
         virtual ~RealSenseNodeFactory() {}
 
     private:
+        rs2::device getDevice(std::string& serial_no);
         virtual void onInit() override;
         void tryGetLogSeverity(rs2_log_severity& severity) const;
 


### PR DESCRIPTION
Merging [icarpis's fix](https://github.com/icarpis/realsense/tree/reset_dev) as mentioned in https://github.com/intel-ros/realsense/issues/314#issuecomment-365196850 so that it works with the current development branch.
Unless the firmware issue will be fundamentally solved, this workaround makes the whole pipeline significantly more robust for the time being.

Tested with `catkin build` on Ubuntu 16.04 / ROS Kinetic Kame with `librealsense 2.16`.