### PR TITLE
Fixed different transforms between xacro and driver

### DIFF
--- a/realsense2_camera/launch/rs_multiple_devices.launch
+++ b/realsense2_camera/launch/rs_multiple_devices.launch
@@ -5,11 +5,13 @@
   <arg name="camera2"              			default="camera2"/>		<!-- Note: Replace with camera name -->
   <arg name="tf_prefix_camera1"           	default="$(arg camera1)"/>
   <arg name="tf_prefix_camera2"           	default="$(arg camera2)"/>
+  <arg name="initial_reset"         default="false"/>
 
   <group ns="$(arg camera1)">
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
       <arg name="serial_no"     value="$(arg serial_no_camera1)"/>
       <arg name="tf_prefix"		value="$(arg tf_prefix_camera1)"/>
+      <arg name="initial_reset"            value="$(arg initial_reset)"/>
     </include>
   </group>
 

--- a/realsense2_camera/urdf/_d435.urdf.xacro
+++ b/realsense2_camera/urdf/_d435.urdf.xacro
@@ -46,7 +46,7 @@ aluminum peripherial evaluation case.
 
     <link name="camera_link">
       <visual>
-      <origin xyz="${d435_cam_mount_from_center_offset} 0.0 ${d435_cam_height/2}" rpy="${M_PI/2} 0 ${M_PI/2}"/>
+      <origin xyz="0.0 ${-1.0 * d435_cam_depth_py} 0.0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
         <geometry>
           <!-- <box size="${d435_cam_width} ${d435_cam_height} ${d435_cam_depth}"/> -->
 	  <mesh filename="package://realsense2_camera/meshes/d435.dae" />
@@ -56,7 +56,7 @@ aluminum peripherial evaluation case.
         <material name="aluminum"/>
       </visual>
       <collision>
-        <origin xyz="0.0 0.0 ${d435_cam_height/2}" rpy="0 0 0"/>
+        <origin xyz="${-1.0 * d435_cam_depth_px} ${-1.0 * d435_cam_depth_py} 0.0" rpy="0 0 0"/>
         <geometry>
         <box size="${d435_cam_depth} ${d435_cam_width} ${d435_cam_height}"/>
         </geometry>
@@ -71,7 +71,7 @@ aluminum peripherial evaluation case.
    
     <!-- camera depth joints and links -->
     <joint name="camera_depth_joint" type="fixed">
-      <origin xyz="${d435_cam_depth_px} ${d435_cam_depth_py} ${d435_cam_depth_pz}" rpy="0 0 0"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
       <parent link="camera_link"/>
       <child link="camera_depth_frame" />
     </joint>

--- a/realsense2_camera/urdf/_d435.urdf.xacro
+++ b/realsense2_camera/urdf/_d435.urdf.xacro
@@ -41,12 +41,19 @@ aluminum peripherial evaluation case.
     <joint name="camera_joint" type="fixed">
       <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
+      <child link="camera_bottom_screw_frame" />
+    </joint>
+    <link name="camera_bottom_screw_frame"/>
+
+    <joint name="camera_link_joint" type="fixed">
+      <origin xyz="0 ${d435_cam_depth_py} ${d435_cam_depth_pz}" rpy="0 0 0"/>
+      <parent link="camera_bottom_screw_frame"/>
       <child link="camera_link" />
     </joint>
 
     <link name="camera_link">
       <visual>
-      <origin xyz="0.0 ${-1.0 * d435_cam_depth_py} 0.0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
+      <origin xyz="${d435_cam_mount_from_center_offset} ${-d435_cam_depth_py} 0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
         <geometry>
           <!-- <box size="${d435_cam_width} ${d435_cam_height} ${d435_cam_depth}"/> -->
 	  <mesh filename="package://realsense2_camera/meshes/d435.dae" />

--- a/realsense2_camera/urdf/_d435.urdf.xacro
+++ b/realsense2_camera/urdf/_d435.urdf.xacro
@@ -63,7 +63,7 @@ aluminum peripherial evaluation case.
         <material name="aluminum"/>
       </visual>
       <collision>
-        <origin xyz="${-1.0 * d435_cam_depth_px} ${-1.0 * d435_cam_depth_py} 0.0" rpy="0 0 0"/>
+        <origin xyz="0 ${-d435_cam_depth_py} 0" rpy="0 0 0"/>
         <geometry>
         <box size="${d435_cam_depth} ${d435_cam_width} ${d435_cam_height}"/>
         </geometry>


### PR DESCRIPTION
This fixes #469 and #497 

The d435 URDF had an error where there was a non-zero transform for camera_link but the driver output a zero origin for this link. This caused the transforms to shift between starting a robot description and starting the driver. This commit brings the transforms in line with the driver while keeping the visual and collision geometry the same. 