### PR TITLE
Initialize the reconfigure server with the private nodehandle

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -1390,7 +1390,7 @@ void BaseD400Node::setParam(base_d400_paramsConfig &config, base_depth_param par
 
 void BaseD400Node::registerDynamicReconfigCb()
 {
-    _server = std::make_shared<dynamic_reconfigure::Server<base_d400_paramsConfig>>();
+    _server = std::make_shared<dynamic_reconfigure::Server<base_d400_paramsConfig>>(_pnh);
     _f = boost::bind(&BaseD400Node::callback, this, _1, _2);
     _server->setCallback(_f);
 }

--- a/realsense2_camera/src/rs415_node.cpp
+++ b/realsense2_camera/src/rs415_node.cpp
@@ -2,12 +2,11 @@
 
 using namespace realsense2_camera;
 
-
-RS415Node::RS415Node(ros::NodeHandle& nodeHandle,
-                     ros::NodeHandle& privateNodeHandle,
-                     rs2::device dev, const std::string& serial_no)
-    : BaseD400Node(nodeHandle, privateNodeHandle, dev, serial_no)
-{}
+RS415Node::RS415Node(ros::NodeHandle &nodeHandle,
+                     ros::NodeHandle &privateNodeHandle, rs2::device dev,
+                     const std::string &serial_no)
+    : BaseD400Node(nodeHandle, privateNodeHandle, dev, serial_no),
+      _server(privateNodeHandle) {}
 
 void RS415Node::registerDynamicReconfigCb()
 {

--- a/realsense2_camera/src/rs435_node.cpp
+++ b/realsense2_camera/src/rs435_node.cpp
@@ -2,12 +2,11 @@
 
 using namespace realsense2_camera;
 
-
-RS435Node::RS435Node(ros::NodeHandle& nodeHandle,
-                     ros::NodeHandle& privateNodeHandle,
-                     rs2::device dev, const std::string& serial_no)
-    : BaseD400Node(nodeHandle, privateNodeHandle, dev, serial_no)
-{}
+RS435Node::RS435Node(ros::NodeHandle &nodeHandle,
+                     ros::NodeHandle &privateNodeHandle, rs2::device dev,
+                     const std::string &serial_no)
+    : BaseD400Node(nodeHandle, privateNodeHandle, dev, serial_no),
+      _server(privateNodeHandle) {}
 
 void RS435Node::registerDynamicReconfigCb()
 {

--- a/realsense2_camera/src/sr300_node.cpp
+++ b/realsense2_camera/src/sr300_node.cpp
@@ -2,9 +2,11 @@
 
 using namespace realsense2_camera;
 
-SR300Node::SR300Node(ros::NodeHandle& nodeHandle, ros::NodeHandle& privateNodeHandle, rs2::device dev, const std::string& serial_no)
-    : BaseRealSenseNode(nodeHandle, privateNodeHandle, dev, serial_no)
-{}
+SR300Node::SR300Node(ros::NodeHandle &nodeHandle,
+                     ros::NodeHandle &privateNodeHandle, rs2::device dev,
+                     const std::string &serial_no)
+    : BaseRealSenseNode(nodeHandle, privateNodeHandle, dev, serial_no),
+      _server(privateNodeHandle) {}
 
 void SR300Node::registerDynamicReconfigCb()
 {


### PR DESCRIPTION
In a nodelet the default nodehandle will be the manager's handle, but
all the parameters are loaded in the private nodehandle. This patch
initialzes all the reconfigure servers such that the parameters are
properly loaded from the private nodehandle.