### PR TITLE
new launch parameter for frame distinction in multi camera use

### DIFF
--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -1,6 +1,7 @@
 <launch>
   <arg name="manager"             default="realsense2_camera_manager"/>
   <arg name="serial_no"           default=""/>
+  <arg name="tf_prefix"           default=""/>
   <arg name="json_file_path"      default=""/>
   <arg name="rosbag_filename"     default=""/>
   <arg name="depth"               default="depth"/>
@@ -43,6 +44,25 @@
   <arg name="enable_pointcloud"   default="false"/>
   <arg name="enable_sync"         default="false"/>
   <arg name="align_depth"         default="false"/>
+  
+  <arg name="base_frame_id"            default="$(arg tf_prefix)camera_link"/>
+  <arg name="depth_frame_id"           default="$(arg tf_prefix)camera_depth_frame"/>
+  <arg name="infra1_frame_id"          default="$(arg tf_prefix)camera_infra1_frame"/>
+  <arg name="infra2_frame_id"          default="$(arg tf_prefix)camera_infra2_frame"/>
+  <arg name="color_frame_id"           default="$(arg tf_prefix)camera_color_frame"/>
+  
+  <arg name="depth_optical_frame_id"   default="$(arg tf_prefix)camera_depth_optical_frame"/>
+  <arg name="infra1_optical_frame_id"  default="$(arg tf_prefix)camera_infra1_optical_frame"/>
+  <arg name="infra2_optical_frame_id"  default="$(arg tf_prefix)camera_infra2_optical_frame"/>
+  <arg name="color_optical_frame_id"   default="$(arg tf_prefix)camera_color_optical_frame"/>
+  <arg name="fisheye_optical_frame_id" default="$(arg tf_prefix)camera_fisheye_optical_frame"/>
+  <arg name="accel_optical_frame_id"   default="$(arg tf_prefix)camera_accel_optical_frame"/>
+  <arg name="gyro_optical_frame_id"    default="$(arg tf_prefix)camera_gyro_optical_frame"/>
+  
+  <arg name="aligned_depth_to_color_frame_id"   default="$(arg tf_prefix)camera_aligned_depth_to_color_frame"/>
+  <arg name="aligned_depth_to_infra1_frame_id" default="$(arg tf_prefix)camera_aligned_depth_to_infra1_frame"/>
+  <arg name="aligned_depth_to_infra2_frame_id"   default="$(arg tf_prefix)camera_aligned_depth_to_infra2_frame"/>
+  <arg name="aligned_depth_to_fisheye_frame_id"    default="$(arg tf_prefix)camera_aligned_depth_to_fisheye_frame"/>
 
   <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>
   <node pkg="nodelet" type="nodelet" name="realsense2_camera" args="load realsense2_camera/RealSenseNodeFactory $(arg manager)">
@@ -83,18 +103,25 @@
     <param name="accel_fps"                type="int"  value="$(arg accel_fps)"/>
     <param name="enable_imu"               type="bool" value="$(arg enable_imu)"/>
 
-    <param name="depth_optical_frame_id"   type="str"  value="camera_depth_optical_frame"/>
-    <param name="infra1_optical_frame_id"  type="str"  value="camera_infra1_optical_frame"/>
-    <param name="infra2_optical_frame_id"  type="str"  value="camera_infra2_optical_frame"/>
-    <param name="color_optical_frame_id"   type="str"  value="camera_color_optical_frame"/>
-    <param name="fisheye_optical_frame_id" type="str"  value="camera_fisheye_optical_frame"/>
-    <param name="accel_optical_frame_id"   type="str"  value="camera_accel_optical_frame"/>
-    <param name="gyro_optical_frame_id"    type="str"  value="camera_gyro_optical_frame"/>
-
-    <param name="aligned_depth_to_color_frame_id"   type="str"  value="camera_aligned_depth_to_color_frame"/>
-    <param name="aligned_depth_to_infra1_frame_id"  type="str"  value="camera_aligned_depth_to_infra1_frame"/>
-    <param name="aligned_depth_to_infra2_frame_id"  type="str"  value="camera_aligned_depth_to_infra2_frame"/>
-    <param name="aligned_depth_to_fisheye_frame_id" type="str"  value="camera_aligned_depth_to_fisheye_frame"/>
+    <param name="base_frame_id"            type="str"  value="$(arg base_frame_id)"/>
+    <param name="depth_frame_id"           type="str"  value="$(arg depth_frame_id)"/>
+    <param name="infra1_frame_id"          type="str"  value="$(arg infra1_frame_id)"/>
+    <param name="infra2_frame_id"          type="str"  value="$(arg infra2_frame_id)"/>
+    <param name="color_frame_id"           type="str"  value="$(arg color_frame_id)"/>
+    
+    <param name="depth_optical_frame_id"   type="str"  value="$(arg depth_optical_frame_id)"/>
+    <param name="infra1_optical_frame_id"  type="str"  value="$(arg infra1_optical_frame_id)"/>
+    <param name="infra2_optical_frame_id"  type="str"  value="$(arg infra2_optical_frame_id)"/>
+    <param name="color_optical_frame_id"   type="str"  value="$(arg color_optical_frame_id)"/>
+    <param name="fisheye_optical_frame_id" type="str"  value="$(arg fisheye_optical_frame_id)"/>
+    <param name="accel_optical_frame_id"   type="str"  value="$(arg accel_optical_frame_id)"/>
+    <param name="gyro_optical_frame_id"    type="str"  value="$(arg gyro_optical_frame_id)"/>
+    
+    <param name="aligned_depth_to_color_frame_id"   type="str"  value="$(arg aligned_depth_to_color_frame_id)"/>
+    <param name="aligned_depth_to_infra1_frame_id"  type="str"  value="$(arg aligned_depth_to_infra1_frame_id)"/>
+    <param name="aligned_depth_to_infra2_frame_id"  type="str"  value="$(arg aligned_depth_to_infra2_frame_id)"/>
+    <param name="aligned_depth_to_fisheye_frame_id" type="str"  value="$(arg aligned_depth_to_fisheye_frame_id)"/>
+    
   </node>
 </launch>
 

--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -45,24 +45,24 @@
   <arg name="enable_sync"         default="false"/>
   <arg name="align_depth"         default="false"/>
   
-  <arg name="base_frame_id"            default="$(arg tf_prefix)camera_link"/>
-  <arg name="depth_frame_id"           default="$(arg tf_prefix)camera_depth_frame"/>
-  <arg name="infra1_frame_id"          default="$(arg tf_prefix)camera_infra1_frame"/>
-  <arg name="infra2_frame_id"          default="$(arg tf_prefix)camera_infra2_frame"/>
-  <arg name="color_frame_id"           default="$(arg tf_prefix)camera_color_frame"/>
+  <arg name="base_frame_id"            default="$(arg tf_prefix)_link"/>
+  <arg name="depth_frame_id"           default="$(arg tf_prefix)_depth_frame"/>
+  <arg name="infra1_frame_id"          default="$(arg tf_prefix)_infra1_frame"/>
+  <arg name="infra2_frame_id"          default="$(arg tf_prefix)_infra2_frame"/>
+  <arg name="color_frame_id"           default="$(arg tf_prefix)_color_frame"/>
   
-  <arg name="depth_optical_frame_id"   default="$(arg tf_prefix)camera_depth_optical_frame"/>
-  <arg name="infra1_optical_frame_id"  default="$(arg tf_prefix)camera_infra1_optical_frame"/>
-  <arg name="infra2_optical_frame_id"  default="$(arg tf_prefix)camera_infra2_optical_frame"/>
-  <arg name="color_optical_frame_id"   default="$(arg tf_prefix)camera_color_optical_frame"/>
-  <arg name="fisheye_optical_frame_id" default="$(arg tf_prefix)camera_fisheye_optical_frame"/>
-  <arg name="accel_optical_frame_id"   default="$(arg tf_prefix)camera_accel_optical_frame"/>
-  <arg name="gyro_optical_frame_id"    default="$(arg tf_prefix)camera_gyro_optical_frame"/>
+  <arg name="depth_optical_frame_id"   default="$(arg tf_prefix)_depth_optical_frame"/>
+  <arg name="infra1_optical_frame_id"  default="$(arg tf_prefix)_infra1_optical_frame"/>
+  <arg name="infra2_optical_frame_id"  default="$(arg tf_prefix)_infra2_optical_frame"/>
+  <arg name="color_optical_frame_id"   default="$(arg tf_prefix)_color_optical_frame"/>
+  <arg name="fisheye_optical_frame_id" default="$(arg tf_prefix)_fisheye_optical_frame"/>
+  <arg name="accel_optical_frame_id"   default="$(arg tf_prefix)_accel_optical_frame"/>
+  <arg name="gyro_optical_frame_id"    default="$(arg tf_prefix)_gyro_optical_frame"/>
   
-  <arg name="aligned_depth_to_color_frame_id"   default="$(arg tf_prefix)camera_aligned_depth_to_color_frame"/>
-  <arg name="aligned_depth_to_infra1_frame_id" default="$(arg tf_prefix)camera_aligned_depth_to_infra1_frame"/>
-  <arg name="aligned_depth_to_infra2_frame_id"   default="$(arg tf_prefix)camera_aligned_depth_to_infra2_frame"/>
-  <arg name="aligned_depth_to_fisheye_frame_id"    default="$(arg tf_prefix)camera_aligned_depth_to_fisheye_frame"/>
+  <arg name="aligned_depth_to_color_frame_id"   default="$(arg tf_prefix)_aligned_depth_to_color_frame"/>
+  <arg name="aligned_depth_to_infra1_frame_id" default="$(arg tf_prefix)_aligned_depth_to_infra1_frame"/>
+  <arg name="aligned_depth_to_infra2_frame_id"   default="$(arg tf_prefix)_aligned_depth_to_infra2_frame"/>
+  <arg name="aligned_depth_to_fisheye_frame_id"    default="$(arg tf_prefix)_aligned_depth_to_fisheye_frame"/>
 
   <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>
   <node pkg="nodelet" type="nodelet" name="realsense2_camera" args="load realsense2_camera/RealSenseNodeFactory $(arg manager)">

--- a/realsense2_camera/launch/rs_aligned_depth.launch
+++ b/realsense2_camera/launch/rs_aligned_depth.launch
@@ -2,6 +2,7 @@
   <arg name="serial_no"           default=""/>
   <arg name="json_file_path"      default=""/>
   <arg name="camera"              default="camera"/>
+  <arg name="tf_prefix"           default=""/>
 
   <arg name="fisheye_width"       default="640"/>
   <arg name="fisheye_height"      default="480"/>
@@ -39,6 +40,7 @@
 
   <group ns="$(arg camera)">
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
+      <arg name="tf_prefix"                value="$(arg tf_prefix)"/>
       <arg name="serial_no"                value="$(arg serial_no)"/>
       <arg name="json_file_path"           value="$(arg json_file_path)"/>
 

--- a/realsense2_camera/launch/rs_aligned_depth.launch
+++ b/realsense2_camera/launch/rs_aligned_depth.launch
@@ -2,7 +2,7 @@
   <arg name="serial_no"           default=""/>
   <arg name="json_file_path"      default=""/>
   <arg name="camera"              default="camera"/>
-  <arg name="tf_prefix"           default=""/>
+  <arg name="tf_prefix"           default="$(arg camera)"/>
 
   <arg name="fisheye_width"       default="640"/>
   <arg name="fisheye_height"      default="480"/>

--- a/realsense2_camera/launch/rs_camera.launch
+++ b/realsense2_camera/launch/rs_camera.launch
@@ -2,6 +2,7 @@
   <arg name="serial_no"           default=""/>
   <arg name="json_file_path"      default=""/>
   <arg name="camera"              default="camera"/>
+  <arg name="tf_prefix"           default=""/>
 
   <arg name="fisheye_width"       default="640"/>
   <arg name="fisheye_height"      default="480"/>
@@ -38,6 +39,7 @@
 
   <group ns="$(arg camera)">
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
+      <arg name="tf_prefix"                value="$(arg tf_prefix)"/>
       <arg name="serial_no"                value="$(arg serial_no)"/>
       <arg name="json_file_path"           value="$(arg json_file_path)"/>
 

--- a/realsense2_camera/launch/rs_camera.launch
+++ b/realsense2_camera/launch/rs_camera.launch
@@ -2,7 +2,7 @@
   <arg name="serial_no"           default=""/>
   <arg name="json_file_path"      default=""/>
   <arg name="camera"              default="camera"/>
-  <arg name="tf_prefix"           default=""/>
+  <arg name="tf_prefix"           default="$(arg camera)"/>
 
   <arg name="fisheye_width"       default="640"/>
   <arg name="fisheye_height"      default="480"/>

--- a/realsense2_camera/launch/rs_multiple_devices.launch
+++ b/realsense2_camera/launch/rs_multiple_devices.launch
@@ -1,16 +1,20 @@
 <launch>
   <arg name="serial_no_camera1"    default=""/> <!-- Note: Replace with actual serial number -->
   <arg name="serial_no_camera2"    default=""/> <!-- Note: Replace with actual serial number -->
+  <arg name="tf_prefix_camera1"    default="camera1_"/> <!-- Note: Replace with camera name -->
+  <arg name="tf_prefix_camera2"    default="camera2_"/> <!-- Note: Replace with camera name -->
 
   <group ns="camera1">
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
-      <arg name="serial_no"    value="$(arg serial_no_camera1)"/>
+      <arg name="serial_no"     value="$(arg serial_no_camera1)"/>
+      <arg name="tf_prefix"		value="$(arg tf_prefix_camera1)"/>
     </include>
   </group>
 
   <group ns="camera2">
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
-      <arg name="serial_no"    value="$(arg serial_no_camera2)"/>
+      <arg name="serial_no"     value="$(arg serial_no_camera2)"/>
+      <arg name="tf_prefix"		value="$(arg tf_prefix_camera2)"/>
     </include>
   </group>
 </launch>

--- a/realsense2_camera/launch/rs_multiple_devices.launch
+++ b/realsense2_camera/launch/rs_multiple_devices.launch
@@ -1,17 +1,19 @@
 <launch>
-  <arg name="serial_no_camera1"    default=""/> <!-- Note: Replace with actual serial number -->
-  <arg name="serial_no_camera2"    default=""/> <!-- Note: Replace with actual serial number -->
-  <arg name="tf_prefix_camera1"    default="camera1_"/> <!-- Note: Replace with camera name -->
-  <arg name="tf_prefix_camera2"    default="camera2_"/> <!-- Note: Replace with camera name -->
+  <arg name="serial_no_camera1"    			default=""/> 			<!-- Note: Replace with actual serial number -->
+  <arg name="serial_no_camera2"    			default=""/> 			<!-- Note: Replace with actual serial number -->
+  <arg name="camera1"              			default="camera1"/>		<!-- Note: Replace with camera name -->
+  <arg name="camera2"              			default="camera2"/>		<!-- Note: Replace with camera name -->
+  <arg name="tf_prefix_camera1"           	default="$(arg camera1)"/>
+  <arg name="tf_prefix_camera2"           	default="$(arg camera2)"/>
 
-  <group ns="camera1">
+  <group ns="$(arg camera1)">
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
       <arg name="serial_no"     value="$(arg serial_no_camera1)"/>
       <arg name="tf_prefix"		value="$(arg tf_prefix_camera1)"/>
     </include>
   </group>
 
-  <group ns="camera2">
+  <group ns="$(arg camera2)">
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
       <arg name="serial_no"     value="$(arg serial_no_camera2)"/>
       <arg name="tf_prefix"		value="$(arg tf_prefix_camera2)"/>

--- a/realsense2_camera/launch/rs_rgbd.launch
+++ b/realsense2_camera/launch/rs_rgbd.launch
@@ -39,6 +39,7 @@ Processing enabled by this node:
 
 <launch>
   <arg name="camera"              default="camera"/>
+  <arg name="tf_prefix"           default=""/>
   <arg name="manager"             default="realsense2_camera_manager"/>
 
   <!-- Camera device specific arguments -->
@@ -112,6 +113,7 @@ Processing enabled by this node:
     <!-- Launch the camera device nodelet-->
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
       <arg name="manager"                  value="$(arg manager)"/>
+      <arg name="tf_prefix"                value="$(arg tf_prefix)"/>
       <arg name="serial_no"                value="$(arg serial_no)"/>
       <arg name="json_file_path"           value="$(arg json_file_path)"/>
 

--- a/realsense2_camera/launch/rs_rgbd.launch
+++ b/realsense2_camera/launch/rs_rgbd.launch
@@ -39,7 +39,7 @@ Processing enabled by this node:
 
 <launch>
   <arg name="camera"              default="camera"/>
-  <arg name="tf_prefix"           default=""/>
+  <arg name="tf_prefix"           default="$(arg camera)"/>
   <arg name="manager"             default="realsense2_camera_manager"/>
 
   <!-- Camera device specific arguments -->


### PR DESCRIPTION
Added a new parameter "tf_prefix" in launch file to be able to use multiple cameras. Before, when multiple cameras were started, all published their topics in frames with the same name (eg. camera_link). Now all cameras can publish to distinct frames (eg. right_camera_link, left_camera_link)