### PR TITLE
Add missing pcl library to tests_camera_core

### DIFF
--- a/realsense_camera/CMakeLists.txt
+++ b/realsense_camera/CMakeLists.txt
@@ -40,6 +40,8 @@ find_package(catkin REQUIRED COMPONENTS
   ${REALSENSE_CATKIN_BASED_DEPS}
 )
 
+find_package(PCL REQUIRED)
+
 add_message_files(
   FILES
   IMUInfo.msg
@@ -130,6 +132,7 @@ if (CATKIN_ENABLE_TESTING)
   target_link_libraries(tests_camera_core
     ${catkin_LIBRARIES}
     ${GTEST_LIBRARIES}
+    ${PCL_LIBRARIES}
     )
   add_dependencies(tests_camera_core ${PROJECT_NAME}_generate_messages_cpp ${PROJECT_NAME}_gencfg)
   add_dependencies(tests_camera_core ${catkin_EXPORTED_TARGETS})


### PR DESCRIPTION
The PR is due to the compile error on Arch Linux.
```
/usr/bin/ld: CMakeFiles/tests_camera_core.dir/test/camera_core.cpp.o: undefined reference to symbol '_ZN3pcl7console5printENS0_15VERBOSITY_LEVELEPKcz'
/usr/bin/ld: /usr/lib/libpcl_common.so.1.8: error adding symbols: DSO missing from command line
```
The cause is that the tests_camera_core module requires `pcl::console::print`, which library `-lpcl_common` is missing in command line. The patch fixes it by adding PCL libraries in cmake.