### PR TITLE
Add librealsense2 dependency to package.xml

### DIFF
--- a/realsense2_camera/package.xml
+++ b/realsense2_camera/package.xml
@@ -13,6 +13,7 @@
   <author email="sergey.dorodnicov@intel.com">Sergey Dorodnicov</author>
   <author email="doron.hirshberg@intel.com">Doron Hirshberg</author>
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>librealsense2</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
@@ -24,6 +25,7 @@
   <build_depend>tf</build_depend>
   <build_depend>ddynamic_reconfigure</build_depend>
   <build_depend>diagnostic_updater</build_depend>
+  <run_depend>librealsense2</run_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>nodelet</run_depend>  


### PR DESCRIPTION
The dependency on librealsense2 is missing in package.xml. This causes build error in building using catkin tools.   

[repro]
mkdir -p test/src
git clone https://github.com/intel-ros/realsense test/src/librealsense
git clone https://github.com/intel-ros/realsense test/src/realsense
catkin build --workspace test

[expected]
build suceeds

[actual]
CMake Error at .../test/src/realsense/realsense2_camera/CMakeLists.txt:37 (message):
   Intel RealSense SDK 2.0 is missing, please install it from https://github.com/IntelRealSense/librealsense/releases
