### PR TITLE
Extract a set of commands that are needed to fill dependency.

### DIFF
--- a/.install_dependency.sh
+++ b/.install_dependency.sh
@@ -6,8 +6,9 @@
 # Codes taken from https://github.com/intel-ros/realsense/blob/c5ea27245967e0938f7d10384f4b7279e01000b4/.travis.yml
 # When used on CI sudo is not usually needed but it is most likely needed when used on your local computer.
 
-echo "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/realsense-public.list
-add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo $(lsb_release -sc) main"
+COMMAND="deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo $(lsb_release -sc) main"
+echo $COMMAND | tee /etc/apt/sources.list.d/realsense-public.list
+add-apt-repository "$COMMAND"
 apt-get update -qq
 apt-get install librealsense2-dkms --allow-unauthenticated -y 
 apt-get install librealsense2-dev --allow-unauthenticated -y

--- a/.install_dependency.sh
+++ b/.install_dependency.sh
@@ -6,7 +6,7 @@
 # Codes taken from https://github.com/intel-ros/realsense/blob/c5ea27245967e0938f7d10384f4b7279e01000b4/.travis.yml
 # When used on CI sudo is not usually needed but it is most likely needed when used on your local computer.
 
-echo 'deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo $(lsb_release -sc) main' | sudo tee /etc/apt/sources.list.d/realsense-public.list
+echo "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/realsense-public.list
 add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo $(lsb_release -sc) main"
 apt-get update -qq
 apt-get install librealsense2-dkms --allow-unauthenticated -y 

--- a/.install_dependency.sh
+++ b/.install_dependency.sh
@@ -6,7 +6,7 @@
 # Codes taken from https://github.com/intel-ros/realsense/blob/c5ea27245967e0938f7d10384f4b7279e01000b4/.travis.yml
 # When used on CI sudo is not usually needed but it is most likely needed when used on your local computer.
 
-echo "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/realsense-public.list
+echo "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/realsense-public.list
 add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo $(lsb_release -sc) main"
 apt-get update -qq
 apt-get install librealsense2-dkms --allow-unauthenticated -y 

--- a/.install_dependency.sh
+++ b/.install_dependency.sh
@@ -6,7 +6,7 @@
 # Codes taken from https://github.com/intel-ros/realsense/blob/c5ea27245967e0938f7d10384f4b7279e01000b4/.travis.yml
 # When used on CI sudo is not usually needed but it is most likely needed when used on your local computer.
 
-echo 'deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo $(lsb_release -sc) main' || sudo tee /etc/apt/sources.list.d/realsense-public.list
+echo 'deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo $(lsb_release -sc) main' | sudo tee /etc/apt/sources.list.d/realsense-public.list
 add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo $(lsb_release -sc) main"
 apt-get update -qq
 apt-get install librealsense2-dkms --allow-unauthenticated -y 

--- a/.install_dependency.sh
+++ b/.install_dependency.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Copyright (c) 2018, PlusOne Robotics Inc. All rights reserved.
+
+# This is a convenience script (hopefully temporary) to install dependency of https://github.com/intel-ros/realsense.
+# Codes taken from https://github.com/intel-ros/realsense/blob/c5ea27245967e0938f7d10384f4b7279e01000b4/.travis.yml
+# When used on CI sudo is not usually needed but it is most likely needed when used on your local computer.
+
+echo 'deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo xenial main' || sudo tee /etc/apt/sources.list.d/realsense-public.list
+add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo xenial main"
+apt-get update -qq
+apt-get install librealsense2-dkms --allow-unauthenticated -y 
+apt-get install librealsense2-dev --allow-unauthenticated -y

--- a/.install_dependency.sh
+++ b/.install_dependency.sh
@@ -6,8 +6,8 @@
 # Codes taken from https://github.com/intel-ros/realsense/blob/c5ea27245967e0938f7d10384f4b7279e01000b4/.travis.yml
 # When used on CI sudo is not usually needed but it is most likely needed when used on your local computer.
 
-echo 'deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo xenial main' || sudo tee /etc/apt/sources.list.d/realsense-public.list
-add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo xenial main"
+echo 'deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo $(lsb_release -sc) main' || sudo tee /etc/apt/sources.list.d/realsense-public.list
+add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo $(lsb_release -sc) main"
 apt-get update -qq
 apt-get install librealsense2-dkms --allow-unauthenticated -y 
 apt-get install librealsense2-dev --allow-unauthenticated -y

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: xenial
 
   # - git clone -v --progress https://github.com/doronhi/realsense.git  # This is Done automatically by TravisCI
 before_install:
-  - ./.install_dependency.sh
+  - sudo ./.install_dependency.sh
   
 install:
   # install ROS:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,7 @@ dist: xenial
 
   # - git clone -v --progress https://github.com/doronhi/realsense.git  # This is Done automatically by TravisCI
 before_install:
-  - echo 'deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo xenial main' || sudo tee /etc/apt/sources.list.d/realsense-public.list
-  # - sudo apt-key adv --keyserver keys.gnupg.net --recv-key C8B3A55A6F3EFCDE || sudo apt-key adv --keyserver hkp://keys.gnupg.net:80 --recv-key C8B3A55A6F3EFCDE
-  - sudo add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo xenial main"
-  - sudo apt-get update -qq
-  - sudo apt-get install librealsense2-dkms --allow-unauthenticated -y 
-  - sudo apt-get install librealsense2-dev --allow-unauthenticated -y
+  - ./.install_dependency.sh
   
 install:
   # install ROS:


### PR DESCRIPTION
# What does this PR do

The portion of commands that installs the dependency on CI can be reusable, not just for CI, so it's worth making them as a self-contained script so that others can easily download and run.

# Review checklist suggested
- CI.
  - [x]  Same commit has already been tested on our private repos on CI.
  - [ ]  CI on this repo pass.
- [ ] Code review.

CC @geoffreychiou 