### PR TITLE
T265

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -14,6 +14,7 @@
 #include <sensor_msgs/point_cloud2_iterator.h>
 #include <sensor_msgs/Imu.h>
 #include <nav_msgs/Odometry.h>
+#include <geometry_msgs/PoseStamped.h>
 
 #include <queue>
 #include <mutex>
@@ -244,6 +245,7 @@ namespace realsense2_camera
 
         std::map<stream_index_pair, ImagePublisherWithFrequencyDiagnostics> _image_publishers;
         std::map<stream_index_pair, ros::Publisher> _imu_publishers;
+        ros::Publisher _odom_publisher;
         std::shared_ptr<SyncedImuPublisher> _synced_imu_publisher;
         std::map<rs2_stream, int> _image_format;
         std::map<stream_index_pair, ros::Publisher> _info_publisher;

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -622,7 +622,8 @@ void BaseRealSenseNode::setupPublishers()
     }
     if (_enable[POSE])
     {
-        _imu_publishers[POSE] = _node_handle.advertise<nav_msgs::Odometry>("odom/sample", 1);
+        _imu_publishers[POSE] = _node_handle.advertise<geometry_msgs::PoseStamped>("pose/sample", 1);
+        _odom_publisher = _node_handle.advertise<nav_msgs::Odometry>("odom/sample", 1);
     }
 
 
@@ -1165,6 +1166,7 @@ void BaseRealSenseNode::pose_callback(rs2::frame frame)
         pose_msg.pose.orientation.y = -pose.rotation.x;
         pose_msg.pose.orientation.z = pose.rotation.y;
         pose_msg.pose.orientation.w = pose.rotation.w;
+        _imu_publishers[stream_index].publish(pose_msg);
 
         geometry_msgs::Vector3Stamped v_msg;
         v_msg.vector.x = -pose.velocity.z;
@@ -1198,7 +1200,7 @@ void BaseRealSenseNode::pose_callback(rs2::frame frame)
                                     0, 0, 0, cov_twist, 0, 0,
                                     0, 0, 0, 0, cov_twist, 0,
                                     0, 0, 0, 0, 0, cov_twist};
-        _imu_publishers[stream_index].publish(odom_msg);
+        _odom_publisher.publish(odom_msg);
         ROS_DEBUG("Publish %s stream", rs2_stream_to_string(frame.get_profile().stream_type()));
 
         static tf2_ros::TransformBroadcaster br;

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -1155,10 +1155,14 @@ void BaseRealSenseNode::pose_callback(rs2::frame frame)
         rs2_pose pose = frame.as<rs2::pose_frame>().get_pose_data();
         double elapsed_camera_ms = (/*ms*/ frame_time - /*ms*/ _camera_time_base) / 1000.0;
         ros::Time t(_ros_time_base.toSec() + elapsed_camera_ms);
+        _seq[stream_index] += 1;
         double cov_pose(_linear_accel_cov * pow(10, 3-pose.tracker_confidence));
         double cov_twist(_angular_velocity_cov * pow(10, 1-pose.tracker_confidence));
 
         geometry_msgs::PoseStamped pose_msg;
+        pose_msg.header.frame_id = _spatial_frame_id;
+        pose_msg.header.stamp = t;
+        pose_msg.header.seq = _seq[stream_index];
         pose_msg.pose.position.x = -pose.translation.z;
         pose_msg.pose.position.y = -pose.translation.x;
         pose_msg.pose.position.z = pose.translation.y;
@@ -1179,8 +1183,6 @@ void BaseRealSenseNode::pose_callback(rs2::frame frame)
         om_msg.vector.z = pose.angular_velocity.y;
 
         nav_msgs::Odometry odom_msg;
-        _seq[stream_index] += 1;
-
         odom_msg.header.frame_id = _spatial_frame_id;
         odom_msg.child_frame_id = _base_frame_id;
         odom_msg.header.stamp = t;

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -610,19 +610,19 @@ void BaseRealSenseNode::setupPublishers()
     {
         if (_enable[GYRO])
         {
-            _imu_publishers[GYRO] = _node_handle.advertise<sensor_msgs::Imu>("gyro/sample", 100);
+            _imu_publishers[GYRO] = _node_handle.advertise<sensor_msgs::Imu>("gyro/sample", 1);
             _info_publisher[GYRO] = _node_handle.advertise<IMUInfo>("gyro/imu_info", 1, true);
         }
 
         if (_enable[ACCEL])
         {
-            _imu_publishers[ACCEL] = _node_handle.advertise<sensor_msgs::Imu>("accel/sample", 100);
+            _imu_publishers[ACCEL] = _node_handle.advertise<sensor_msgs::Imu>("accel/sample", 1);
             _info_publisher[ACCEL] = _node_handle.advertise<IMUInfo>("accel/imu_info", 1, true);
         }
     }
     if (_enable[POSE])
     {
-        _imu_publishers[POSE] = _node_handle.advertise<nav_msgs::Odometry>("odom/sample", 100);
+        _imu_publishers[POSE] = _node_handle.advertise<nav_msgs::Odometry>("odom/sample", 1);
     }
 
 


### PR DESCRIPTION
@doronhi, I noticed that I get high latency in the odometry messages after ~1s and they arrive in batches (see screenshot). This seems to be related to TCP batching and can be avoided by using the no TCP latency option in the subscriber or UDP but unfortunately it seems there is no option for the publisher. I didn't see this issue with other messages like PoseStamped and Vector3Stamped and would prefer to add them to avoid running into this issue for applications that require low latency. (Maybe the odometry could be published at a lower rate then?)

![odom_gyro_screenshot from 2019-02-21 14-06-21](https://user-images.githubusercontent.com/28366639/53210615-558ade00-35f3-11e9-8411-25c46c4ba311.png)

