### PR TITLE
fix the aligned depth frame unit conversion issue again

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -653,6 +653,19 @@ void BaseRealSenseNode::publishAlignedDepthToOthers(rs2::frameset frames, const 
             rs2::frameset processed = frames.apply_filter(align);
             rs2::depth_frame aligned_depth_frame = processed.get_depth_frame();
 
+            static const auto meter_to_mm = 0.001f;
+            int width = aligned_depth_frame.get_width();
+            int height = aligned_depth_frame.get_height();
+            uint16_t* p_depth_frame = reinterpret_cast<uint16_t*>(const_cast<void*>(aligned_depth_frame.get_data()));
+            for (int y=0; y<height; ++y)
+            {
+                for (int x=0; x<width; ++x)
+                {
+                    p_depth_frame[y*width+x] *= _depth_scale_meters / meter_to_mm;
+                }
+
+            }
+
             publishFrame(aligned_depth_frame, t, sip,
                          _depth_aligned_image,
                          _depth_aligned_info_publisher,


### PR DESCRIPTION
When I run roslaunch realsense2_camera rs_rgbd.launch and examine the pointcloud published on in RViz, the points appear to be projected incorrectly (about 8 times larger than the correct size).

* Environment info:
    - Camera: SR300
    - ROS: kinetic
    - librealsense: v2.18.1
    - realsense_ros: 2.1.4

This issue was reported in following issues and solved in tag 2.0.4 of realsense(ros):
* depth_registered pointcloud has incorrect depth scaling #332
* fix the aligned depth frame unit conversion issue #367

But the same problem occurred again from tag 2.1.1 of realsense(ros).
I think refactoring in tag 2.1.0 is the cause of this problem.

I made a pull request to fix this problem, so please approve it.