### PR TITLE
fix: wrong reference for the gmock dependency

### DIFF
--- a/ddynamic_reconfigure/package.xml
+++ b/ddynamic_reconfigure/package.xml
@@ -16,5 +16,5 @@
     <depend>roscpp</depend>
 
     <test_depend>rostest</test_depend>
-    <test_depend>gmock</test_depend>
+    <test_depend>google-mock</test_depend>
 </package>

--- a/realsense2_camera/package.xml
+++ b/realsense2_camera/package.xml
@@ -23,7 +23,6 @@
   <build_depend>image_transport</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>ddynamic_reconfigure</build_depend>
-  <build_depend>dddynamic_reconfigure</build_depend>
   <build_depend>diagnostic_updater</build_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>cv_bridge</run_depend>
@@ -35,7 +34,6 @@
   <run_depend>message_runtime</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>ddynamic_reconfigure</run_depend>
-  <run_depend>dddynamic_reconfigure</run_depend>
   <run_depend>diagnostic_updater</run_depend>
   <export>
     <nodelet plugin="${prefix}/nodelet_plugins.xml" />


### PR DESCRIPTION
Additionaly fix: typo(unecessary lines) with dddynamic_reconfigure

The **google-mock** dependency [reference](https://github.com/ros/rosdistro/blob/8f89b25e24045b0a20b2d3a3b65118fc32fc215e/rosdep/base.yaml#L1023).