### PR TITLE
Estimate clock offset by low-pass filter.

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -147,6 +147,8 @@ namespace realsense2_camera
                         const rs2_extrinsics& from_to_other,
                         std::vector<uint8_t>& out_vec);
 
+        void updateClockOffset(const ros::Time& ros_time, const rs2::frame& frame);
+
         std::string _json_file_path;
         std::string _serial_no;
         float _depth_scale_meters;
@@ -175,11 +177,12 @@ namespace realsense2_camera
         std::map<stream_index_pair, int> _unit_step_size;
         std::map<stream_index_pair, sensor_msgs::CameraInfo> _camera_info;
         bool _intialize_time_base;
-        double _camera_time_base;
+        double _last_sync_time;
+        double _clock_offset;
+        double _depth_latency;
         std::map<stream_index_pair, std::vector<rs2::stream_profile>> _enabled_profiles;
 
         ros::Publisher _pointcloud_publisher;
-        ros::Time _ros_time_base;
         bool _align_depth;
         bool _sync_frames;
         bool _pointcloud;

--- a/realsense2_camera/include/constants.h
+++ b/realsense2_camera/include/constants.h
@@ -32,6 +32,8 @@ namespace realsense2_camera
     const uint16_t RS435_RGB_PID    = 0x0b07; // AWGC
     const uint16_t RS405_PID        = 0x0b0c; // DS5U
 
+    const float CLOCK_OFFSET_FILTER_WIDTH = 1.f;
+    const double DEPTH_LATENCY = 0.;
     const bool ALIGN_DEPTH    = false;
     const bool POINTCLOUD     = false;
     const bool SYNC_FRAMES    = false;


### PR DESCRIPTION
The clock on realsense camera is significantly skewed, and the message timestamp diverges from ROS/system clock if a constant offset is added as currently implemented. This PR add the low-pass filter to estimate the offset that can gradually change overtime. The filter is 1-tap IIR, and its computational cost is negligible. 

Here is the comparison of measured offset, filtered offset (this PR), and constant offset (current implementation). The offset is the difference between device timestamp and ros::Time::now() in callback. The clock is clearly skewed i.e. the offset is not constant, and the filtered result fits to the measurement well.    
https://paste.pics/263f5be4d111c3a36279d8389fdf5b1c