### PR TITLE
Potential Fix for librealsense2 v2.17.0 Compatilbility

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -54,12 +54,19 @@ namespace realsense2_camera
 
     class NamedFilter
     {
-        public:
-            std::string _name;
-            std::shared_ptr<rs2::filter> _filter;
+        private:
+#if RS2_API_VERSION >= 21700
+            typedef rs2::filter RS2_FilterType;
+#else  // RS2_API_VERSION
+            typedef rs2::processing_block RS2_FilterType;
+#endif // RS2_API_VERSION
 
         public:
-            NamedFilter(std::string name, std::shared_ptr<rs2::filter> filter):
+            std::string _name;
+            std::shared_ptr<RS2_FilterType> _filter;
+
+        public:
+            NamedFilter(std::string name, std::shared_ptr<RS2_FilterType> filter):
             _name(name), _filter(filter)
             {}
     };

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -56,10 +56,10 @@ namespace realsense2_camera
     {
         public:
             std::string _name;
-            std::shared_ptr<rs2::processing_block> _filter;
+            std::shared_ptr<rs2::filter> _filter;
 
         public:
-            NamedFilter(std::string name, std::shared_ptr<rs2::processing_block> filter):
+            NamedFilter(std::string name, std::shared_ptr<rs2::filter> filter):
             _name(name), _filter(filter)
             {}
     };


### PR DESCRIPTION
This commit seems to fix intel-ros/realsense#522 on the SoftWear Automation ROS builds by changing processing_block to filter as documented in the librealsense2 v2.17.0 API change log.