### PR TITLE
Add ROS parameter for the required firmware version.

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -103,6 +103,8 @@ namespace realsense2_camera
         };
 
         static std::string getNamespaceStr();
+        static bool isFirmwareLatest(const std::string& current_version,
+                                     const std::string& required_version);
         void getParameters();
         void setupDevice();
         void setupPublishers();
@@ -147,6 +149,7 @@ namespace realsense2_camera
                         const rs2_extrinsics& from_to_other,
                         std::vector<uint8_t>& out_vec);
 
+        std::string _required_firmware_version;
         std::string _json_file_path;
         std::string _serial_no;
         float _depth_scale_meters;

--- a/realsense2_camera/include/constants.h
+++ b/realsense2_camera/include/constants.h
@@ -92,6 +92,6 @@ namespace realsense2_camera
     const std::string DEFAULT_ALIGNED_DEPTH_TO_FISHEYE_FRAME_ID = "camera_aligned_depth_to_fisheye_frame";
 
     const std::string DEFAULT_FILTERS                  = "";
-
+    const std::string DEFAULT_REQUIRED_FIRMWARE_VERSION = "";
     using stream_index_pair = std::pair<rs2_stream, int>;
 }  // namespace realsense2_camera


### PR DESCRIPTION
When the system is involved with many cameras that are partially replaced/added over time, synchronizing the firmware of the all connected cameras is not a trivial task. It would be nice if the sensors with outdated firmware could automatically be detected. With this PR, a ROS parameter is added to verify that the current firmware is same as or newer than the known stable version. This PR does not change the default behavior.