### PR TITLE
Remove gencfg dependency

### DIFF
--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -85,7 +85,6 @@ add_library(${PROJECT_NAME}
 
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_generate_messages_cpp)
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
-add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
 
 
 target_include_directories(${PROJECT_NAME}


### PR DESCRIPTION
Now with ddynamic_reconfigure being the backend for dynamic reconfigurability, the ${PROJECT_NAME}_gencfg target doesn't exist anymore and this dependency can be removed.

When running `catkin_make <TAB> <TAB>` the `..._gencfg` target doesn't show up:
```
realsense2
realsense2_camera
realsense2_camera_gencpp
realsense2_camera_generate_messages
realsense2_camera_generate_messages_cpp
realsense2_camera_generate_messages_eus
realsense2_camera_generate_messages_lisp
realsense2_camera_generate_messages_nodejs
realsense2_camera_generate_messages_py
realsense2_camera_geneus
realsense2_camera_genlisp
realsense2_camera_gennodejs
realsense2_camera_genpy
```