### PR TITLE
Add ROS parameter to change the max depth.

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -169,6 +169,7 @@ namespace realsense2_camera
         bool _align_depth;
         bool _sync_frames;
         bool _pointcloud;
+        float _max_depth;
 		PipelineSyncer _syncer;
 
         std::map<stream_index_pair, cv::Mat> _depth_aligned_image;

--- a/realsense2_camera/include/constants.h
+++ b/realsense2_camera/include/constants.h
@@ -35,6 +35,7 @@ namespace realsense2_camera
     const bool ALIGN_DEPTH    = false;
     const bool POINTCLOUD     = false;
     const bool SYNC_FRAMES    = false;
+    const float MAX_DEPTH     = 5.f;
 
     const int DEPTH_WIDTH     = 640;
     const int DEPTH_HEIGHT    = 480;

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -103,6 +103,7 @@ void BaseRealSenseNode::getParameters()
     _pnh.param("align_depth", _align_depth, ALIGN_DEPTH);
     _pnh.param("enable_pointcloud", _pointcloud, POINTCLOUD);
     _pnh.param("enable_sync", _sync_frames, SYNC_FRAMES);
+    _pnh.param("max_depth", _max_depth, MAX_DEPTH);
     if (_pointcloud || _align_depth)
         _sync_frames = true;
 
@@ -1106,7 +1107,7 @@ void BaseRealSenseNode::publishRgbToDepthPCTopic(const ros::Time& t, const std::
             float depth_pixel[2] = {static_cast<float>(x), static_cast<float>(y)};
             rs2_deproject_pixel_to_point(depth_point, &depth_intrinsics, depth_pixel, scaled_depth);
 
-            if (depth_point[2] <= 0.f || depth_point[2] > 5.f)
+            if (depth_point[2] <= 0.f || depth_point[2] > _max_depth)
             {
                 depth_point[0] = 0.f;
                 depth_point[1] = 0.f;


### PR DESCRIPTION
Currently the max depth of published point cloud is hard-coded to 5 meters. While the distant points tend to be inaccurate, it would be nicer to have a parameter to change the limit. This PR does not change the default behavior.