### PR TITLE
Add handling t265 coordinate system

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The topics are of the form: ```/camera/aligned_depth_to_color/image_raw``` etc.
 - **enable_*<stream_name>***: Choose whether to enable a specified stream or not. Default is true. <stream_name> can be any of *infra1, infra2, color, depth, fisheye, fisheye1, fisheye2, gyro, accel, pose*.
 - **tf_prefix**: By default all frame's ids have the same prefix - `camera_`. This allows changing it per camera.
 - **base_frame_id**: defines the frame_id all static transformations refers to.
-- **spatial_frame_id**: defines the frame_id that `pose` topic refers to.
+- **odom_frame_id**: defines the origin coordinate system in ROS convention (X-Forward, Y-Left, Z-Up). pose topic defines the pose relative to that system.
 - **All the rest of the frame_ids can be found in the template launch file: [nodelet.launch.xml](./realsense2_camera/launch/includes/nodelet.launch.xml)**
 - **unite_imu_method**: The D435i and T265 cameras have built in IMU components which produce 2 unrelated streams: *gyro* - which shows angular velocity and *accel* which shows linear acceleration. Each with it's own frequency. By default, 2 corresponding topics are available, each with only the relevant fields of the message sensor_msgs::Imu are filled out.
 Setting *unite_imu_method* creates a new topic, *imu*, that replaces the default *gyro* and *accel* topics. Under the new topic, all the fields in the Imu message are filled out.

--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -33,7 +33,7 @@ if(SET_USER_BREAK_AT_STARTUP)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBPDEBUG")
 endif()
 
-find_package(realsense2 2.18.1)
+find_package(realsense2 2.19.0)
 if(NOT realsense2_FOUND)
     message(FATAL_ERROR "\n\n Intel RealSense SDK 2.0 is missing, please install it from https://github.com/IntelRealSense/librealsense/releases\n\n")
 endif()
@@ -79,8 +79,10 @@ add_library(${PROJECT_NAME}
     include/constants.h
     include/realsense_node_factory.h
     include/base_realsense_node.h
+    include/t265_realsense_node.h
     src/realsense_node_factory.cpp
     src/base_realsense_node.cpp
+    src/t265_realsense_node.cpp
     )
 
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_generate_messages_cpp)

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -107,15 +107,6 @@ namespace realsense2_camera
         enum imu_sync_method{NONE, COPY, LINEAR_INTERPOLATION};
 
     protected:
-
-        const uint32_t set_default_dynamic_reconfig_values = 0xffffffff;
-        rs2::device _dev;
-        ros::NodeHandle& _node_handle, _pnh;
-        std::map<stream_index_pair, rs2::sensor> _sensors;
-        std::map<std::string, std::function<void(rs2::frame)>> _sensors_callback;
-        std::vector<std::shared_ptr<ddynamic_reconfigure::DDynamicReconfigure>> _ddynrec;
-
-    private:
         class float3
         {
             public:
@@ -138,11 +129,24 @@ namespace realsense2_camera
                 }
         };
 
-        struct quaternion
-        {
-            double x, y, z, w;
-        };
+        std::string _base_frame_id;
+        std::string _odom_frame_id;
+        std::map<stream_index_pair, std::string> _frame_id;
+        std::map<stream_index_pair, std::string> _optical_frame_id;
+        std::map<stream_index_pair, std::string> _depth_aligned_frame_id;
+        bool _align_depth;
 
+        virtual void calcAndPublishStaticTransform(const stream_index_pair& stream, const rs2::stream_profile& base_profile);
+        rs2::stream_profile getAProfile(const stream_index_pair& stream);
+        tf::Quaternion rotationMatrixToQuaternion(const float rotation[9]) const;
+        void publish_static_tf(const ros::Time& t,
+                               const float3& trans,
+                               const tf::Quaternion& q,
+                               const std::string& from,
+                               const std::string& to);
+
+
+    private:
         class CIMUHistory
         {
             public:
@@ -188,17 +192,9 @@ namespace realsense2_camera
         void setBaseTime(double frame_time, bool warn_no_metadata);
         void clip_depth(rs2::depth_frame& depth_frame, float depth_scale, float clipping_dist);
         void updateStreamCalibData(const rs2::video_stream_profile& video_profile);
-        tf::Quaternion rotationMatrixToQuaternion(const float rotation[9]) const;
-        void publish_static_tf(const ros::Time& t,
-                               const float3& trans,
-                               const quaternion& q,
-                               const std::string& from,
-                               const std::string& to);
-        void calcAndPublishStaticTransform(const stream_index_pair& stream, const rs2::stream_profile& base_profile);
         void publishStaticTransforms();
         void publishPointCloud(rs2::points f, const ros::Time& t, const rs2::frameset& frameset);
         Extrinsics rsExtrinsicsToMsg(const rs2_extrinsics& extrinsics, const std::string& frame_id) const;
-        rs2::stream_profile getAProfile(const stream_index_pair& stream);
 
         IMUInfo getImuInfo(const stream_index_pair& stream_index);
         void publishFrame(rs2::frame f, const ros::Time& t,
@@ -226,6 +222,12 @@ namespace realsense2_camera
         void registerDynamicOption(ros::NodeHandle& nh, rs2::options sensor, std::string& module_name);
         rs2_stream rs2_string_to_stream(std::string str);
 
+        rs2::device _dev;
+        ros::NodeHandle& _node_handle, _pnh;
+        std::map<stream_index_pair, rs2::sensor> _sensors;
+        std::map<std::string, std::function<void(rs2::frame)>> _sensors_callback;
+        std::vector<std::shared_ptr<ddynamic_reconfigure::DDynamicReconfigure>> _ddynrec;
+
         std::string _json_file_path;
         std::string _serial_no;
         float _depth_scale_meters;
@@ -251,10 +253,6 @@ namespace realsense2_camera
         std::map<rs2_stream, std::string> _encoding;
         std::map<stream_index_pair, std::vector<uint8_t>> _aligned_depth_images;
 
-        std::string _base_frame_id;
-        std::string _spatial_frame_id;
-        std::map<stream_index_pair, std::string> _frame_id;
-        std::map<stream_index_pair, std::string> _optical_frame_id;
         std::map<stream_index_pair, int> _seq;
         std::map<rs2_stream, int> _unit_step_size;
         std::map<stream_index_pair, sensor_msgs::CameraInfo> _camera_info;
@@ -264,7 +262,6 @@ namespace realsense2_camera
 
         ros::Publisher _pointcloud_publisher;
         ros::Time _ros_time_base;
-        bool _align_depth;
         bool _sync_frames;
         bool _pointcloud;
         imu_sync_method _imu_sync_method;
@@ -281,7 +278,6 @@ namespace realsense2_camera
         std::map<stream_index_pair, int> _depth_aligned_seq;
         std::map<stream_index_pair, ros::Publisher> _depth_aligned_info_publisher;
         std::map<stream_index_pair, ImagePublisherWithFrequencyDiagnostics> _depth_aligned_image_publishers;
-        std::map<stream_index_pair, std::string> _depth_aligned_frame_id;
         std::map<stream_index_pair, ros::Publisher> _depth_to_other_extrinsics_publishers;
         std::map<stream_index_pair, rs2_extrinsics> _depth_to_other_extrinsics;
 

--- a/realsense2_camera/include/constants.h
+++ b/realsense2_camera/include/constants.h
@@ -56,7 +56,7 @@ namespace realsense2_camera
 
 
     const std::string DEFAULT_BASE_FRAME_ID            = "camera_link";
-    const std::string DEFAULT_SPATIAL_FRAME_ID         = "spatial";
+    const std::string DEFAULT_ODOM_FRAME_ID            = "odom_frame";
     const std::string DEFAULT_DEPTH_FRAME_ID           = "camera_depth_frame";
     const std::string DEFAULT_INFRA1_FRAME_ID          = "camera_infra1_frame";
     const std::string DEFAULT_INFRA2_FRAME_ID          = "camera_infra2_frame";

--- a/realsense2_camera/include/t265_realsense_node.h
+++ b/realsense2_camera/include/t265_realsense_node.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <base_realsense_node.h>
+
+namespace realsense2_camera
+{
+    class T265RealsenseNode : public BaseRealSenseNode
+    {
+        public:
+            T265RealsenseNode(ros::NodeHandle& nodeHandle,
+                          ros::NodeHandle& privateNodeHandle,
+                          rs2::device dev,
+                          const std::string& serial_no);
+
+        protected:
+            void calcAndPublishStaticTransform(const stream_index_pair& stream, const rs2::stream_profile& base_profile) override;
+    };
+}

--- a/realsense2_camera/launch/demo_t265.launch
+++ b/realsense2_camera/launch/demo_t265.launch
@@ -1,0 +1,4 @@
+<launch>
+  <include file="$(find realsense2_camera)/launch/rs_t265.launch"/>
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find realsense2_camera)/rviz/t265.rviz" required="true" />
+</launch>

--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -70,7 +70,7 @@
   <arg name="aligned_depth_to_fisheye1_frame_id" default="$(arg tf_prefix)_aligned_depth_to_fisheye1_frame"/>
   <arg name="aligned_depth_to_fisheye2_frame_id" default="$(arg tf_prefix)_aligned_depth_to_fisheye2_frame"/>
 
-  <arg name="spatial_frame_id"        default="$(arg tf_prefix)_spatial"/>
+  <arg name="odom_frame_id"            default="$(arg tf_prefix)_odom_frame"/>
 
   <arg name="filters"                  default=""/>
   <arg name="clip_distance"            default="-1"/>
@@ -149,7 +149,7 @@
     <param name="aligned_depth_to_fisheye1_frame_id" type="str"  value="$(arg aligned_depth_to_fisheye1_frame_id)"/>
     <param name="aligned_depth_to_fisheye2_frame_id" type="str"  value="$(arg aligned_depth_to_fisheye2_frame_id)"/>
 
-    <param name="spatial_frame_id"                   type="str"  value="$(arg spatial_frame_id)"/>
+    <param name="odom_frame_id"            type="str"  value="$(arg odom_frame_id)"/>
 
     <param name="filters"                  type="str"    value="$(arg filters)"/>
     <param name="clip_distance"            type="double" value="$(arg clip_distance)"/>

--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -8,13 +8,15 @@
   <arg name="fisheye_width"       default="0"/>
   <arg name="fisheye_height"      default="0"/>
   <arg name="enable_fisheye"      default="true"/>
+  <arg name="enable_fisheye1"     default="true"/>
+  <arg name="enable_fisheye2"     default="true"/>
 
   <arg name="depth_width"         default="640"/>
   <arg name="depth_height"        default="480"/>
   <arg name="enable_depth"        default="true"/>
 
-  <arg name="infra_width"        default="640"/>
-  <arg name="infra_height"       default="480"/>
+  <arg name="infra_width"         default="640"/>
+  <arg name="infra_height"        default="480"/>
   <arg name="enable_infra1"       default="true"/>
   <arg name="enable_infra2"       default="true"/>
 
@@ -92,6 +94,8 @@
     <param name="fisheye_width"            type="int"  value="$(arg fisheye_width)"/>
     <param name="fisheye_height"           type="int"  value="$(arg fisheye_height)"/>
     <param name="enable_fisheye"           type="bool" value="$(arg enable_fisheye)"/>
+    <param name="enable_fisheye1"          type="bool" value="$(arg enable_fisheye1)"/>
+    <param name="enable_fisheye2"          type="bool" value="$(arg enable_fisheye2)"/>
 
     <param name="depth_width"              type="int"  value="$(arg depth_width)"/>
     <param name="depth_height"             type="int"  value="$(arg depth_height)"/>

--- a/realsense2_camera/launch/rs_t265.launch
+++ b/realsense2_camera/launch/rs_t265.launch
@@ -12,7 +12,8 @@ https://github.com/IntelRealSense/librealsense/blob/master/third-party/libtm/lib
 
   <arg name="fisheye_width"       default="848"/> 
   <arg name="fisheye_height"      default="800"/>
-  <arg name="enable_fisheye"      default="true"/>
+  <arg name="enable_fisheye1"     default="true"/>
+  <arg name="enable_fisheye2"     default="true"/>
 
   <arg name="fisheye_fps"         default="30"/>
 
@@ -37,7 +38,8 @@ https://github.com/IntelRealSense/librealsense/blob/master/third-party/libtm/lib
 
       <arg name="fisheye_width"            value="$(arg fisheye_width)"/>
       <arg name="fisheye_height"           value="$(arg fisheye_height)"/>
-      <arg name="enable_fisheye"           value="$(arg enable_fisheye)"/>
+      <arg name="enable_fisheye1"          value="$(arg enable_fisheye1)"/>
+      <arg name="enable_fisheye2"          value="$(arg enable_fisheye2)"/>
 
       <arg name="fisheye_fps"              value="$(arg fisheye_fps)"/>
       <arg name="gyro_fps"                 value="$(arg gyro_fps)"/>

--- a/realsense2_camera/rviz/t265.rviz
+++ b/realsense2_camera/rviz/t265.rviz
@@ -1,0 +1,212 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /Odometry1
+        - /Odometry1/Shape1
+        - /Axes1
+        - /TF1
+        - /TF1/Frames1
+      Splitter Ratio: 0.740634024
+    Tree Height: 568
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.588679016
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.0299999993
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Angle Tolerance: 0.100000001
+      Class: rviz/Odometry
+      Covariance:
+        Orientation:
+          Alpha: 0.5
+          Color: 255; 255; 127
+          Color Style: Unique
+          Frame: Local
+          Offset: 1
+          Scale: 1
+          Value: true
+        Position:
+          Alpha: 0.300000012
+          Color: 204; 51; 204
+          Scale: 1
+          Value: true
+        Value: false
+      Enabled: true
+      Keep: 1
+      Name: Odometry
+      Position Tolerance: 0.100000001
+      Shape:
+        Alpha: 1
+        Axes Length: 0.300000012
+        Axes Radius: 0.0299999993
+        Color: 255; 25; 0
+        Head Length: 0.300000012
+        Head Radius: 0.100000001
+        Shaft Length: 1
+        Shaft Radius: 0.0500000007
+        Value: Axes
+      Topic: /camera/odom/sample
+      Unreliable: false
+      Value: true
+    - Class: rviz/Axes
+      Enabled: true
+      Length: 1
+      Name: Axes
+      Radius: 0.00999999978
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: false
+        camera_accel_frame:
+          Value: false
+        camera_accel_optical_frame:
+          Value: false
+        camera_fisheye1_frame:
+          Value: false
+        camera_fisheye1_optical_frame:
+          Value: false
+        camera_fisheye2_frame:
+          Value: false
+        camera_fisheye2_optical_frame:
+          Value: false
+        camera_gyro_frame:
+          Value: false
+        camera_gyro_optical_frame:
+          Value: false
+        camera_link:
+          Value: true
+        camera_pose_frame:
+          Value: false
+        camera_pose_optical_frame:
+          Value: false
+        camera_odom_frame:
+          Value: false
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: false
+      Tree:
+        camera_odom_frame:
+          camera_pose_optical_frame:
+            camera_pose_frame:
+              camera_link:
+                camera_accel_frame:
+                  camera_accel_optical_frame:
+                    {}
+                camera_fisheye1_frame:
+                  camera_fisheye1_optical_frame:
+                    {}
+                camera_fisheye2_frame:
+                  camera_fisheye2_optical_frame:
+                    {}
+                camera_gyro_frame:
+                  camera_gyro_optical_frame:
+                    {}
+      Update Interval: 0
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: camera_odom_frame
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Topic: /initialpose
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 1.40621364
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.0599999987
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0
+        Y: 0
+        Z: 0
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.0500000007
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.00999999978
+      Pitch: 0.315398008
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 5.69856501
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 849
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000019b000002c7fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006100fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000028000002c7000000d700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002c7fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a005600690065007700730100000028000002c7000000ad00fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000005f00000003efc0100000002fb0000000800540069006d00650100000000000005f00000030000fffffffb0000000800540069006d006501000000000000045000000000000000000000033a000002c700000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1520
+  X: 65
+  Y: 24

--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -3,6 +3,7 @@
 
 #include "../include/realsense_node_factory.h"
 #include "../include/base_realsense_node.h"
+#include "../include/t265_realsense_node.h"
 #include <iostream>
 #include <map>
 #include <mutex>
@@ -203,8 +204,10 @@ void RealSenseNodeFactory::StartDevice()
 	case RS435_RGB_PID:
 	case RS435i_RGB_PID:
 	case RS_USB2_PID:
-	case RS_T265_PID:
 		_realSenseNode = std::unique_ptr<BaseRealSenseNode>(new BaseRealSenseNode(nh, privateNh, _device, _serial_no));
+		break;
+	case RS_T265_PID:
+		_realSenseNode = std::unique_ptr<T265RealsenseNode>(new T265RealsenseNode(nh, privateNh, _device, _serial_no));
 		break;
 	default:
 		ROS_FATAL_STREAM("Unsupported device!" << " Product ID: 0x" << pid_str);

--- a/realsense2_camera/src/t265_realsense_node.cpp
+++ b/realsense2_camera/src/t265_realsense_node.cpp
@@ -1,0 +1,60 @@
+#include "../include/t265_realsense_node.h"
+
+using namespace realsense2_camera;
+
+T265RealsenseNode::T265RealsenseNode(ros::NodeHandle& nodeHandle,
+                                     ros::NodeHandle& privateNodeHandle,
+                                     rs2::device dev,
+                                     const std::string& serial_no) : 
+                                     BaseRealSenseNode(nodeHandle, privateNodeHandle, dev, serial_no) {}
+
+void T265RealsenseNode::calcAndPublishStaticTransform(const stream_index_pair& stream, const rs2::stream_profile& base_profile)
+{
+    // Transform base to stream
+    tf::Quaternion quaternion_optical;
+    quaternion_optical.setRPY(M_PI / 2, 0.0, -M_PI / 2);
+    float3 zero_trans{0, 0, 0};
+
+    ros::Time transform_ts_ = ros::Time::now();
+
+    rs2_extrinsics ex;
+    try
+    {
+        ex = getAProfile(stream).get_extrinsics_to(base_profile);
+    }
+    catch (std::exception& e)
+    {
+        if (!strcmp(e.what(), "Requested extrinsics are not available!"))
+        {
+            ROS_WARN_STREAM(e.what() << " : using unity as default.");
+            ex = rs2_extrinsics({{1, 0, 0, 0, 1, 0, 0, 0, 1}, {0,0,0}});
+        }
+        else
+        {
+            throw e;
+        }
+    }
+
+    auto Q = rotationMatrixToQuaternion(ex.rotation);
+    Q = quaternion_optical * Q * quaternion_optical.inverse();
+    float3 trans{ex.translation[0], ex.translation[1], ex.translation[2]};
+    if (stream == POSE)
+    {
+        Q = Q.inverse();
+        quaternion_optical = quaternion_optical.inverse();
+
+        publish_static_tf(transform_ts_, trans, Q, _frame_id[stream], _base_frame_id);
+    }
+    else
+    {
+        publish_static_tf(transform_ts_, trans, Q, _base_frame_id, _frame_id[stream]);
+        publish_static_tf(transform_ts_, zero_trans, quaternion_optical, _frame_id[stream], _optical_frame_id[stream]);
+
+        // Add align_depth_to if exist:
+        if (_align_depth && _depth_aligned_frame_id.find(stream) != _depth_aligned_frame_id.end())
+        {
+            publish_static_tf(transform_ts_, trans, Q, _base_frame_id, _depth_aligned_frame_id[stream]);
+            publish_static_tf(transform_ts_, zero_trans, quaternion_optical, _depth_aligned_frame_id[stream], _optical_frame_id[stream]);
+        }
+    }
+}


### PR DESCRIPTION
The inner coordinate system of t265 is different then the d400 series. Added a child class to handle it.
renamed spatial_frame to odom_frame. 
publish tf transform for camera_odom_frame always, not waiting for the topic /camera/odom/sample to be subscribed to.
