### PR TITLE
TM265

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cd ~/catkin_ws/src/
 - Clone the latest Intel&reg; RealSense&trade; ROS from [here](https://github.com/intel-ros/realsense/releases) into 'catkin_ws/src/'
 
 ```bash
-catkin_init_workspace 
+catkin_init_workspace
 cd ..
 catkin_make clean
 catkin_make -DCATKIN_ENABLE_TESTING=False -DCMAKE_BUILD_TYPE=Release
@@ -37,12 +37,7 @@ source ~/.bashrc
 ## Usage Instructions
 
 ### Start the camera node
-To start the camera node in ROS, install rgbd_launch:
-
-```bash
-sudo apt-get install ros-kinetic-rgbd-launch
-```
-Then type:
+To start the camera node in ROS:
 
 ```bash
 roslaunch realsense2_camera rs_camera.launch
@@ -52,17 +47,71 @@ This will stream all camera sensors and publish on the appropriate ROS topics.
 
 Other stream resolutions and frame rates can optionally be provided as parameters to the 'rs_camera.launch' file.
 
+### Published Topics
+The published topics differ according to the device and parameters.
+After running the above command with D435i attached, the following list of topics will be available (This is a partial list. For full one type `rostopic list`):
+- /camera/color/camera_info
+- /camera/color/image_raw
+- /camera/depth/camera_info
+- /camera/depth/image_rect_raw
+- /camera/extrinsics/depth_to_color
+- /camera/extrinsics/depth_to_infra1
+- /camera/extrinsics/depth_to_infra2
+- /camera/infra1/camera_info
+- /camera/infra1/image_rect_raw
+- /camera/infra2/camera_info
+- /camera/infra2/image_rect_raw
+- /camera/gyro/imu_info
+- /camera/gyro/sample
+- /camera/accel/imu_info
+- /camera/accel/sample
+
+The "/camera" prefix is the default and can be changed. Check the rs_multiple_devices.launch file for an example.
+If using D435 or D415, the gyro and accel topics wont be available. Likewise, other topics will be available when using TM265 (see below).
+
+### Launch parameters
+The following parameters are available by the wrapper:
+- **serial_no**: will attach to the device with the given serial number. Default, attach to available RealSense device in random.
+- **rosbag_filename**: Will publish topics from rosbag file.
+- enable_tm2: if set to true Will wait on start until the TM265 device is ready.
+- **initial_reset**: On occasions the device was not closed properly and due to firmware issues needs to reset. If set to true, the device will reset prior to usage.
+- **align_depth**: If set to true, will publish additional topics with the all the images aligned to the depth image.</br>
+The topics are of the form: ```/camera/aligned_depth_to_color/image_raw``` etc.
+- **filters**: any of the following options, separated by commas:</br>
+ - ```colorizer```: will color the depth image. On the depth topic an RGB image will be published, instead of the 16bit depth values .
+ - ```pointcloud```: will add a pointcloud topic `/camera/depth/color/points`. The texture of the pointcloud can be modified in rqt_reconfigure (see below) or using the parameters: `pointcloud_texture_stream` and `pointcloud_texture_index`. Run rqt_reconfigure to see available values for these parameters.
+ - The following filters have detailed descriptions in : https://github.com/IntelRealSense/librealsense/blob/master/doc/post-processing-filters.md
+   - ```disparity```
+   - ```spatial```
+   - ```temporal```
+   - ```decimation```
+- **enable_sync**: gathers closest frames of different sensors, infra red, color and depth, to be sent with the same timetag. This happens automatically when such filters as pointcloud are enabled.
+- ***<stream_type>*_width**, ***<stream_type>*_height**, ***<stream_type>*_fps**: <stream_type> can be any of *infra, color, fisheye, depth, gyro, accel, pose*. Sets the required format of the device. If the specified combination of parameters is not available by the device, the stream will not be published. Setting a value to 0, will choose the first format in the inner list. (i.e. consistent between runs but not defined). Note: for gyro accel and pose, only _fps option is meaningful.
+- **enable_*<stream_name>***: Choose whether to enable a specified stream or not. Default is true. <stream_name> can be any of *infra1, infra2, color, depth, fisheye, fisheye1, fisheye2, gyro, accel, pose*.
+- **tf_prefix**: By default all frame's ids have the same prefix - `camera_`. This allows changing it per camera.
+- **base_frame_id**: defines the frame_id all static transformations refers to.
+- **spatial_frame_id**: defines the frame_id that `pose` topic refers to.
+- **All the rest of the frame_ids can be found in the template launch file: [nodelet.launch.xml](./realsense2_camera/launch/includes/nodelet.launch.xml)**
+- **unite_imu_method**: The D435i and TM265 cameras have built in IMU components which produce 2 unrelated streams: *gyro* - which shows angular velocity and *accel* which shows linear acceleration. Each with it's own frequency. By default, 2 corresponding topics are available, each with only the relevant fields of the message sensor_msgs::Imu are filled out.
+Setting *unite_imu_method* creates a new topic, *imu*, that replaces the default *gyro* and *accel* topics. Under the new topic, all the fields in the Imu message are filled out.
+ - linear_interpolation: Each message contains the last original value of item A interpolated with the previous value of item A, combined with the last original value of item B on last item B's timestamp. (items A and B are accel and gyro but without specific)
+ - copy: For each new message, accel or gyro, the relevant fields and timestamp are filled out while the others maintain the previous data.
+- **clip_distance**: remove from the depth image all values above a given value (meters). Disable by giving negative value (default)
+- **linear_accel_cov**, **angular_velocity_cov**: sets the variance given to the Imu readings. For the TM265, these values are being modified by the inner confidence value.
+- **hold_back_imu_for_frames**: Images processing takes time. Therefor there is a time gap between the moment the image arrives at the wrapper and the moment the image is published to the ROS environment. During this time, Imu messages keep on arriving and a situation is created where an image with earlier timestamp is published after Imu message with later timestamp. If that is a problem, setting *hold_back_imu_for_frames* to *true* will hold the Imu messages back while processing the images and then publish them all in a burst, thus keeping the order of publication as the order of arrival. Note that in either case, the timestamp in each message's header reflects the time of it's origin.
+
 ### RGBD Point Cloud
 Here is an example of how to start the camera node and make it publish the RGBD point cloud using aligned depth topic.
 ```bash
-roslaunch realsense2_camera rs_rgbd.launch
+roslaunch realsense2_camera rs_camera.launch filters:=pointcloud
 ```
+Then open rviz to watch the pointcloud:
 <p align="center"><img src="https://user-images.githubusercontent.com/17433152/35396613-ddcb1d6c-01f5-11e8-8887-4debf178d0cc.gif" /></p>
 
 ### Aligned Depth Frames
 Here is an example of how to start the camera node and make it publish the aligned depth stream to other available streams such as color or infra-red.
 ```bash
-roslaunch realsense2_camera rs_aligned_depth.launch
+roslaunch realsense2_camera rs_camera.launch align_depth:=true
 ```
 <p align="center"><img width=50% src="https://user-images.githubusercontent.com/17433152/35343104-6eede0f0-0132-11e8-8866-e6c7524dd079.png" /></p>
 
@@ -79,8 +128,11 @@ Here is an example of how to start the camera node and streaming with two camera
 roslaunch realsense2_camera rs_multiple_devices.launch serial_no_camera1:=<serial number of the first camera> serial_no_camera2:=<serial number of the second camera>
 ```
 The camera serial number should be provided to `serial_no_camera1` and `serial_no_camera2` parameters. One way to get the serial number is from the [rs-enumerate-devices](https://github.com/IntelRealSense/librealsense/blob/58d99783cc2781b1026eeed959aa3f7b562b20ca/tools/enumerate-devices/readme.md) tool.
+```bash
+rs-enumerate-devices | grep Serial
+```
 
-Another war of obtaining the serial number is connecting the camera alone, running 
+Another way of obtaining the serial number is connecting the camera alone, running
 ```bash
 roslaunch realsense2_camera rs_camera.launch
 ```
@@ -108,6 +160,19 @@ to activate the filters, use the argument "filters" and deperate them with a com
 ```bash
 roslaunch realsense2_camera rs_camera.launch filters:=temporal,spatial,pointcloud
 ```
+
+## Using TM265 ##
+When using TM265 Tracking Module you should specify it with a parameter `enable_tm2` as is set in the following launch file:
+```bash
+roslaunch realsense2_camera rs_tm260.launch
+```
+The TM265 sets its usb unique ID during initialization and without this parameter it wont be found.
+Once running it will publish, among others, the following topics:
+- /camera/odom/sample
+- /camera/accel/sample
+- /camera/gyro/sample
+- /camera/fisheye1/image_raw
+- /camera/fisheye2/image_raw
 
 
 ## Packages using RealSense ROS Camera

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -107,6 +107,7 @@ namespace realsense2_camera
         rs2::device _dev;
         ros::NodeHandle& _node_handle, _pnh;
         std::map<stream_index_pair, rs2::sensor> _sensors;
+        std::map<std::string, std::function<void(rs2::frame)>> _sensors_callback;
         std::vector<std::shared_ptr<ddynamic_reconfigure::DDynamicReconfigure>> _ddynrec;
 
     private:
@@ -214,6 +215,7 @@ namespace realsense2_camera
         static void ConvertFromOpticalFrameToFrame(float3& data);
         void imu_callback(rs2::frame frame);
         void imu_callback_sync(rs2::frame frame, imu_sync_method sync_method=imu_sync_method::COPY);
+        void frame_callback(rs2::frame frame);
         void registerDynamicOption(ros::NodeHandle& nh, rs2::options sensor, std::string& module_name);
         rs2_stream rs2_string_to_stream(std::string str);
 
@@ -264,6 +266,7 @@ namespace realsense2_camera
         PipelineSyncer _syncer;
         std::vector<NamedFilter> _filters;
         std::vector<rs2::sensor> _dev_sensors;
+        std::map<rs2_stream, std::shared_ptr<rs2::align>> _align;
 
         std::map<stream_index_pair, cv::Mat> _depth_aligned_image;
         std::map<rs2_stream, std::string> _depth_aligned_encoding;

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -9,6 +9,11 @@
 
 #include <diagnostic_updater/diagnostic_updater.h>
 #include <diagnostic_updater/update_functions.h>
+#include <sensor_msgs/CameraInfo.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <sensor_msgs/point_cloud2_iterator.h>
+#include <sensor_msgs/Imu.h>
+#include <nav_msgs/Odometry.h>
 
 #include <queue>
 #include <mutex>
@@ -215,6 +220,8 @@ namespace realsense2_camera
         static void ConvertFromOpticalFrameToFrame(float3& data);
         void imu_callback(rs2::frame frame);
         void imu_callback_sync(rs2::frame frame, imu_sync_method sync_method=imu_sync_method::COPY);
+        void pose_callback(rs2::frame frame);
+        void multiple_message_callback(rs2::frame frame, imu_sync_method sync_method);
         void frame_callback(rs2::frame frame);
         void registerDynamicOption(ros::NodeHandle& nh, rs2::options sensor, std::string& module_name);
         rs2_stream rs2_string_to_stream(std::string str);
@@ -239,7 +246,6 @@ namespace realsense2_camera
         std::map<stream_index_pair, ros::Publisher> _imu_publishers;
         std::shared_ptr<SyncedImuPublisher> _synced_imu_publisher;
         std::map<rs2_stream, int> _image_format;
-        std::map<rs2_stream, rs2_format> _format;
         std::map<stream_index_pair, ros::Publisher> _info_publisher;
         std::map<stream_index_pair, cv::Mat> _image;
         std::map<rs2_stream, std::string> _encoding;

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -252,6 +252,7 @@ namespace realsense2_camera
         std::map<stream_index_pair, std::vector<uint8_t>> _aligned_depth_images;
 
         std::string _base_frame_id;
+        std::string _spatial_frame_id;
         std::map<stream_index_pair, std::string> _frame_id;
         std::map<stream_index_pair, std::string> _optical_frame_id;
         std::map<stream_index_pair, int> _seq;

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -12,6 +12,7 @@
 
 #include <queue>
 #include <mutex>
+#include <atomic>
 
 namespace realsense2_camera
 {
@@ -178,6 +179,7 @@ namespace realsense2_camera
         void enable_devices();
         void setupFilters();
         void setupStreams();
+        void setBaseTime(double frame_time, bool warn_no_metadata);
         void clip_depth(rs2::depth_frame& depth_frame, float depth_scale, float clipping_dist);
         void updateStreamCalibData(const rs2::video_stream_profile& video_profile);
         tf::Quaternion rotationMatrixToQuaternion(const float rotation[9]) const;
@@ -186,6 +188,7 @@ namespace realsense2_camera
                                const quaternion& q,
                                const std::string& from,
                                const std::string& to);
+        void calcAndPublishStaticTransform(const stream_index_pair& stream, const rs2::stream_profile& base_profile);
         void publishStaticTransforms();
         void publishPointCloud(rs2::points f, const ros::Time& t, const rs2::frameset& frameset);
         Extrinsics rsExtrinsicsToMsg(const rs2_extrinsics& extrinsics, const std::string& frame_id) const;
@@ -200,12 +203,9 @@ namespace realsense2_camera
                           std::map<stream_index_pair, int>& seq,
                           std::map<stream_index_pair, sensor_msgs::CameraInfo>& camera_info,
                           const std::map<stream_index_pair, std::string>& optical_frame_id,
-                          const std::map<stream_index_pair, std::string>& encoding,
+                          const std::map<rs2_stream, std::string>& encoding,
                           bool copy_data_from_frame = true);
         bool getEnabledProfile(const stream_index_pair& stream_index, rs2::stream_profile& profile);
-
-        void updateIsFrameArrived(std::map<stream_index_pair, bool>& is_frame_arrived,
-                                  rs2_stream stream_type, int stream_index);
 
         void publishAlignedDepthToOthers(rs2::frameset frames, const ros::Time& t);
         static void callback(const ddynamic_reconfigure::DDMap& map, int, rs2::options sensor);
@@ -230,26 +230,26 @@ namespace realsense2_camera
         std::map<stream_index_pair, int> _height;
         std::map<stream_index_pair, int> _fps;
         std::map<stream_index_pair, bool> _enable;
-        std::map<stream_index_pair, std::string> _stream_name;
+        std::map<rs2_stream, std::string> _stream_name;
         tf2_ros::StaticTransformBroadcaster _static_tf_broadcaster;
 
         std::map<stream_index_pair, ImagePublisherWithFrequencyDiagnostics> _image_publishers;
         std::map<stream_index_pair, ros::Publisher> _imu_publishers;
         std::shared_ptr<SyncedImuPublisher> _synced_imu_publisher;
-        std::map<stream_index_pair, int> _image_format;
-        std::map<stream_index_pair, rs2_format> _format;
+        std::map<rs2_stream, int> _image_format;
+        std::map<rs2_stream, rs2_format> _format;
         std::map<stream_index_pair, ros::Publisher> _info_publisher;
         std::map<stream_index_pair, cv::Mat> _image;
-        std::map<stream_index_pair, std::string> _encoding;
+        std::map<rs2_stream, std::string> _encoding;
         std::map<stream_index_pair, std::vector<uint8_t>> _aligned_depth_images;
 
         std::string _base_frame_id;
         std::map<stream_index_pair, std::string> _frame_id;
         std::map<stream_index_pair, std::string> _optical_frame_id;
         std::map<stream_index_pair, int> _seq;
-        std::map<stream_index_pair, int> _unit_step_size;
+        std::map<rs2_stream, int> _unit_step_size;
         std::map<stream_index_pair, sensor_msgs::CameraInfo> _camera_info;
-        bool _intialize_time_base;
+        std::atomic_bool _is_initialized_time_base;
         double _camera_time_base;
         std::map<stream_index_pair, std::vector<rs2::stream_profile>> _enabled_profiles;
 
@@ -266,7 +266,7 @@ namespace realsense2_camera
         std::vector<rs2::sensor> _dev_sensors;
 
         std::map<stream_index_pair, cv::Mat> _depth_aligned_image;
-        std::map<stream_index_pair, std::string> _depth_aligned_encoding;
+        std::map<rs2_stream, std::string> _depth_aligned_encoding;
         std::map<stream_index_pair, sensor_msgs::CameraInfo> _depth_aligned_camera_info;
         std::map<stream_index_pair, int> _depth_aligned_seq;
         std::map<stream_index_pair, ros::Publisher> _depth_aligned_info_publisher;
@@ -275,7 +275,6 @@ namespace realsense2_camera
         std::map<stream_index_pair, ros::Publisher> _depth_to_other_extrinsics_publishers;
         std::map<stream_index_pair, rs2_extrinsics> _depth_to_other_extrinsics;
 
-        std::map<stream_index_pair, bool> _is_frame_arrived;
         const std::string _namespace;
 
     };//end class

--- a/realsense2_camera/include/constants.h
+++ b/realsense2_camera/include/constants.h
@@ -56,6 +56,7 @@ namespace realsense2_camera
 
 
     const std::string DEFAULT_BASE_FRAME_ID            = "camera_link";
+    const std::string DEFAULT_SPATIAL_FRAME_ID         = "spatial";
     const std::string DEFAULT_DEPTH_FRAME_ID           = "camera_depth_frame";
     const std::string DEFAULT_INFRA1_FRAME_ID          = "camera_infra1_frame";
     const std::string DEFAULT_INFRA2_FRAME_ID          = "camera_infra2_frame";

--- a/realsense2_camera/include/constants.h
+++ b/realsense2_camera/include/constants.h
@@ -43,8 +43,7 @@ namespace realsense2_camera
     const int IMAGE_HEIGHT    = 480;
     const int IMAGE_FPS       = 30;
 
-    const int GYRO_FPS        = 400;
-    const int ACCEL_FPS       = 250;
+    const int IMU_FPS         = 0;
 
 
     const bool ENABLE_DEPTH   = true;

--- a/realsense2_camera/include/constants.h
+++ b/realsense2_camera/include/constants.h
@@ -30,34 +30,19 @@ namespace realsense2_camera
     const uint16_t RS430_MM_RGB_PID = 0x0b01; // AWGCT
     const uint16_t RS460_PID        = 0x0b03; // DS5U
     const uint16_t RS435_RGB_PID    = 0x0b07; // AWGC
-    const uint16_t RS435i_RGB_PID    = 0x0B3A; // AWGC_MM
+    const uint16_t RS435i_RGB_PID   = 0x0B3A; // AWGC_MM
     const uint16_t RS405_PID        = 0x0b0c; // DS5U
+    const uint16_t RS_T265_PID      = 0x0b37; // 
+    
 
     const bool ALIGN_DEPTH    = false;
     const bool POINTCLOUD     = false;
     const bool SYNC_FRAMES    = false;
 
-    const int DEPTH_WIDTH     = 640;
-    const int DEPTH_HEIGHT    = 480;
+    const int IMAGE_WIDTH     = 640;
+    const int IMAGE_HEIGHT    = 480;
+    const int IMAGE_FPS       = 30;
 
-    const int INFRA1_WIDTH    = 640;
-    const int INFRA1_HEIGHT   = 480;
-
-    const int INFRA2_WIDTH    = 640;
-    const int INFRA2_HEIGHT   = 480;
-
-    const int COLOR_WIDTH     = 640;
-    const int COLOR_HEIGHT    = 480;
-
-    const int FISHEYE_WIDTH   = 640;
-    const int FISHEYE_HEIGHT  = 480;
-
-
-    const int DEPTH_FPS       = 30;
-    const int INFRA1_FPS      = 30;
-    const int INFRA2_FPS      = 30;
-    const int COLOR_FPS       = 30;
-    const int FISHEYE_FPS     = 30;
     const int GYRO_FPS        = 400;
     const int ACCEL_FPS       = 250;
 

--- a/realsense2_camera/include/realsense_node_factory.h
+++ b/realsense2_camera/include/realsense_node_factory.h
@@ -33,12 +33,15 @@ namespace realsense2_camera
     const stream_index_pair INFRA1{RS2_STREAM_INFRARED, 1};
     const stream_index_pair INFRA2{RS2_STREAM_INFRARED, 2};
     const stream_index_pair FISHEYE{RS2_STREAM_FISHEYE, 0};
+    const stream_index_pair FISHEYE1{RS2_STREAM_FISHEYE, 1};
+    const stream_index_pair FISHEYE2{RS2_STREAM_FISHEYE, 2};
     const stream_index_pair GYRO{RS2_STREAM_GYRO, 0};
     const stream_index_pair ACCEL{RS2_STREAM_ACCEL, 0};
 
     const std::vector<std::vector<stream_index_pair>> IMAGE_STREAMS = {{{DEPTH, INFRA1, INFRA2},
                                                                         {COLOR},
-                                                                        {FISHEYE}}};
+                                                                        {FISHEYE},
+                                                                        {FISHEYE1, FISHEYE2}}};
 
     const std::vector<std::vector<stream_index_pair>> HID_STREAMS = {{GYRO, ACCEL}};
 
@@ -58,7 +61,8 @@ namespace realsense2_camera
 
     private:
         static void signalHandler(int signum);
-        rs2::device getDevice(std::string& serial_no);
+        rs2::device getDevice(std::string& serial_no, bool shutdown_on_failure=true);
+        void waitForDevice(rs2::device& dev);
         virtual void onInit() override;
         void tryGetLogSeverity(rs2_log_severity& severity) const;
 

--- a/realsense2_camera/include/realsense_node_factory.h
+++ b/realsense2_camera/include/realsense_node_factory.h
@@ -13,14 +13,10 @@
 #include <librealsense2/hpp/rs_processing.hpp>
 #include <librealsense2/rs_advanced_mode.hpp>
 #include <cv_bridge/cv_bridge.h>
-#include <sensor_msgs/CameraInfo.h>
-#include <sensor_msgs/PointCloud2.h>
-#include <sensor_msgs/point_cloud2_iterator.h>
 #include <constants.h>
 #include <realsense2_camera/Extrinsics.h>
 #include <tf/transform_broadcaster.h>
 #include <tf2_ros/static_transform_broadcaster.h>
-#include <sensor_msgs/Imu.h>
 #include <realsense2_camera/IMUInfo.h>
 #include <csignal>
 #include <eigen3/Eigen/Geometry>
@@ -37,13 +33,15 @@ namespace realsense2_camera
     const stream_index_pair FISHEYE2{RS2_STREAM_FISHEYE, 2};
     const stream_index_pair GYRO{RS2_STREAM_GYRO, 0};
     const stream_index_pair ACCEL{RS2_STREAM_ACCEL, 0};
+    const stream_index_pair POSE{RS2_STREAM_POSE, 0};
+    
 
-    const std::vector<std::vector<stream_index_pair>> IMAGE_STREAMS = {{{DEPTH, INFRA1, INFRA2},
-                                                                        {COLOR},
-                                                                        {FISHEYE},
-                                                                        {FISHEYE1, FISHEYE2}}};
+    const std::vector<stream_index_pair> IMAGE_STREAMS = {DEPTH, INFRA1, INFRA2,
+                                                          COLOR,
+                                                          FISHEYE,
+                                                          FISHEYE1, FISHEYE2};
 
-    const std::vector<std::vector<stream_index_pair>> HID_STREAMS = {{GYRO, ACCEL}};
+    const std::vector<stream_index_pair> HID_STREAMS = {GYRO, ACCEL, POSE};
 
     class InterfaceRealSenseNode
     {

--- a/realsense2_camera/launch/demo_pointcloud.launch
+++ b/realsense2_camera/launch/demo_pointcloud.launch
@@ -18,7 +18,8 @@
       <arg name="enable_infra1"     value="false"/>
       <arg name="enable_infra2"     value="false"/>
       <arg name="enable_fisheye"    value="false"/>
-      <arg name="enable_imu"        value="false"/>
+      <arg name="enable_gyro"       value="false"/>
+      <arg name="enable_accel"      value="false"/>
       <arg name="enable_pointcloud" value="true"/>
       <arg name="enable_sync"       value="true"/>
       <arg name="tf_prefix"         value="$(arg camera)"/>

--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -5,8 +5,8 @@
   <arg name="json_file_path"      default=""/>
   <arg name="rosbag_filename"     default=""/>
 
-  <arg name="fisheye_width"       default="640"/>
-  <arg name="fisheye_height"      default="480"/>
+  <arg name="fisheye_width"       default="0"/>
+  <arg name="fisheye_height"      default="0"/>
   <arg name="enable_fisheye"      default="true"/>
 
   <arg name="depth_width"         default="640"/>
@@ -26,8 +26,8 @@
   <arg name="depth_fps"           default="30"/>
   <arg name="infra_fps"           default="30"/>
   <arg name="color_fps"           default="30"/>
-  <arg name="gyro_fps"            default="400"/>
-  <arg name="accel_fps"           default="250"/>
+  <arg name="gyro_fps"            default="0"/>
+  <arg name="accel_fps"           default="0"/>
   <arg name="enable_gyro"         default="true"/>
   <arg name="enable_accel"        default="true"/>
   <arg name="enable_tm2"          default="false"/>
@@ -39,24 +39,37 @@
   <arg name="enable_sync"         default="false"/>
   <arg name="align_depth"         default="false"/>
 
-  <arg name="base_frame_id"            default="$(arg tf_prefix)_link"/>
-  <arg name="depth_frame_id"           default="$(arg tf_prefix)_depth_frame"/>
-  <arg name="infra1_frame_id"          default="$(arg tf_prefix)_infra1_frame"/>
-  <arg name="infra2_frame_id"          default="$(arg tf_prefix)_infra2_frame"/>
-  <arg name="color_frame_id"           default="$(arg tf_prefix)_color_frame"/>
+  <arg name="base_frame_id"             default="$(arg tf_prefix)_link"/>
+  <arg name="depth_frame_id"            default="$(arg tf_prefix)_depth_frame"/>
+  <arg name="infra1_frame_id"           default="$(arg tf_prefix)_infra1_frame"/>
+  <arg name="infra2_frame_id"           default="$(arg tf_prefix)_infra2_frame"/>
+  <arg name="color_frame_id"            default="$(arg tf_prefix)_color_frame"/>
+  <arg name="fisheye_frame_id"          default="$(arg tf_prefix)_fisheye_frame"/>
+  <arg name="fisheye1_frame_id"         default="$(arg tf_prefix)_fisheye1_frame"/>
+  <arg name="fisheye2_frame_id"         default="$(arg tf_prefix)_fisheye2_frame"/>
+  <arg name="accel_frame_id"            default="$(arg tf_prefix)_accel_frame"/>
+  <arg name="gyro_frame_id"             default="$(arg tf_prefix)_gyro_frame"/>
+  <arg name="pose_frame_id"             default="$(arg tf_prefix)_pose_frame"/>
 
-  <arg name="depth_optical_frame_id"   default="$(arg tf_prefix)_depth_optical_frame"/>
-  <arg name="infra1_optical_frame_id"  default="$(arg tf_prefix)_infra1_optical_frame"/>
-  <arg name="infra2_optical_frame_id"  default="$(arg tf_prefix)_infra2_optical_frame"/>
-  <arg name="color_optical_frame_id"   default="$(arg tf_prefix)_color_optical_frame"/>
-  <arg name="fisheye_optical_frame_id" default="$(arg tf_prefix)_fisheye_optical_frame"/>
-  <arg name="accel_optical_frame_id"   default="$(arg tf_prefix)_accel_optical_frame"/>
-  <arg name="gyro_optical_frame_id"    default="$(arg tf_prefix)_gyro_optical_frame"/>
+  <arg name="depth_optical_frame_id"    default="$(arg tf_prefix)_depth_optical_frame"/>
+  <arg name="infra1_optical_frame_id"   default="$(arg tf_prefix)_infra1_optical_frame"/>
+  <arg name="infra2_optical_frame_id"   default="$(arg tf_prefix)_infra2_optical_frame"/>
+  <arg name="color_optical_frame_id"    default="$(arg tf_prefix)_color_optical_frame"/>
+  <arg name="fisheye_optical_frame_id"  default="$(arg tf_prefix)_fisheye_optical_frame"/>
+  <arg name="fisheye1_optical_frame_id" default="$(arg tf_prefix)_fisheye1_optical_frame"/>
+  <arg name="fisheye2_optical_frame_id" default="$(arg tf_prefix)_fisheye2_optical_frame"/>
+  <arg name="accel_optical_frame_id"    default="$(arg tf_prefix)_accel_optical_frame"/>
+  <arg name="gyro_optical_frame_id"     default="$(arg tf_prefix)_gyro_optical_frame"/>
+  <arg name="pose_optical_frame_id"     default="$(arg tf_prefix)_pose_optical_frame"/>
 
-  <arg name="aligned_depth_to_color_frame_id"   default="$(arg tf_prefix)_aligned_depth_to_color_frame"/>
-  <arg name="aligned_depth_to_infra1_frame_id" default="$(arg tf_prefix)_aligned_depth_to_infra1_frame"/>
+  <arg name="aligned_depth_to_color_frame_id"    default="$(arg tf_prefix)_aligned_depth_to_color_frame"/>
+  <arg name="aligned_depth_to_infra1_frame_id"   default="$(arg tf_prefix)_aligned_depth_to_infra1_frame"/>
   <arg name="aligned_depth_to_infra2_frame_id"   default="$(arg tf_prefix)_aligned_depth_to_infra2_frame"/>
-  <arg name="aligned_depth_to_fisheye_frame_id"    default="$(arg tf_prefix)_aligned_depth_to_fisheye_frame"/>
+  <arg name="aligned_depth_to_fisheye_frame_id"  default="$(arg tf_prefix)_aligned_depth_to_fisheye_frame"/>
+  <arg name="aligned_depth_to_fisheye1_frame_id" default="$(arg tf_prefix)_aligned_depth_to_fisheye1_frame"/>
+  <arg name="aligned_depth_to_fisheye2_frame_id" default="$(arg tf_prefix)_aligned_depth_to_fisheye2_frame"/>
+
+  <arg name="spatial_frame_id"        default="$(arg tf_prefix)_spatial"/>
 
   <arg name="filters"                  default=""/>
   <arg name="clip_distance"            default="-1"/>
@@ -109,19 +122,32 @@
     <param name="infra1_frame_id"          type="str"  value="$(arg infra1_frame_id)"/>
     <param name="infra2_frame_id"          type="str"  value="$(arg infra2_frame_id)"/>
     <param name="color_frame_id"           type="str"  value="$(arg color_frame_id)"/>
+    <param name="fisheye_frame_id"         type="str"  value="$(arg fisheye_frame_id)"/>
+    <param name="fisheye1_frame_id"        type="str"  value="$(arg fisheye1_frame_id)"/>
+    <param name="fisheye2_frame_id"        type="str"  value="$(arg fisheye2_frame_id)"/>
+    <param name="accel_frame_id"           type="str"  value="$(arg accel_frame_id)"/>
+    <param name="gyro_frame_id"            type="str"  value="$(arg gyro_frame_id)"/>
+    <param name="pose_frame_id"            type="str"  value="$(arg pose_frame_id)"/>
 
-    <param name="depth_optical_frame_id"   type="str"  value="$(arg depth_optical_frame_id)"/>
-    <param name="infra1_optical_frame_id"  type="str"  value="$(arg infra1_optical_frame_id)"/>
-    <param name="infra2_optical_frame_id"  type="str"  value="$(arg infra2_optical_frame_id)"/>
-    <param name="color_optical_frame_id"   type="str"  value="$(arg color_optical_frame_id)"/>
-    <param name="fisheye_optical_frame_id" type="str"  value="$(arg fisheye_optical_frame_id)"/>
-    <param name="accel_optical_frame_id"   type="str"  value="$(arg accel_optical_frame_id)"/>
-    <param name="gyro_optical_frame_id"    type="str"  value="$(arg gyro_optical_frame_id)"/>
+    <param name="depth_optical_frame_id"    type="str"  value="$(arg depth_optical_frame_id)"/>
+    <param name="infra1_optical_frame_id"   type="str"  value="$(arg infra1_optical_frame_id)"/>
+    <param name="infra2_optical_frame_id"   type="str"  value="$(arg infra2_optical_frame_id)"/>
+    <param name="color_optical_frame_id"    type="str"  value="$(arg color_optical_frame_id)"/>
+    <param name="fisheye_optical_frame_id"  type="str"  value="$(arg fisheye_optical_frame_id)"/>
+    <param name="fisheye1_optical_frame_id" type="str"  value="$(arg fisheye1_optical_frame_id)"/>
+    <param name="fisheye2_optical_frame_id" type="str"  value="$(arg fisheye2_optical_frame_id)"/>
+    <param name="accel_optical_frame_id"    type="str"  value="$(arg accel_optical_frame_id)"/>
+    <param name="gyro_optical_frame_id"     type="str"  value="$(arg gyro_optical_frame_id)"/>
+    <param name="pose_optical_frame_id"     type="str"  value="$(arg pose_optical_frame_id)"/>
 
-    <param name="aligned_depth_to_color_frame_id"   type="str"  value="$(arg aligned_depth_to_color_frame_id)"/>
-    <param name="aligned_depth_to_infra1_frame_id"  type="str"  value="$(arg aligned_depth_to_infra1_frame_id)"/>
-    <param name="aligned_depth_to_infra2_frame_id"  type="str"  value="$(arg aligned_depth_to_infra2_frame_id)"/>
-    <param name="aligned_depth_to_fisheye_frame_id" type="str"  value="$(arg aligned_depth_to_fisheye_frame_id)"/>
+    <param name="aligned_depth_to_color_frame_id"    type="str"  value="$(arg aligned_depth_to_color_frame_id)"/>
+    <param name="aligned_depth_to_infra1_frame_id"   type="str"  value="$(arg aligned_depth_to_infra1_frame_id)"/>
+    <param name="aligned_depth_to_infra2_frame_id"   type="str"  value="$(arg aligned_depth_to_infra2_frame_id)"/>
+    <param name="aligned_depth_to_fisheye_frame_id"  type="str"  value="$(arg aligned_depth_to_fisheye_frame_id)"/>
+    <param name="aligned_depth_to_fisheye1_frame_id" type="str"  value="$(arg aligned_depth_to_fisheye1_frame_id)"/>
+    <param name="aligned_depth_to_fisheye2_frame_id" type="str"  value="$(arg aligned_depth_to_fisheye2_frame_id)"/>
+
+    <param name="spatial_frame_id"                   type="str"  value="$(arg spatial_frame_id)"/>
 
     <param name="filters"                  type="str"    value="$(arg filters)"/>
     <param name="clip_distance"            type="double" value="$(arg clip_distance)"/>

--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -13,12 +13,9 @@
   <arg name="depth_height"        default="480"/>
   <arg name="enable_depth"        default="true"/>
 
-  <arg name="infra1_width"        default="640"/>
-  <arg name="infra1_height"       default="480"/>
+  <arg name="infra_width"        default="640"/>
+  <arg name="infra_height"       default="480"/>
   <arg name="enable_infra1"       default="true"/>
-
-  <arg name="infra2_width"        default="640"/>
-  <arg name="infra2_height"       default="480"/>
   <arg name="enable_infra2"       default="true"/>
 
   <arg name="color_width"         default="640"/>
@@ -27,12 +24,12 @@
 
   <arg name="fisheye_fps"         default="30"/>
   <arg name="depth_fps"           default="30"/>
-  <arg name="infra1_fps"          default="30"/>
-  <arg name="infra2_fps"          default="30"/>
+  <arg name="infra_fps"           default="30"/>
   <arg name="color_fps"           default="30"/>
   <arg name="gyro_fps"            default="400"/>
   <arg name="accel_fps"           default="250"/>
-  <arg name="enable_imu"          default="true"/>
+  <arg name="enable_gyro"         default="true"/>
+  <arg name="enable_accel"        default="true"/>
   <arg name="enable_tm2"          default="false"/>
 
   <arg name="enable_pointcloud"   default="false"/>
@@ -92,22 +89,19 @@
     <param name="color_height"             type="int"  value="$(arg color_height)"/>
     <param name="enable_color"             type="bool" value="$(arg enable_color)"/>
 
-    <param name="infra1_width"             type="int"  value="$(arg infra1_width)"/>
-    <param name="infra1_height"            type="int"  value="$(arg infra1_height)"/>
+    <param name="infra_width"             type="int"  value="$(arg infra_width)"/>
+    <param name="infra_height"            type="int"  value="$(arg infra_height)"/>
     <param name="enable_infra1"            type="bool" value="$(arg enable_infra1)"/>
-
-    <param name="infra2_width"             type="int"  value="$(arg infra2_width)"/>
-    <param name="infra2_height"            type="int"  value="$(arg infra2_height)"/>
     <param name="enable_infra2"            type="bool" value="$(arg enable_infra2)"/>
 
     <param name="fisheye_fps"              type="int"  value="$(arg fisheye_fps)"/>
     <param name="depth_fps"                type="int"  value="$(arg depth_fps)"/>
-    <param name="infra1_fps"               type="int"  value="$(arg infra1_fps)"/>
-    <param name="infra2_fps"               type="int"  value="$(arg infra2_fps)"/>
+    <param name="infra_fps"               type="int"  value="$(arg infra_fps)"/>
     <param name="color_fps"                type="int"  value="$(arg color_fps)"/>
     <param name="gyro_fps"                 type="int"  value="$(arg gyro_fps)"/>
     <param name="accel_fps"                type="int"  value="$(arg accel_fps)"/>
-    <param name="enable_imu"               type="bool" value="$(arg enable_imu)"/>
+    <param name="enable_gyro"              type="bool" value="$(arg enable_gyro)"/>
+    <param name="enable_accel"             type="bool" value="$(arg enable_accel)"/>
     <param name="enable_tm2"               type="bool" value="$(arg enable_tm2)"/>
 
     <param name="base_frame_id"            type="str"  value="$(arg base_frame_id)"/>

--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -4,13 +4,6 @@
   <arg name="tf_prefix"           default=""/>
   <arg name="json_file_path"      default=""/>
   <arg name="rosbag_filename"     default=""/>
-  <arg name="depth"               default="depth"/>
-  <arg name="infra1"              default="infra1"/>
-  <arg name="infra2"              default="infra2"/>
-  <arg name="rgb"                 default="color"/>
-  <arg name="fisheye"             default="fisheye"/>
-  <arg name="accel"               default="accel"/>
-  <arg name="gyro"                default="gyro"/>
 
   <arg name="fisheye_width"       default="640"/>
   <arg name="fisheye_height"      default="480"/>
@@ -40,6 +33,7 @@
   <arg name="gyro_fps"            default="400"/>
   <arg name="accel_fps"           default="250"/>
   <arg name="enable_imu"          default="true"/>
+  <arg name="enable_tm2"          default="false"/>
 
   <arg name="enable_pointcloud"   default="false"/>
   <arg name="pointcloud_texture_stream" default="RS2_STREAM_COLOR"/>  <!-- use RS2_STREAM_ANY to avoid using texture -->
@@ -114,6 +108,7 @@
     <param name="gyro_fps"                 type="int"  value="$(arg gyro_fps)"/>
     <param name="accel_fps"                type="int"  value="$(arg accel_fps)"/>
     <param name="enable_imu"               type="bool" value="$(arg enable_imu)"/>
+    <param name="enable_tm2"               type="bool" value="$(arg enable_tm2)"/>
 
     <param name="base_frame_id"            type="str"  value="$(arg base_frame_id)"/>
     <param name="depth_frame_id"           type="str"  value="$(arg depth_frame_id)"/>

--- a/realsense2_camera/launch/rs_aligned_depth.launch
+++ b/realsense2_camera/launch/rs_aligned_depth.launch
@@ -31,7 +31,8 @@
   <arg name="color_fps"           default="30"/>
   <arg name="gyro_fps"            default="400"/>
   <arg name="accel_fps"           default="250"/>
-  <arg name="enable_imu"          default="true"/>
+  <arg name="enable_gyro"         default="true"/>
+  <arg name="enable_accel"        default="true"/>
 
   <arg name="enable_pointcloud"   default="false"/>
   <arg name="enable_sync"         default="true"/>
@@ -76,7 +77,8 @@
       <arg name="color_fps"                value="$(arg color_fps)"/>
       <arg name="gyro_fps"                 value="$(arg gyro_fps)"/>
       <arg name="accel_fps"                value="$(arg accel_fps)"/>
-      <arg name="enable_imu"               value="$(arg enable_imu)"/>
+      <arg name="enable_gyro"              value="$(arg enable_gyro)"/>
+      <arg name="enable_accel"             value="$(arg enable_accel)"/>
 
       <arg name="filters"                  value="$(arg filters)"/>
     </include>

--- a/realsense2_camera/launch/rs_aligned_depth.launch
+++ b/realsense2_camera/launch/rs_aligned_depth.launch
@@ -12,12 +12,9 @@
   <arg name="depth_height"        default="480"/>
   <arg name="enable_depth"        default="true"/>
 
-  <arg name="infra1_width"        default="640"/>
-  <arg name="infra1_height"       default="480"/>
+  <arg name="infra_width"         default="640"/>
+  <arg name="infra_height"        default="480"/>
   <arg name="enable_infra1"       default="true"/>
-
-  <arg name="infra2_width"        default="640"/>
-  <arg name="infra2_height"       default="480"/>
   <arg name="enable_infra2"       default="true"/>
 
   <arg name="color_width"         default="640"/>
@@ -62,12 +59,9 @@
       <arg name="color_height"             value="$(arg color_height)"/>
       <arg name="enable_color"             value="$(arg enable_color)"/>
 
-      <arg name="infra1_width"             value="$(arg infra1_width)"/>
-      <arg name="infra1_height"            value="$(arg infra1_height)"/>
+      <arg name="infra_width"              value="$(arg infra_width)"/>
+      <arg name="infra_height"             value="$(arg infra_height)"/>
       <arg name="enable_infra1"            value="$(arg enable_infra1)"/>
-
-      <arg name="infra2_width"             value="$(arg infra2_width)"/>
-      <arg name="infra2_height"            value="$(arg infra2_height)"/>
       <arg name="enable_infra2"            value="$(arg enable_infra2)"/>
 
       <arg name="fisheye_fps"              value="$(arg fisheye_fps)"/>

--- a/realsense2_camera/launch/rs_camera.launch
+++ b/realsense2_camera/launch/rs_camera.launch
@@ -12,12 +12,9 @@
   <arg name="depth_height"        default="480"/>
   <arg name="enable_depth"        default="true"/>
 
-  <arg name="infra1_width"        default="640"/>
-  <arg name="infra1_height"       default="480"/>
+  <arg name="infra_width"        default="640"/>
+  <arg name="infra_height"       default="480"/>
   <arg name="enable_infra1"       default="true"/>
-
-  <arg name="infra2_width"        default="640"/>
-  <arg name="infra2_height"       default="480"/>
   <arg name="enable_infra2"       default="true"/>
 
   <arg name="color_width"         default="640"/>
@@ -26,12 +23,13 @@
 
   <arg name="fisheye_fps"         default="30"/>
   <arg name="depth_fps"           default="30"/>
-  <arg name="infra1_fps"          default="30"/>
-  <arg name="infra2_fps"          default="30"/>
+  <arg name="infra_fps"           default="30"/>
   <arg name="color_fps"           default="30"/>
   <arg name="gyro_fps"            default="400"/>
   <arg name="accel_fps"           default="250"/>
-  <arg name="enable_imu"          default="true"/>
+  <arg name="enable_gyro"         default="true"/>
+  <arg name="enable_accel"        default="true"/>
+  <arg name="enable_tm2"          default="false"/>
 
   <arg name="enable_pointcloud"         default="false"/>
   <arg name="pointcloud_texture_stream" default="RS2_STREAM_COLOR"/>
@@ -70,22 +68,20 @@
       <arg name="color_height"             value="$(arg color_height)"/>
       <arg name="enable_color"             value="$(arg enable_color)"/>
 
-      <arg name="infra1_width"             value="$(arg infra1_width)"/>
-      <arg name="infra1_height"            value="$(arg infra1_height)"/>
+      <arg name="infra_width"              value="$(arg infra_width)"/>
+      <arg name="infra_height"             value="$(arg infra_height)"/>
       <arg name="enable_infra1"            value="$(arg enable_infra1)"/>
-
-      <arg name="infra2_width"             value="$(arg infra2_width)"/>
-      <arg name="infra2_height"            value="$(arg infra2_height)"/>
       <arg name="enable_infra2"            value="$(arg enable_infra2)"/>
 
       <arg name="fisheye_fps"              value="$(arg fisheye_fps)"/>
       <arg name="depth_fps"                value="$(arg depth_fps)"/>
-      <arg name="infra1_fps"               value="$(arg infra1_fps)"/>
-      <arg name="infra2_fps"               value="$(arg infra2_fps)"/>
+      <arg name="infra_fps"                value="$(arg infra_fps)"/>
       <arg name="color_fps"                value="$(arg color_fps)"/>
       <arg name="gyro_fps"                 value="$(arg gyro_fps)"/>
       <arg name="accel_fps"                value="$(arg accel_fps)"/>
-      <arg name="enable_imu"               value="$(arg enable_imu)"/>
+      <arg name="enable_gyro"              value="$(arg enable_gyro)"/>
+      <arg name="enable_accel"             value="$(arg enable_accel)"/>
+      <arg name="enable_tm2"               value="$(arg enable_tm2)"/>
 
       <arg name="filters"                  value="$(arg filters)"/>
       <arg name="clip_distance"            value="$(arg clip_distance)"/>

--- a/realsense2_camera/launch/rs_d400_and_tm2.launch
+++ b/realsense2_camera/launch/rs_d400_and_tm2.launch
@@ -1,0 +1,29 @@
+<launch>
+  <arg name="serial_no_camera1"    			default=""/> 			<!-- Note: Replace with actual serial number -->
+  <arg name="serial_no_camera2"    			default=""/> 			<!-- Note: Replace with actual serial number -->
+  <arg name="camera1"              			default="tm2"/>		<!-- Note: Replace with camera name -->
+  <arg name="camera2"              			default="d400"/>		<!-- Note: Replace with camera name -->
+  <arg name="tf_prefix_camera1"         default="$(arg camera1)"/>
+  <arg name="tf_prefix_camera2"         default="$(arg camera2)"/>
+  <arg name="initial_reset"             default="false"/>
+
+  <group ns="$(arg camera1)">
+    <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
+      <arg name="serial_no"             value="$(arg serial_no_camera1)"/>
+      <arg name="tf_prefix"         		value="$(arg tf_prefix_camera1)"/>
+      <arg name="initial_reset"         value="$(arg initial_reset)"/>
+      <arg name="enable_tm2"            value="true"/>
+    </include>
+  </group>
+
+  <group ns="$(arg camera2)">
+    <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
+      <arg name="serial_no"             value="$(arg serial_no_camera2)"/>
+      <arg name="tf_prefix"		          value="$(arg tf_prefix_camera2)"/>
+      <arg name="initial_reset"         value="$(arg initial_reset)"/>
+      <arg name="align_depth"           value="true"/>
+      <arg name="filters"               value="pointcloud"/>
+    </include>
+  </group>
+  <node pkg="tf" type="static_transform_publisher" name="tm2_to_d400" args="0 0 0 0 0 0 /$(arg tf_prefix_camera1)_link /$(arg tf_prefix_camera2)_link 100"/>
+</launch>

--- a/realsense2_camera/launch/rs_from_file.launch
+++ b/realsense2_camera/launch/rs_from_file.launch
@@ -13,12 +13,9 @@
   <arg name="depth_height"        default="0"/>
   <arg name="enable_depth"        default="true"/>
 
-  <arg name="infra1_width"        default="0"/>
-  <arg name="infra1_height"       default="0"/>
+  <arg name="infra_width"        default="0"/>
+  <arg name="infra_height"       default="0"/>
   <arg name="enable_infra1"       default="true"/>
-
-  <arg name="infra2_width"        default="0"/>
-  <arg name="infra2_height"       default="0"/>
   <arg name="enable_infra2"       default="true"/>
 
   <arg name="color_width"         default="0"/>
@@ -27,12 +24,12 @@
 
   <arg name="fisheye_fps"         default="0"/>
   <arg name="depth_fps"           default="0"/>
-  <arg name="infra1_fps"          default="0"/>
-  <arg name="infra2_fps"          default="0"/>
+  <arg name="infra_fps"          default="0"/>
   <arg name="color_fps"           default="0"/>
   <arg name="gyro_fps"            default="400"/>
   <arg name="accel_fps"           default="250"/>
-  <arg name="enable_imu"          default="true"/>
+  <arg name="enable_gyro"         default="true"/>
+  <arg name="enable_accel"        default="true"/>
 
   <arg name="enable_pointcloud"   default="false"/>
   <arg name="enable_sync"         default="false"/>
@@ -64,22 +61,19 @@
       <arg name="color_height"             value="$(arg color_height)"/>
       <arg name="enable_color"             value="$(arg enable_color)"/>
 
-      <arg name="infra1_width"             value="$(arg infra1_width)"/>
-      <arg name="infra1_height"            value="$(arg infra1_height)"/>
+      <arg name="infra_width"             value="$(arg infra_width)"/>
+      <arg name="infra_height"            value="$(arg infra_height)"/>
       <arg name="enable_infra1"            value="$(arg enable_infra1)"/>
-
-      <arg name="infra2_width"             value="$(arg infra2_width)"/>
-      <arg name="infra2_height"            value="$(arg infra2_height)"/>
       <arg name="enable_infra2"            value="$(arg enable_infra2)"/>
 
       <arg name="fisheye_fps"              value="$(arg fisheye_fps)"/>
       <arg name="depth_fps"                value="$(arg depth_fps)"/>
-      <arg name="infra1_fps"               value="$(arg infra1_fps)"/>
-      <arg name="infra2_fps"               value="$(arg infra2_fps)"/>
+      <arg name="infra_fps"               value="$(arg infra_fps)"/>
       <arg name="color_fps"                value="$(arg color_fps)"/>
       <arg name="gyro_fps"                 value="$(arg gyro_fps)"/>
       <arg name="accel_fps"                value="$(arg accel_fps)"/>
-      <arg name="enable_imu"               value="$(arg enable_imu)"/>
+      <arg name="enable_gyro"              value="$(arg enable_gyro)"/>
+      <arg name="enable_accel"             value="$(arg enable_accel)"/>
       <arg name="filters"                  value="$(arg filters)"/>
     </include>
   </group>

--- a/realsense2_camera/launch/rs_rgbd.launch
+++ b/realsense2_camera/launch/rs_rgbd.launch
@@ -55,12 +55,9 @@ Processing enabled by this node:
   <arg name="depth_height"        default="480"/>
   <arg name="enable_depth"        default="true"/>
 
-  <arg name="infra1_width"        default="640"/>
-  <arg name="infra1_height"       default="480"/>
+  <arg name="infra_width"         default="640"/>
+  <arg name="infra_height"        default="480"/>
   <arg name="enable_infra1"       default="true"/>
-
-  <arg name="infra2_width"        default="640"/>
-  <arg name="infra2_height"       default="480"/>
   <arg name="enable_infra2"       default="true"/>
 
   <arg name="color_width"         default="640"/>
@@ -69,8 +66,7 @@ Processing enabled by this node:
 
   <arg name="fisheye_fps"         default="30"/>
   <arg name="depth_fps"           default="30"/>
-  <arg name="infra1_fps"          default="30"/>
-  <arg name="infra2_fps"          default="30"/>
+  <arg name="infra_fps"           default="30"/>
   <arg name="color_fps"           default="30"/>
   <arg name="gyro_fps"            default="400"/>
   <arg name="accel_fps"           default="250"/>
@@ -135,18 +131,14 @@ Processing enabled by this node:
       <arg name="color_height"             value="$(arg color_height)"/>
       <arg name="enable_color"             value="$(arg enable_color)"/>
 
-      <arg name="infra1_width"             value="$(arg infra1_width)"/>
-      <arg name="infra1_height"            value="$(arg infra1_height)"/>
+      <arg name="infra_width"              value="$(arg infra_width)"/>
+      <arg name="infra_height"             value="$(arg infra_height)"/>
       <arg name="enable_infra1"            value="$(arg enable_infra1)"/>
-
-      <arg name="infra2_width"             value="$(arg infra2_width)"/>
-      <arg name="infra2_height"            value="$(arg infra2_height)"/>
       <arg name="enable_infra2"            value="$(arg enable_infra2)"/>
 
       <arg name="fisheye_fps"              value="$(arg fisheye_fps)"/>
       <arg name="depth_fps"                value="$(arg depth_fps)"/>
-      <arg name="infra1_fps"               value="$(arg infra1_fps)"/>
-      <arg name="infra2_fps"               value="$(arg infra2_fps)"/>
+      <arg name="infra_fps"                value="$(arg infra_fps)"/>
       <arg name="color_fps"                value="$(arg color_fps)"/>
       <arg name="gyro_fps"                 value="$(arg gyro_fps)"/>
       <arg name="accel_fps"                value="$(arg accel_fps)"/>

--- a/realsense2_camera/launch/rs_rgbd.launch
+++ b/realsense2_camera/launch/rs_rgbd.launch
@@ -74,7 +74,8 @@ Processing enabled by this node:
   <arg name="color_fps"           default="30"/>
   <arg name="gyro_fps"            default="400"/>
   <arg name="accel_fps"           default="250"/>
-  <arg name="enable_imu"          default="true"/>
+  <arg name="enable_gyro"         default="true"/>
+  <arg name="enable_accel"        default="true"/>
 
   <arg name="enable_pointcloud"   default="false"/>
   <arg name="enable_sync"         default="true"/>
@@ -149,7 +150,8 @@ Processing enabled by this node:
       <arg name="color_fps"                value="$(arg color_fps)"/>
       <arg name="gyro_fps"                 value="$(arg gyro_fps)"/>
       <arg name="accel_fps"                value="$(arg accel_fps)"/>
-      <arg name="enable_imu"               value="$(arg enable_imu)"/>
+      <arg name="enable_gyro"              value="$(arg enable_gyro)"/>
+      <arg name="enable_accel"             value="$(arg enable_accel)"/>
       <arg name="filters"                  value="$(arg filters)"/>
     </include>
 

--- a/realsense2_camera/launch/rs_tm260.launch
+++ b/realsense2_camera/launch/rs_tm260.launch
@@ -1,0 +1,48 @@
+<launch>
+  <arg name="serial_no"           default=""/>
+  <arg name="json_file_path"      default=""/>
+  <arg name="camera"              default="camera"/>
+  <arg name="tf_prefix"           default="$(arg camera)"/>
+
+  <arg name="fisheye_width"       default="848"/> 
+  <arg name="fisheye_height"      default="800"/>
+  <arg name="enable_fisheye"      default="true"/>
+
+  <arg name="fisheye_fps"         default="30"/>
+
+  <arg name="gyro_fps"            default="200"/>
+  <arg name="accel_fps"           default="62"/>
+  <arg name="enable_imu"          default="true"/>
+  <arg name="enable_tm2"          default="true"/>
+
+
+  <arg name="enable_sync"           default="false"/>
+
+  <arg name="linear_accel_cov"      default="0.01"/>
+  <arg name="initial_reset"         default="false"/>
+  <arg name="unite_imu_method"      default=""/>
+  
+  <group ns="$(arg camera)">
+    <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
+      <arg name="tf_prefix"                value="$(arg tf_prefix)"/>
+      <arg name="serial_no"                value="$(arg serial_no)"/>
+      <arg name="json_file_path"           value="$(arg json_file_path)"/>
+
+      <arg name="enable_sync"              value="$(arg enable_sync)"/>
+
+      <arg name="fisheye_width"            value="$(arg fisheye_width)"/>
+      <arg name="fisheye_height"           value="$(arg fisheye_height)"/>
+      <arg name="enable_fisheye"           value="$(arg enable_fisheye)"/>
+
+      <arg name="fisheye_fps"              value="$(arg fisheye_fps)"/>
+      <arg name="gyro_fps"                 value="$(arg gyro_fps)"/>
+      <arg name="accel_fps"                value="$(arg accel_fps)"/>
+      <arg name="enable_imu"               value="$(arg enable_imu)"/>
+      <arg name="enable_tm2"               value="$(arg enable_tm2)"/>
+
+      <arg name="linear_accel_cov"         value="$(arg linear_accel_cov)"/>
+      <arg name="initial_reset"            value="$(arg initial_reset)"/>
+      <arg name="unite_imu_method"         value="$(arg unite_imu_method)"/>
+    </include>
+  </group>
+</launch>

--- a/realsense2_camera/launch/rs_tm260.launch
+++ b/realsense2_camera/launch/rs_tm260.launch
@@ -12,7 +12,8 @@
 
   <arg name="gyro_fps"            default="200"/>
   <arg name="accel_fps"           default="62"/>
-  <arg name="enable_imu"          default="true"/>
+  <arg name="enable_gyro"         default="true"/>
+  <arg name="enable_accel"        default="true"/>
   <arg name="enable_tm2"          default="true"/>
 
 
@@ -37,7 +38,8 @@
       <arg name="fisheye_fps"              value="$(arg fisheye_fps)"/>
       <arg name="gyro_fps"                 value="$(arg gyro_fps)"/>
       <arg name="accel_fps"                value="$(arg accel_fps)"/>
-      <arg name="enable_imu"               value="$(arg enable_imu)"/>
+      <arg name="enable_gyro"              value="$(arg enable_gyro)"/>
+      <arg name="enable_accel"             value="$(arg enable_accel)"/>
       <arg name="enable_tm2"               value="$(arg enable_tm2)"/>
 
       <arg name="linear_accel_cov"         value="$(arg linear_accel_cov)"/>

--- a/realsense2_camera/scripts/rs2_test.py
+++ b/realsense2_camera/scripts/rs2_test.py
@@ -147,7 +147,8 @@ test_types = {'vis_avg': {'listener_theme': 'colorStream',
                           'data_func': lambda x: None,
                           'test_func': NotImageColorTest},
               'pointscloud_avg': {'listener_theme': 'pointscloud',
-                          'data_func': lambda x: {'width': [776534, 2300], 'height': [1], 'avg': [np.array([ 1.28251814, -0.15839984, 4.82235184, 65, 88, 95])], 'epsilon': [0.02, 2]},
+                        #   'data_func': lambda x: {'width': [776534, 2300], 'height': [1], 'avg': [np.array([ 1.28251814, -0.15839984, 4.82235184, 65, 88, 95])], 'epsilon': [0.02, 2]},
+                          'data_func': lambda x: {'width': [776534, 2300], 'height': [1], 'avg': [np.array([ 1.28251814, -0.15839984, 4.82235184, 125, 116, 102])], 'epsilon': [0.02, 2]},
                           'test_func': PointCloudTest},
               'align_depth_ir1': {'listener_theme': 'alignedDepthInfra1',
                                   'data_func': ImageDepthGetData,
@@ -272,7 +273,7 @@ def main():
     results = run_tests(tests_to_run)
     print_results(results)
 
-    res = int(all([result[1] for result in results])) - 1
+    res = int(all([result[1][0] for result in results])) - 1
     print 'exit (%d)' % res
     exit(res)
 

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -321,27 +321,27 @@ void BaseRealSenseNode::getParameters()
     for (auto& stream : IMAGE_STREAMS)
     {
         string param_name(_stream_name[stream.first] + "_width");
-        ROS_INFO_STREAM("reading parameter:" << param_name);
+        ROS_DEBUG_STREAM("reading parameter:" << param_name);
         _pnh.param(param_name, _width[stream], IMAGE_WIDTH);
         param_name = _stream_name[stream.first] + "_height";
-        ROS_INFO_STREAM("reading parameter:" << param_name);
+        ROS_DEBUG_STREAM("reading parameter:" << param_name);
         _pnh.param(param_name, _height[stream], IMAGE_HEIGHT);
         param_name = _stream_name[stream.first] + "_fps";
-        ROS_INFO_STREAM("reading parameter:" << param_name);
+        ROS_DEBUG_STREAM("reading parameter:" << param_name);
         _pnh.param(param_name, _fps[stream], IMAGE_FPS);
         param_name = "enable_" + STREAM_NAME(stream);
-        ROS_INFO_STREAM("reading parameter:" << param_name);
+        ROS_DEBUG_STREAM("reading parameter:" << param_name);
         _pnh.param(param_name, _enable[stream], true);
     }
 
     for (auto& stream : HID_STREAMS)
     {
         string param_name(_stream_name[stream.first] + "_fps");
-        ROS_INFO_STREAM("reading parameter:" << param_name);
+        ROS_DEBUG_STREAM("reading parameter:" << param_name);
         _pnh.param(param_name, _fps[stream], IMU_FPS);
         param_name = "enable_" + STREAM_NAME(stream);
         _pnh.param(param_name, _enable[stream], ENABLE_IMU);
-        ROS_INFO_STREAM("_enable[" << _stream_name[stream.first] << "]:" << _enable[stream]);
+        ROS_DEBUG_STREAM("_enable[" << _stream_name[stream.first] << "]:" << _enable[stream]);
     }
     _pnh.param("base_frame_id", _base_frame_id, DEFAULT_BASE_FRAME_ID);
     _pnh.param("spatial_frame_id", _spatial_frame_id, DEFAULT_SPATIAL_FRAME_ID);
@@ -352,10 +352,10 @@ void BaseRealSenseNode::getParameters()
     {
         string param_name(static_cast<std::ostringstream&&>(std::ostringstream() << STREAM_NAME(stream) << "_frame_id").str());
         _pnh.param(param_name, _frame_id[stream], FRAME_ID(stream));
-        ROS_INFO_STREAM("frame_id: reading parameter:" << param_name << " : " << _frame_id[stream]);
+        ROS_DEBUG_STREAM("frame_id: reading parameter:" << param_name << " : " << _frame_id[stream]);
         param_name = static_cast<std::ostringstream&&>(std::ostringstream() << STREAM_NAME(stream) << "_optical_frame_id").str();
         _pnh.param(param_name, _optical_frame_id[stream], OPTICAL_FRAME_ID(stream));
-        ROS_INFO_STREAM("optical: reading parameter:" << param_name << " : " << _optical_frame_id[stream]);
+        ROS_DEBUG_STREAM("optical: reading parameter:" << param_name << " : " << _optical_frame_id[stream]);
     }
 
     std::string unite_imu_method_str("");
@@ -653,7 +653,7 @@ void BaseRealSenseNode::publishAlignedDepthToOthers(rs2::frameset frames, const 
             }
             catch(const std::out_of_range& e)
             {
-                ROS_WARN_STREAM("Allocate align filter for:" << rs2_stream_to_string(sip.first) << sip.second);
+                ROS_DEBUG_STREAM("Allocate align filter for:" << rs2_stream_to_string(sip.first) << sip.second);
                 align = (_align[stream_type] = std::make_shared<rs2::align>(stream_type));
             }
             rs2::frameset processed = frames.apply_filter(*align);

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -246,7 +246,17 @@ void BaseRealSenseNode::registerDynamicOption(ros::NodeHandle& nh, rs2::options 
         }
         else
         {
-            ROS_DEBUG_STREAM("Add enum: " << rs2_option_to_string(option) << ". value=" << int(sensor.get_option(option)));
+            if (int(sensor.get_option(option)) > (int)enum_dict.size())
+            {
+                ROS_WARN_STREAM("Option " << rs2_option_to_string(option) << 
+                                " has a value: " << int(sensor.get_option(option)) << 
+                                " which is beyond it's scope: " << enum_dict.size());
+                ROS_INFO_STREAM("Add enum: " << rs2_option_to_string(option) << ". value=" << int(sensor.get_option(option)));
+                for (auto item: enum_dict)
+                {
+                    ROS_INFO_STREAM("Add item: " << item.first << ":" << item.second); // << ":" << sensor.get_option_description(static_cast<rs2_option>(item.second)));
+                }
+            }
             ddynrec->add(new DDEnum(rs2_option_to_string(option), i, sensor.get_option_description(option), int(sensor.get_option(option)), enum_dict));
         }
     }
@@ -1132,9 +1142,8 @@ void BaseRealSenseNode::pose_callback(rs2::frame frame)
         rs2_pose pose = frame.as<rs2::pose_frame>().get_pose_data();
         double elapsed_camera_ms = (/*ms*/ frame_time - /*ms*/ _camera_time_base) / 1000.0;
         ros::Time t(_ros_time_base.toSec() + elapsed_camera_ms);
-
-        double cov_pose(pow(10, pose.tracker_confidence - 2.0));
-        double cov_twist(pow(10, pose.tracker_confidence - 4.0));
+        double cov_pose(_linear_accel_cov * pow(10, 3-pose.tracker_confidence));
+        double cov_twist(_angular_velocity_cov * pow(10, 1-pose.tracker_confidence));
 
         geometry_msgs::PoseStamped pose_msg;
         pose_msg.pose.position.x = -pose.translation.z;

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -1189,13 +1189,20 @@ void BaseRealSenseNode::pose_callback(rs2::frame frame)
         _imu_publishers[stream_index].publish(odom_msg);
         ROS_DEBUG("Publish %s stream", rs2_stream_to_string(frame.get_profile().stream_type()));
 
-        // publish static transform:
-        static tf::TransformBroadcaster br;
-        tf::Transform transform;
-        transform.setOrigin( tf::Vector3(pose_msg.pose.position.x, pose_msg.pose.position.y, pose_msg.pose.position.z) );
-        tf::Quaternion q1(pose_msg.pose.orientation.x, pose_msg.pose.orientation.y, pose_msg.pose.orientation.z, pose_msg.pose.orientation.w);
-        transform.setRotation(q1);
-        br.sendTransform(tf::StampedTransform(transform, ros::Time::now(), _spatial_frame_id, _base_frame_id));        
+        static tf2_ros::TransformBroadcaster br;
+        geometry_msgs::TransformStamped msg;
+        msg.header.stamp = t;
+        msg.header.frame_id = _spatial_frame_id;
+        msg.child_frame_id = _base_frame_id;
+        msg.transform.translation.x = pose_msg.pose.position.x;
+        msg.transform.translation.y = pose_msg.pose.position.y;
+        msg.transform.translation.z = pose_msg.pose.position.z;
+        msg.transform.rotation.x = pose_msg.pose.orientation.x;
+        msg.transform.rotation.y = pose_msg.pose.orientation.y;
+        msg.transform.rotation.z = pose_msg.pose.orientation.z;
+        msg.transform.rotation.w = pose_msg.pose.orientation.w;
+
+        br.sendTransform(msg);
     }
 }
 

--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -174,8 +174,15 @@ void RealSenseNodeFactory::onInit()
 				ROS_INFO("Resetting device...");
 				rs2::device dev;
 				dev = getDevice(serial_no);
-				dev.hardware_reset();
-				waitForDevice(dev);
+				try
+				{
+					dev.hardware_reset();
+					waitForDevice(dev);
+				}
+				catch(const std::exception& ex)
+				{
+					ROS_WARN_STREAM("An exception has been thrown: " << ex.what());
+				}
 			}
 			_device = getDevice(serial_no);
 			if (!_device)

--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -8,6 +8,8 @@
 #include <mutex>
 #include <condition_variable>
 #include <signal.h>
+#include <thread>
+#include <sys/time.h>
 
 using namespace realsense2_camera;
 
@@ -44,46 +46,67 @@ void RealSenseNodeFactory::signalHandler(int signum)
 	exit(signum);
 }
 
-rs2::device RealSenseNodeFactory::getDevice(std::string& serial_no)
+rs2::device RealSenseNodeFactory::getDevice(std::string& serial_no, bool shutdown_on_failure)
 {
+	rs2::device retDev;
 	auto list = _ctx.query_devices();
 	if (0 == list.size())
 	{
-		ROS_ERROR("No RealSense devices were found! Terminating RealSense Node...");
+		ROS_ERROR("No RealSense devices were found!");
+	}
+	else
+	{
+		bool found = false;
+
+		for (auto&& dev : list)
+		{
+			auto sn = dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
+			ROS_DEBUG_STREAM("Device with serial number " << sn << " was found.");
+			if (serial_no.empty())
+			{
+				retDev = dev;
+				serial_no = sn;
+				found = true;
+				break;
+			}
+			else if (sn == serial_no)
+			{
+				retDev = dev;
+				found = true;
+				break;
+			}
+		}
+
+		if (!found)
+		{
+			ROS_ERROR_STREAM("The requested device with serial number " << serial_no << " is NOT found!");
+		}
+	}
+	if (!retDev && shutdown_on_failure)
+	{
+		ROS_ERROR("Terminating RealSense Node...");
 		ros::shutdown();
 		exit(1);
 	}
-
-	bool found = false;
-	rs2::device retDev;
-
-	for (auto&& dev : list)
-	{
-		auto sn = dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
-		ROS_DEBUG_STREAM("Device with serial number " << sn << " was found.");
-		if (serial_no.empty())
-		{
-			retDev = dev;
-			serial_no = sn;
-			found = true;
-			break;
-		}
-		else if (sn == serial_no)
-		{
-			retDev = dev;
-			found = true;
-			break;
-		}
-	}
-
-	if (!found)
-	{
-		ROS_FATAL_STREAM("The requested device with serial number " << serial_no << " is NOT found!");
-		ros::shutdown();
-		exit(1);
-	}
-
 	return retDev;
+}
+
+void RealSenseNodeFactory::waitForDevice(rs2::device& dev)
+{
+	std::mutex mtx;
+	std::condition_variable cv;
+	_ctx.set_devices_changed_callback([&dev, &cv](rs2::event_information& info)
+			{
+				if (info.was_removed(dev))
+				{
+					cv.notify_one();
+				}
+			});
+
+	{
+		std::unique_lock<std::mutex> lk(mtx);
+		cv.wait(lk);
+	}
 }
 
 void RealSenseNodeFactory::onInit()
@@ -115,30 +138,51 @@ void RealSenseNodeFactory::onInit()
 		}
 		else
 		{
+			bool enable_tm2;
+			privateNh.param("enable_tm2", enable_tm2, false);
+			if (enable_tm2)
+			{
+				// Currentlty need to wait before start quering device.
+ 				_ctx.query_devices();
+				const double wait_time(10);
+				// std::this_thread::sleep_for(std::chrono::milliseconds(5000));
+				time_t start_time = time(NULL);
+				ROS_INFO_STREAM("Waiting for up to " << wait_time << "(sec) for TM2 Device to load.");
+				int ms(200);
+				rs2::device dev;
+				while (difftime(time(NULL), start_time) < wait_time)
+				{
+					dev = getDevice(serial_no, false);
+					if (dev)
+					{
+						break;
+					}
+					std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+				}
+				if (!dev)
+				{
+					ROS_ERROR("Timeout while waiting for TM2 device. Terminating RealSense Node...");
+					ros::shutdown();
+					exit(1);
+				}
+				ROS_INFO_STREAM("TM2 device found after " << difftime(time(NULL), start_time) << "(sec)");
+			}
 			bool initial_reset;
 			privateNh.param("initial_reset", initial_reset, false);
 			if (initial_reset)
 			{
 				ROS_INFO("Resetting device...");
-				std::mutex mtx;
-				std::condition_variable cv;
 				rs2::device dev;
-				_ctx.set_devices_changed_callback([&dev, &cv](rs2::event_information& info)
-						{
-							if (info.was_removed(dev))
-							{
-								cv.notify_one();
-							}
-						});
-
 				dev = getDevice(serial_no);
 				dev.hardware_reset();
-				{
-					std::unique_lock<std::mutex> lk(mtx);
-					cv.wait(lk);
-				}
+				waitForDevice(dev);
 			}
 			_device = getDevice(serial_no);
+			if (!_device)
+			{
+				ros::shutdown();
+				exit(1);
+			}
 
 			_ctx.set_devices_changed_callback([this](rs2::event_information& info)
 					{
@@ -172,6 +216,7 @@ void RealSenseNodeFactory::onInit()
 			case RS435_RGB_PID:
 			case RS435i_RGB_PID:
 			case RS_USB2_PID:
+			case RS_T265_PID:
 				_realSenseNode = std::unique_ptr<BaseRealSenseNode>(new BaseRealSenseNode(nh, privateNh, _device, serial_no));
 				break;
 			default:


### PR DESCRIPTION
Add basic support for TM265 Tracking Module.
Include some interface changes: 
- new topics for tracking.
- add new parameters in launch files for fisheye1 and fisheye2 cameras, enable_tm2
- removed duplicate parameters in launch files: parameters for both infra1 and infra2 reduced to infra, as in the devices themselves.
- instead of enable_imu there are the more basic enable_gyro and enable_accel.

Some inner code modifications in order to generalize it a little.
Fix issue with align filter - was initiated every frame.

