### PR TITLE
Add support for post processing filters

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -105,7 +105,8 @@ namespace realsense2_camera
                                const std::string& from,
                                const std::string& to);
         void publishStaticTransforms();
-        void publishRgbToDepthPCTopic(const ros::Time& t, const std::map<stream_index_pair, bool>& is_frame_arrived);
+        void publishPointCloud(rs2::points f, const ros::Time& t, const rs2::frameset& frameset);
+        rs2::frame get_frame(const rs2::frameset& frameset, const rs2_stream stream, const int index = 0);
         Extrinsics rsExtrinsicsToMsg(const rs2_extrinsics& extrinsics, const std::string& frame_id) const;
         rs2_extrinsics getRsExtrinsics(const stream_index_pair& from_stream, const stream_index_pair& to_stream);
 
@@ -126,7 +127,7 @@ namespace realsense2_camera
                                   rs2_stream stream_type, int stream_index);
 
         void publishAlignedDepthToOthers(rs2::frame depth_frame, const std::vector<rs2::frame>& frames, const ros::Time& t);
-
+        rs2_stream rs2_string_to_stream(std::string str);
         void alignFrame(const rs2_intrinsics& from_intrin,
                         const rs2_intrinsics& other_intrin,
                         rs2::frame from_image,
@@ -170,6 +171,8 @@ namespace realsense2_camera
         bool _align_depth;
         bool _sync_frames;
         bool _pointcloud;
+        std::string _filters_str;
+        stream_index_pair _pointcloud_texture;
         PipelineSyncer _syncer;
         std::map<std::string, std::shared_ptr<rs2::processing_block>> _filters;
         // Declare pointcloud object, for calculating pointclouds and texture mappings

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -170,8 +170,8 @@ namespace realsense2_camera
         bool _align_depth;
         bool _sync_frames;
         bool _pointcloud;
-		PipelineSyncer _syncer;
-		std::map<string, std::shared_ptr<rs2::processing_block> _filters;
+        PipelineSyncer _syncer;
+        std::map<std::string, std::shared_ptr<rs2::processing_block>> _filters;
         // Declare pointcloud object, for calculating pointclouds and texture mappings
         // rs2::pointcloud _pc_filter;
 

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -51,6 +51,18 @@ namespace realsense2_camera
     };
     typedef std::pair<image_transport::Publisher, std::shared_ptr<FrequencyDiagnostics>> ImagePublisherWithFrequencyDiagnostics;
 
+    class NamedFilter
+    {
+        public:
+            std::string _name;
+            std::shared_ptr<rs2::processing_block> _filter;
+
+        public:
+            NamedFilter(std::string name, std::shared_ptr<rs2::processing_block> filter):
+            _name(name), _filter(filter)
+            {}
+    };
+
 	class PipelineSyncer : public rs2::asynchronous_syncer
 	{
 	public: 
@@ -174,7 +186,7 @@ namespace realsense2_camera
         std::string _filters_str;
         stream_index_pair _pointcloud_texture;
         PipelineSyncer _syncer;
-        std::map<std::string, std::shared_ptr<rs2::processing_block>> _filters;
+        std::vector<NamedFilter> _filters;
         // Declare pointcloud object, for calculating pointclouds and texture mappings
         // rs2::pointcloud _pc_filter;
 

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -95,6 +95,7 @@ namespace realsense2_camera
         void setupDevice();
         void setupPublishers();
         void enable_devices();
+        void setupFilters();
         void setupStreams();
         void updateStreamCalibData(const rs2::video_stream_profile& video_profile);
         tf::Quaternion rotationMatrixToQuaternion(const float rotation[9]) const;
@@ -170,6 +171,9 @@ namespace realsense2_camera
         bool _sync_frames;
         bool _pointcloud;
 		PipelineSyncer _syncer;
+		std::map<string, std::shared_ptr<rs2::processing_block> _filters;
+        // Declare pointcloud object, for calculating pointclouds and texture mappings
+        // rs2::pointcloud _pc_filter;
 
         std::map<stream_index_pair, cv::Mat> _depth_aligned_image;
         std::map<stream_index_pair, std::string> _depth_aligned_encoding;

--- a/realsense2_camera/include/constants.h
+++ b/realsense2_camera/include/constants.h
@@ -6,8 +6,8 @@
 #include <string>
 
 #define REALSENSE_ROS_MAJOR_VERSION    2
-#define REALSENSE_ROS_MINOR_VERSION    0
-#define REALSENSE_ROS_PATCH_VERSION    3
+#define REALSENSE_ROS_MINOR_VERSION    1
+#define REALSENSE_ROS_PATCH_VERSION    0
 
 #define STRINGIFY(arg) #arg
 #define VAR_ARG_STRING(arg) STRINGIFY(arg)

--- a/realsense2_camera/include/constants.h
+++ b/realsense2_camera/include/constants.h
@@ -91,5 +91,7 @@ namespace realsense2_camera
     const std::string DEFAULT_ALIGNED_DEPTH_TO_INFRA2_FRAME_ID = "camera_aligned_depth_to_infra2_frame";
     const std::string DEFAULT_ALIGNED_DEPTH_TO_FISHEYE_FRAME_ID = "camera_aligned_depth_to_fisheye_frame";
 
+    const std::string DEFAULT_FILTERS                  = "";
+
     using stream_index_pair = std::pair<rs2_stream, int>;
 }  // namespace realsense2_camera

--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -44,6 +44,9 @@
   <arg name="enable_sync"         default="false"/>
   <arg name="align_depth"         default="false"/>
 
+  <arg name="filters"             default=""/>
+
+
   <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>
   <node pkg="nodelet" type="nodelet" name="realsense2_camera" args="load realsense2_camera/RealSenseNodeFactory $(arg manager)">
     <param name="serial_no"                type="str"  value="$(arg serial_no)"/>
@@ -95,6 +98,9 @@
     <param name="aligned_depth_to_infra1_frame_id"  type="str"  value="camera_aligned_depth_to_infra1_frame"/>
     <param name="aligned_depth_to_infra2_frame_id"  type="str"  value="camera_aligned_depth_to_infra2_frame"/>
     <param name="aligned_depth_to_fisheye_frame_id" type="str"  value="camera_aligned_depth_to_fisheye_frame"/>
+
+    <param name="filters" type="str"  value="$(arg filters)"/>
+
   </node>
 </launch>
 

--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -41,6 +41,9 @@
   <arg name="enable_imu"          default="true"/>
 
   <arg name="enable_pointcloud"   default="false"/>
+  <arg name="pointcloud_texture_stream" default="RS2_STREAM_COLOR"/>  <!-- use RS2_STREAM_ANY to avoid using texture -->
+  <arg name="pointcloud_texture_index"  default="0"/>
+
   <arg name="enable_sync"         default="false"/>
   <arg name="align_depth"         default="false"/>
 
@@ -54,6 +57,8 @@
     <param name="rosbag_filename"          type="str"  value="$(arg rosbag_filename)"/>
 
     <param name="enable_pointcloud"        type="bool" value="$(arg enable_pointcloud)"/>
+    <param name="pointcloud_texture_stream" type="str" value="$(arg pointcloud_texture_stream)"/>
+    <param name="pointcloud_texture_index"  type="int" value="$(arg pointcloud_texture_index)"/>
     <param name="enable_sync"              type="bool" value="$(arg enable_sync)"/>
     <param name="align_depth"              type="bool" value="$(arg align_depth)"/>
 

--- a/realsense2_camera/launch/rs_camera.launch
+++ b/realsense2_camera/launch/rs_camera.launch
@@ -36,6 +36,8 @@
   <arg name="enable_sync"         default="false"/>
   <arg name="align_depth"         default="false"/>
 
+  <arg name="filters"             default=""/>
+
   <group ns="$(arg camera)">
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
       <arg name="serial_no"                value="$(arg serial_no)"/>
@@ -73,6 +75,8 @@
       <arg name="gyro_fps"                 value="$(arg gyro_fps)"/>
       <arg name="accel_fps"                value="$(arg accel_fps)"/>
       <arg name="enable_imu"               value="$(arg enable_imu)"/>
+
+      <arg name="filters"                  value="$(arg filters)"/>
     </include>
   </group>
 </launch>

--- a/realsense2_camera/launch/rs_camera.launch
+++ b/realsense2_camera/launch/rs_camera.launch
@@ -32,7 +32,10 @@
   <arg name="accel_fps"           default="1000"/>
   <arg name="enable_imu"          default="true"/>
 
-  <arg name="enable_pointcloud"   default="false"/>
+  <arg name="enable_pointcloud"         default="false"/>
+  <arg name="pointcloud_texture_stream" default="RS2_STREAM_COLOR"/>
+  <arg name="pointcloud_texture_index"  default="0"/>
+
   <arg name="enable_sync"         default="false"/>
   <arg name="align_depth"         default="false"/>
 
@@ -44,6 +47,8 @@
       <arg name="json_file_path"           value="$(arg json_file_path)"/>
 
       <arg name="enable_pointcloud"        value="$(arg enable_pointcloud)"/>
+      <arg name="pointcloud_texture_stream" value="$(arg pointcloud_texture_stream)"/>
+      <arg name="pointcloud_texture_index"  value="$(arg pointcloud_texture_index)"/>
       <arg name="enable_sync"              value="$(arg enable_sync)"/>
       <arg name="align_depth"              value="$(arg align_depth)"/>
 

--- a/realsense2_camera/launch/rs_from_file.launch
+++ b/realsense2_camera/launch/rs_from_file.launch
@@ -37,6 +37,8 @@
   <arg name="enable_sync"         default="false"/>
 
   <arg name="align_depth"         default="false"/>
+  <arg name="filters"             default=""/>
+
 
   <group ns="$(arg camera)">
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
@@ -76,6 +78,7 @@
       <arg name="gyro_fps"                 value="$(arg gyro_fps)"/>
       <arg name="accel_fps"                value="$(arg accel_fps)"/>
       <arg name="enable_imu"               value="$(arg enable_imu)"/>
+      <arg name="filters"                  value="$(arg filters)"/>
     </include>
   </group>
 </launch>

--- a/realsense2_camera/package.xml
+++ b/realsense2_camera/package.xml
@@ -4,14 +4,14 @@
   <version>2.0.3</version>
   <description>RealSense Camera package allowing access to Intel 3D D400 cameras</description>
   <maintainer email="sergey.dorodnicov@intel.com">Sergey Dorodnicov</maintainer>
-  <maintainer email="itay.carpis@intel.com">Itay Carpis</maintainer>
+  <maintainer email="doron.hirshberg@intel.com">Doron Hirshberg</maintainer>
   <license>Apache 2.0</license>
   
   <url type="website">http://www.ros.org/wiki/RealSense</url>
   <url type="bugtracker">https://github.com/intel-ros/realsense/issues</url>
 
   <author email="sergey.dorodnicov@intel.com">Sergey Dorodnicov</author>
-  <author email="itay.carpis@intel.com">Itay Carpis</author>
+  <author email="doron.hirshberg@intel.com">Doron Hirshberg</author>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>roscpp</build_depend>

--- a/realsense2_camera/scripts/rs2_listener.py
+++ b/realsense2_camera/scripts/rs2_listener.py
@@ -2,10 +2,29 @@ import sys
 import time
 import rospy
 from sensor_msgs.msg import Image as msg_Image
+from sensor_msgs.msg import PointCloud2 as msg_PointCloud2
+import sensor_msgs.point_cloud2 as pc2
 import numpy as np
 from cv_bridge import CvBridge, CvBridgeError
 import inspect
+import ctypes
+import struct
 
+
+def pc2_to_xyzrgb(point):
+	# Thanks to Panos for his code used in this function.
+    x, y, z = point[:3]
+    rgb = point[3]
+
+    # cast float32 to int so that bitwise operations are possible
+    s = struct.pack('>f', rgb)
+    i = struct.unpack('>l', s)[0]
+    # you can get back the float value by the inverse operations
+    pack = ctypes.c_uint32(i).value
+    r = (pack & 0x00FF0000) >> 16
+    g = (pack & 0x0000FF00) >> 8
+    b = (pack & 0x000000FF)
+    return x, y, z, r, g, b
 
 
 class CWaitForMessage:
@@ -20,7 +39,8 @@ class CWaitForMessage:
         self.bridge = CvBridge()
 
         self.themes = {'depthStream': {'topic': '', 'callback': self.imageDepthCallback, 'msg_type': msg_Image},
-                       'colorStream': {'topic': '/camera/color/image_raw', 'callback': self.imageColorCallback, 'msg_type': msg_Image}}
+                       'colorStream': {'topic': '/camera/color/image_raw', 'callback': self.imageColorCallback, 'msg_type': msg_Image},
+                       'pointscloud': {'topic': '/camera/depth/color/points', 'callback': self.pointscloudCallback, 'msg_type': msg_PointCloud2},}
 
         self.func_data = dict()
 
@@ -43,6 +63,31 @@ class CWaitForMessage:
 
     def imageDepthCallback(self, data):
         pass
+
+    def pointscloudCallback(self, data):
+        self.prev_time = time.time()
+        print 'Got pointcloud: %d, %d' % (data.width, data.height)
+        func_name = inspect.stack()[0][3]
+        theme_name = [key for key, value in self.themes.items() if func_name in value['callback'].__name__][0]
+
+        self.func_data[theme_name].setdefault('avg', [])
+        self.func_data[theme_name].setdefault('size', [])
+        self.func_data[theme_name].setdefault('width', [])
+        self.func_data[theme_name].setdefault('height', [])
+        # until parsing pointcloud is done in real time, I'll use only the first frame.
+        if len(self.func_data[theme_name]['width']) > 0:
+            return
+
+        try:
+            points = np.array([pc2_to_xyzrgb(pp) for pp in pc2.read_points(data, skip_nans=True, field_names=("x", "y", "z", "rgb")) if pp[0] > 0])
+        except Exception as e:
+            print(e)
+            return
+        print 'len(avg)=%d' % (len(self.func_data[theme_name]['avg']))
+        self.func_data[theme_name]['avg'].append(points.mean(0))
+        self.func_data[theme_name]['size'].append(len(points))
+        self.func_data[theme_name]['width'].append(data.width)
+        self.func_data[theme_name]['height'].append(data.height)
 
     def wait_for_message(self, params):
         topic = params['topic']
@@ -104,8 +149,9 @@ def main():
     if len(sys.argv) < 2 or '--help' in sys.argv or '/?' in sys.argv:
         print 'USAGE:'
         print '------'
-        print 'rs2_listener.py <topic> [Options]'
+        print 'rs2_listener.py <topic | theme> [Options]'
         print 'example: rs2_listener.py /camera/color/image_raw --time 1532423022.044515610 --timeout 3'
+        print 'example: rs2_listener.py pointscloud'
         print ''
         print 'Application subscribes on <topic>, wait for the first message matching [Options].'
         print 'When found, prints the timestamp.'
@@ -120,8 +166,7 @@ def main():
     # wanted_seq = 58250
 
     wanted_topic = sys.argv[1]
-    msg_params = {'topic': wanted_topic}
-
+    msg_params = {}
     for idx in range(2, len(sys.argv)):
         if sys.argv[idx] == '-s':
             msg_params['seq'] = int(sys.argv[idx + 1])
@@ -131,9 +176,14 @@ def main():
             msg_params['timeout_secs'] = int(sys.argv[idx + 1])
 
     msg_retriever = CWaitForMessage(msg_params)
-    res = msg_retriever.wait_for_message()
-
-    rospy.loginfo('Got message: %s' % res.header)
+    if '/' in wanted_topic:
+        msg_params = {'topic': wanted_topic}
+        res = msg_retriever.wait_for_message(msg_params)
+        rospy.loginfo('Got message: %s' % res.header)
+    else:
+        themes = [wanted_topic]
+        res = msg_retriever.wait_for_messages(themes)
+        print res
 
 
 if __name__ == '__main__':

--- a/realsense2_camera/scripts/rs2_listener.py
+++ b/realsense2_camera/scripts/rs2_listener.py
@@ -70,11 +70,18 @@ class CWaitForMessage:
         func_name = inspect.stack()[0][3]
         theme_name = [key for key, value in self.themes.items() if func_name in value['callback'].__name__][0]
 
+        self.func_data[theme_name].setdefault('frame_counter', 0)
         self.func_data[theme_name].setdefault('avg', [])
         self.func_data[theme_name].setdefault('size', [])
         self.func_data[theme_name].setdefault('width', [])
         self.func_data[theme_name].setdefault('height', [])
         # until parsing pointcloud is done in real time, I'll use only the first frame.
+        self.func_data[theme_name]['frame_counter'] += 1
+
+        if self.func_data[theme_name]['frame_counter'] == 1:
+            # Known issue - 1st pointcloud published has invalid texture. Skip 1st frame.
+            return
+
         if len(self.func_data[theme_name]['width']) > 0:
             return
 
@@ -83,7 +90,6 @@ class CWaitForMessage:
         except Exception as e:
             print(e)
             return
-        print 'len(avg)=%d' % (len(self.func_data[theme_name]['avg']))
         self.func_data[theme_name]['avg'].append(points.mean(0))
         self.func_data[theme_name]['size'].append(len(points))
         self.func_data[theme_name]['width'].append(data.width)

--- a/realsense2_camera/scripts/rs2_test.py
+++ b/realsense2_camera/scripts/rs2_test.py
@@ -71,7 +71,8 @@ test_types = {'vis_avg': {'listener_theme': 'colorStream',
                           'data_func': lambda x: None,
                           'test_func': lambda x, y: not ImageColorTest(x, y)},
               'pointscloud_avg': {'listener_theme': 'pointscloud',
-                          'data_func': lambda x: {'width': [1280], 'height': [720], 'avg': [np.array([ 1.50336195,  0.0145172 ,  4.55452856, 73, 103, 115])], 'epsilon': [0.02, 2]},
+                          'data_func': lambda x: {'width': [921600], 'height': [1], 'avg': [np.array([ 1.50336195,  0.0145172 ,  4.55452856, 73, 103, 115])], 'epsilon': [0.02, 2]},
+						  # 'data_func': lambda x: {'width': [1280], 'height': [720], 'avg': [np.array([ 1.50336195,  0.0145172 ,  4.55452856, 73, 103, 115])], 'epsilon': [0.02, 2]},
                           'test_func': PointCloudTest},
               }
 

--- a/realsense2_camera/scripts/rs2_test.py
+++ b/realsense2_camera/scripts/rs2_test.py
@@ -71,8 +71,7 @@ test_types = {'vis_avg': {'listener_theme': 'colorStream',
                           'data_func': lambda x: None,
                           'test_func': lambda x, y: not ImageColorTest(x, y)},
               'pointscloud_avg': {'listener_theme': 'pointscloud',
-                          'data_func': lambda x: {'width': [921600], 'height': [1], 'avg': [np.array([ 1.50336195,  0.0145172 ,  4.55452856, 73, 103, 115])], 'epsilon': [0.02, 2]},
-						  # 'data_func': lambda x: {'width': [1280], 'height': [720], 'avg': [np.array([ 1.50336195,  0.0145172 ,  4.55452856, 73, 103, 115])], 'epsilon': [0.02, 2]},
+                          'data_func': lambda x: {'width': [776534], 'height': [1], 'avg': [np.array([ 1.28251814, -0.15839984, 4.82235184, 65, 88, 95])], 'epsilon': [0.02, 2]},
                           'test_func': PointCloudTest},
               }
 

--- a/realsense2_camera/scripts/rs2_test.py
+++ b/realsense2_camera/scripts/rs2_test.py
@@ -41,12 +41,26 @@ def ImageColorTest(data, gt_data):
         print 'Expect %d channels. Got %d channels.' % (channels[0], gt_data['num_channels'])
         if len(channels) > 1 or channels[0] != gt_data['num_channels']:
             return False
-        print 'Expect avarage of %.3f. Got avarage of %.3f.' % (np.array(data['avg']).mean(), gt_data['avg'].mean())
+        print 'Expect average of %.3f (+-%.3f). Got average of %.3f.' % (gt_data['avg'].mean(), gt_data['epsilon'], np.array(data['avg']).mean())
         if abs(np.array(data['avg']) - gt_data['avg']).max() > gt_data['epsilon']:
             return False
     except Exception as e:
         print 'Test Failed: %s' % e
         return False
+    return True
+
+
+def PointCloudTest(data, gt_data):
+    print 'Expect image size %d, %d. Got %d, %d.' % (gt_data['width'][0], gt_data['height'][0], data['width'][0], data['height'][0])
+    if data['width'][0] != gt_data['width'][0] or data['height'][0] != gt_data['height'][0]:
+        return False
+    print 'Expect average position of %s (+-%.3f). Got average of %s.' % (gt_data['avg'][0][:3], gt_data['epsilon'][0], data['avg'][0][:3])
+    if abs(data['avg'][0][:3] - gt_data['avg'][0][:3]).max() > gt_data['epsilon'][0]:
+        return False
+    print 'Expect average color of %s (+-%.3f). Got average of %s.' % (gt_data['avg'][0][3:], gt_data['epsilon'][1], data['avg'][0][3:])
+    if abs(data['avg'][0][3:] - gt_data['avg'][0][3:]).max() > gt_data['epsilon'][1]:
+        return False
+
     return True
 
 
@@ -56,36 +70,44 @@ test_types = {'vis_avg': {'listener_theme': 'colorStream',
               'no_file': {'listener_theme': 'colorStream',
                           'data_func': lambda x: None,
                           'test_func': lambda x, y: not ImageColorTest(x, y)},
+              'pointscloud_avg': {'listener_theme': 'pointscloud',
+                          'data_func': lambda x: {'width': [1280], 'height': [720], 'avg': [np.array([ 1.50336195,  0.0145172 ,  4.55452856, 73, 103, 115])], 'epsilon': [0.02, 2]},
+                          'test_func': PointCloudTest},
               }
 
 
 def run_test(test, listener_res):
-    # gather ground truth with test_types[test['type']]['data_func'] and recording from test['rec_filename']
+    # gather ground truth with test_types[test['type']]['data_func'] and recording from test['rosbag_filename']
     # return results from test_types[test['type']]['test_func']
     test_type = test_types[test['type']]
-    gt_data = test_type['data_func'](test['rec_filename'])
+    gt_data = test_type['data_func'](test['params']['rosbag_filename'])
     return test_type['test_func'](listener_res[test_type['listener_theme']], gt_data)
 
 
 def print_results(results):
-    print '{:^20s}'.format('TEST RESULTS')
-    print '-'*20
-    print '{:<10s}{:>10s}'.format('test name', 'score')
-    print '-'*9 + ' '*2 + '-'*9
-    print '\n'.join(['{:<10s}{:>10s}'.format(test[0], 'OK' if test[1] else 'FAILED') for test in results])
+    title = 'TEST RESULTS'
+    headers = ['test name', 'score']
+    col_0_width = max([len(headers[0])] + [len(test[0]) for test in results]) + 1
+    col_1_width = max([len(headers[1]), len('OK'), len('FAILED')]) + 1
+    total_width = col_0_width + col_1_width
+    print ('{:^%ds}'%total_width).format(title)
+    print '-'*total_width
+    print ('{:<%ds}{:>%ds}' % (col_0_width, col_1_width)).format('test name', 'score')
+    print '-'*(col_0_width-1) + ' '*2 + '-'*(col_1_width-1)
+    print '\n'.join([('{:<%ds}{:>%ds}' % (col_0_width, col_1_width)).format(test[0], 'OK' if test[1] else 'FAILED') for test in results])
     print
 
 
 def run_tests(tests):
     msg_params = {'timeout_secs': 5}
     results = []
-    rec_filenames = set([os.path.abspath(test['rec_filename']) for test in tests])
-    for rec in rec_filenames:
-        rec_tests = [test for test in tests if os.path.abspath(test['rec_filename']) == rec]
+    params_strs = set([test['params_str'] for test in tests])
+    for params_str in params_strs:
+        rec_tests = [test for test in tests if test['params_str'] == params_str]
         themes = [test_types[test['type']]['listener_theme'] for test in rec_tests]
         msg_retriever = CWaitForMessage(msg_params)
         print 'Starting ROS'
-        p_wrapper = subprocess.Popen(['roslaunch', 'realsense2_camera', 'rs_from_file.launch', 'rosbag_filename:=%s' % rec], stdout=None, stderr=None)
+        p_wrapper = subprocess.Popen(['roslaunch', 'realsense2_camera', 'rs_from_file.launch'] + params_str.split(' '), stdout=None, stderr=None)
         listener_res = msg_retriever.wait_for_messages(themes)
         print 'Killing ROS'
         p_wrapper.terminate()
@@ -103,9 +125,15 @@ def run_tests(tests):
     return results
 
 def main():
-    all_tests = [{'name': 'vis_avg_1', 'type': 'no_file', 'rec_filename': '/home/non_existent_file.txt'},
-                 # {'name': 'vis_avg_2', 'type': 'vis_avg', 'rec_filename': '/home/doronhi/Downloads/checkerboard_30cm.bag'},
-                 {'name': 'vis_avg_2', 'type': 'vis_avg', 'rec_filename': './records/outdoors.bag'}]
+    all_tests = [{'name': 'vis_avg_1', 'type': 'no_file', 'params': {'rosbag_filename': '/home/non_existent_file.txt'}},
+                 # {'name': 'vis_avg_2', 'type': 'vis_avg', 'params': {'rosbag_filename': '/home/doronhi/Downloads/checkerboard_30cm.bag'}},
+                 {'name': 'vis_avg_2', 'type': 'vis_avg', 'params': {'rosbag_filename': './records/outdoors.bag'}},
+                 {'name': 'points_cloud_1', 'type': 'pointscloud_avg', 'params': {'rosbag_filename': './records/outdoors.bag', 'enable_pointcloud': 'true'}}]
+
+    # Normalize parameters:
+    for test in all_tests:
+        test['params']['rosbag_filename'] = os.path.abspath(test['params']['rosbag_filename'])
+        test['params_str'] = ' '.join([key + ':=' + test['params'][key] for key in sorted(test['params'].keys())])
 
     if len(sys.argv) < 2 or '--help' in sys.argv or '/?' in sys.argv:
         print 'USAGE:'

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -2,6 +2,7 @@
 #include "../include/sr300_node.h"
 #include "assert.h"
 #include <boost/algorithm/string.hpp>
+#include <algorithm>    // std::max
 
 using namespace realsense2_camera;
 
@@ -582,6 +583,7 @@ void BaseRealSenseNode::setupFilters()
     if (_pointcloud)
     {
     	ROS_INFO("Add Filter: pointcloud");
+//        _filters["pointcloud"] = std::make_shared<rs2::pointcloud>();
         _filters["pointcloud"] = std::make_shared<rs2::pointcloud>(_pointcloud_texture.first, _pointcloud_texture.second);
     }
     ROS_INFO("num_filters: %d", static_cast<int>(_filters.size()));
@@ -665,31 +667,32 @@ void BaseRealSenseNode::setupStreams()
                                   rs2_stream_to_string(stream_type), stream_index, rs2_format_to_string(stream_format), stream_unique_id, frame.get_frame_number(), frame.get_timestamp(), t.toNSec());
                     }
                     ROS_DEBUG("END OF LIST");
-                    ROS_DEBUG_STREAM("Remove streams with same type and index:");
-                    std::map<stream_index_pair, rs2::frame> frames_to_publish;
+//                    ROS_DEBUG_STREAM("Remove streams with same type and index:");
+//                    std::map<stream_index_pair, rs2::frame> frames_to_publish;
+//                    for (auto it = frameset.begin(); it != frameset.end(); ++it)
+//                    {
+//                        auto f = (*it);
+//                        auto stream_type = f.get_profile().stream_type();
+//                        auto stream_index = f.get_profile().stream_index();
+//                        stream_index_pair sip{stream_type,stream_index};
+//                        frames_to_publish.insert(std::pair<stream_index_pair, rs2::frame>(sip, f));
+//                    }
+//                    for (auto it = frames_to_publish.begin(); it != frames_to_publish.end(); ++it)
+//                    {
+//                        auto f = it->second;
+//                        auto stream_type = f.get_profile().stream_type();
+//                        auto stream_index = f.get_profile().stream_index();
+//                        auto stream_format = f.get_profile().format();
+//                        auto stream_unique_id = f.get_profile().unique_id();
+//
+//                        ROS_DEBUG("Frameset contain (%s, %d, %s %d) frame. frame_number: %llu ; frame_TS: %f ; ros_TS(NSec): %lu",
+//                                  rs2_stream_to_string(stream_type), stream_index, rs2_format_to_string(stream_format), stream_unique_id, frame.get_frame_number(), frame.get_timestamp(), t.toNSec());
+//                    }
+
                     for (auto it = frameset.begin(); it != frameset.end(); ++it)
                     {
+//                        auto f = it->second;
                         auto f = (*it);
-                        auto stream_type = f.get_profile().stream_type();
-                        auto stream_index = f.get_profile().stream_index();
-                        stream_index_pair sip{stream_type,stream_index};
-                        frames_to_publish.insert(std::pair<stream_index_pair, rs2::frame>(sip, f));
-                    }
-                    for (auto it = frames_to_publish.begin(); it != frames_to_publish.end(); ++it)
-                    {
-                        auto f = it->second;
-                        auto stream_type = f.get_profile().stream_type();
-                        auto stream_index = f.get_profile().stream_index();
-                        auto stream_format = f.get_profile().format();
-                        auto stream_unique_id = f.get_profile().unique_id();
-
-                        ROS_DEBUG("Frameset contain (%s, %d, %s %d) frame. frame_number: %llu ; frame_TS: %f ; ros_TS(NSec): %lu",
-                                  rs2_stream_to_string(stream_type), stream_index, rs2_format_to_string(stream_format), stream_unique_id, frame.get_frame_number(), frame.get_timestamp(), t.toNSec());
-                    }
-
-                    for (auto it = frames_to_publish.begin(); it != frames_to_publish.end(); ++it)
-                    {
-                        auto f = it->second;
                         auto stream_type = f.get_profile().stream_type();
                         auto stream_index = f.get_profile().stream_index();
                         auto stream_format = f.get_profile().format();
@@ -750,6 +753,12 @@ void BaseRealSenseNode::setupStreams()
                                  _camera_info, _optical_frame_id,
                                  _encoding);
                 }
+
+                // if(_pointcloud && (0 != _pointcloud_publisher.getNumSubscribers()))
+                // {
+                //     ROS_DEBUG("publishPCTopic(...)");
+                //     publishRgbToDepthPCTopic(t, is_frame_arrived);
+                // }
             }
             catch(const std::exception& ex)
             {
@@ -1180,7 +1189,14 @@ rs2::frame BaseRealSenseNode::get_frame(const rs2::frameset& frameset, const rs2
 
 void BaseRealSenseNode::publishPointCloud(rs2::points pc, const ros::Time& t, const rs2::frameset& frameset)
 {
-    rs2::video_frame texture_frame = get_frame(frameset, _pointcloud_texture.first, _pointcloud_texture.second).as<rs2::video_frame>();
+    rs2::frame temp_frame = get_frame(frameset, _pointcloud_texture.first, _pointcloud_texture.second).as<rs2::video_frame>();
+    if (!temp_frame.is<rs2::video_frame>())
+    {
+        ROS_DEBUG_STREAM("texture frame not found");
+        return;
+    }
+
+    rs2::video_frame texture_frame = temp_frame.as<rs2::video_frame>();
     auto f = texture_frame;
     auto stream_type = f.get_profile().stream_type();
     auto stream_index = f.get_profile().stream_index();
@@ -1191,13 +1207,29 @@ void BaseRealSenseNode::publishPointCloud(rs2::points pc, const ros::Time& t, co
 
     unsigned char* color_data = (uint8_t*)texture_frame.get_data();
     int texture_width = texture_frame.get_width();
+    int texture_height = texture_frame.get_height();
     int bpp = texture_frame.get_bytes_per_pixel();
     assert(bpp == 3); // TODO: Need to support PointCloud based in IR image.
+
+
+    const rs2::texture_coordinate* color_point = pc.get_texture_coordinates();
+    int num_valid_points(0);
+    for (size_t point_idx=0; point_idx < pc.size(); point_idx++, color_point++)
+    {
+        float i = static_cast<float>(color_point->u);
+        float j = static_cast<float>(color_point->v);
+
+        if (i >= 0.f && i <= 1.f && j >= 0.f && j <= 1.f)
+        {
+            num_valid_points++;
+        }
+    }
+
 
     sensor_msgs::PointCloud2 msg_pointcloud;
     msg_pointcloud.header.stamp = t;
     msg_pointcloud.header.frame_id = _optical_frame_id[DEPTH];
-    msg_pointcloud.width = pc.size();
+    msg_pointcloud.width = num_valid_points;
     msg_pointcloud.height = 1;
     msg_pointcloud.is_dense = true;
 
@@ -1220,25 +1252,39 @@ void BaseRealSenseNode::publishPointCloud(rs2::points pc, const ros::Time& t, co
 
     // Fill the PointCloud2 fields
     const rs2::vertex* vertex = pc.get_vertices();
-    const rs2::texture_coordinate* color_pixel = pc.get_texture_coordinates();
+    color_point = pc.get_texture_coordinates();
 
-    for (size_t point_idx=0; point_idx < pc.size(); point_idx++, vertex++, color_pixel++)
+    ROS_DEBUG_STREAM("pointcloud size: " << num_valid_points);
+//    float max_i(0), max_j(0);
+    float color_pixel[2];
+
+    for (size_t point_idx=0; point_idx < pc.size(); vertex++, point_idx++, color_point++)
     {
-        *iter_x = vertex->x;
-        *iter_y = vertex->y;
-        *iter_z = vertex->z;
+        float i = static_cast<float>(color_point->u);
+        float j = static_cast<float>(color_point->v);
+        if (i >= 0.f && i <= 1.f && j >= 0.f && j <= 1.f)
+        {
+            *iter_x = vertex->x;
+            *iter_y = vertex->y;
+            *iter_z = vertex->z;
 
-        int i = static_cast<int>(color_pixel->u);
-        int j = static_cast<int>(color_pixel->v);
+            color_pixel[0] = i * texture_width;
+            color_pixel[1] = j * texture_height;
 
-        auto offset = (j * texture_width + i ) * 3;
-        *iter_r = static_cast<uint8_t>(color_data[offset]);
-        *iter_g = static_cast<uint8_t>(color_data[offset + 1]);
-        *iter_b = static_cast<uint8_t>(color_data[offset + 2]);
+            auto pixx = static_cast<int>(color_pixel[0]);
+            auto pixy = static_cast<int>(color_pixel[1]);
+            int offset = (pixy * texture_width + pixx) * 3;
+            *iter_r = static_cast<uint8_t>(color_data[offset]);
+            *iter_g = static_cast<uint8_t>(color_data[offset + 1]);
+            *iter_b = static_cast<uint8_t>(color_data[offset + 2]);
 
-        ++iter_x; ++iter_y; ++iter_z;
-        ++iter_r; ++iter_g; ++iter_b;
+            ++iter_x; ++iter_y; ++iter_z;
+            ++iter_r; ++iter_g; ++iter_b;
+        }
+//        ROS_DEBUG("Color pointcloud: %d, %d, %d", *iter_r, *iter_g, *iter_b);
+
     }
+//    ROS_DEBUG_STREAM("max_i, max_j = " << max_i << ", " << max_j);
     _pointcloud_publisher.publish(msg_pointcloud);
 }
 

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -87,6 +87,7 @@ void BaseRealSenseNode::publishTopics()
     setupDevice();
     setupPublishers();
     setupStreams();
+    setupFilters();
     publishStaticTransforms();
     ROS_INFO_STREAM("RealSense Node Is Up!");
 }
@@ -528,6 +529,14 @@ void BaseRealSenseNode::enable_devices()
 			_depth_aligned_image[profiles.first] = cv::Mat(_width[DEPTH], _height[DEPTH], _image_format[DEPTH], cv::Scalar(0, 0, 0));
 		}
 	}
+}
+
+void BaseRealSenseNode::setupFilters()
+{
+    if (_pointcloud)
+    {
+        _filters["pointcloud"] = std::make_shared<rs2::pointcloud>();
+    }
 }
 
 void BaseRealSenseNode::setupStreams()

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -1208,8 +1208,7 @@ void BaseRealSenseNode::publishPointCloud(rs2::points pc, const ros::Time& t, co
         color_data = (uint8_t*)texture_frame.get_data();
         texture_width = texture_frame.get_width();
         texture_height = texture_frame.get_height();
-        int bpp = texture_frame.get_bytes_per_pixel();
-        assert(bpp == 3); // TODO: Need to support PointCloud based in IR image.
+        assert(texture_frame.get_bytes_per_pixel() == 3); // TODO: Need to support IR image texture.
     }
     else
     {

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -1275,8 +1275,8 @@ void BaseRealSenseNode::publishPointCloud(rs2::points pc, const ros::Time& t, co
             color_pixel[0] = i * texture_width;
             color_pixel[1] = j * texture_height;
 
-            auto pixx = static_cast<int>(color_pixel[0]);
-            auto pixy = static_cast<int>(color_pixel[1]);
+            int pixx = static_cast<int>(color_pixel[0]);
+            int pixy = static_cast<int>(color_pixel[1]);
             int offset = (pixy * texture_width + pixx) * 3;
             *iter_r = static_cast<uint8_t>(color_data[offset]);
             *iter_g = static_cast<uint8_t>(color_data[offset + 1]);

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -593,6 +593,22 @@ void BaseRealSenseNode::setupStreams()
 
                         ROS_DEBUG("Frameset contain (%s, %d) frame. frame_number: %llu ; frame_TS: %f ; ros_TS(NSec): %lu",
                                   rs2_stream_to_string(stream_type), stream_index, frame.get_frame_number(), frame.get_timestamp(), t.toNSec());
+                    }
+                    for (std::map<std::string, std::shared_ptr<rs2::processing_block>>::const_iterator filter_it = _filters.begin(); filter_it != _filters.end(); filter_it++)
+                    {
+                        ROS_DEBUG("Applying filter: %s", filter_it->first.c_str());
+                        filter_it->second->process(frame);
+                    }
+
+                    ROS_DEBUG("List of frameset after applying filters:");
+                    for (auto it = frameset.begin(); it != frameset.end(); ++it)
+                    {
+                        auto f = (*it);
+                        auto stream_type = f.get_profile().stream_type();
+                        auto stream_index = f.get_profile().stream_index();
+
+                        ROS_DEBUG("Frameset contain (%s, %d) frame. frame_number: %llu ; frame_TS: %f ; ros_TS(NSec): %lu",
+                                  rs2_stream_to_string(stream_type), stream_index, frame.get_frame_number(), frame.get_timestamp(), t.toNSec());
 
                         stream_index_pair sip{stream_type,stream_index};
                         publishFrame(f, t,


### PR DESCRIPTION
In this PR we enable the post processing filters that exist in Realsense 2.0 SDK
The filters can be enabled by setting "filters" argument in the launch file to a string with the names of the filters, seperated by commas. i.e.:
roslaunch realsense2_camera rs_camera.launch **filters:=spatial,temporal,pointcloud**
Valid options for filters: colorizer, spatial, temporal, pointcloud
Notice that pointcloud can still be enabled with argument enable_pointcloud:=true but as it now uses the official RealSense 2.0 SDK's pipeline, it also is being treated as a filter.

**Known issue:** Since the publishers are indexed with sensor type and sensor index, without regard to sensor format, it is impossible to publish some filters together.
For example, both filters "colorizer" and "pointcloud" use the sensor type "depth" and index 0. The difference being that the first is of format XYZ32F and the second - RGB.