### PR TITLE
Set defaults from param server

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -217,14 +217,22 @@ std::map<std::string, int> get_enum_method(rs2::options sensor, rs2_option optio
 }
 
 /**
+ * Same as ros::names::isValidCharInName, but re-implemented here because it's not exposed.
+ */
+bool isValidCharInName(char c)
+{
+    return std::isalnum(c) || c == '/' || c == '_';
+}
+
+/**
  * ROS Graph Resource names don't allow spaces and hyphens (see http://wiki.ros.org/Names),
  * so we replace them here with underscores.
  */
 std::string create_graph_resource_name(const std::string &original_name)
 {
   std::string fixed_name = original_name;
-  std::replace(fixed_name.begin(), fixed_name.end(), '-', '_');
-  std::replace(fixed_name.begin(), fixed_name.end(), ' ', '_');
+  std::replace_if(fixed_name.begin(), fixed_name.end(), [](const char c) { return !isValidCharInName(c); },
+                  '_');
   return fixed_name;
 }
 

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -209,9 +209,12 @@ std::map<std::string, int> get_enum_method(rs2::options sensor, rs2_option optio
     if (is_enum_option(sensor, option))
     {
         rs2::option_range op_range = sensor.get_option_range(option);
-        for (auto val = op_range.min; val <= op_range.max; val += op_range.step)
+        const auto op_range_min = int(op_range.min);
+        const auto op_range_max = int(op_range.max);
+        const auto op_range_step = int(op_range.step);
+        for (auto val = op_range_min; val <= op_range_max; val += op_range_step)
         {
-            dict[sensor.get_option_value_description(option, val)] = int(val);
+            dict[sensor.get_option_value_description(option, val)] = val;
         }
     }
     return dict;

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -2,6 +2,7 @@
 #include "assert.h"
 #include <boost/algorithm/string.hpp>
 #include <algorithm>
+#include <cctype>
 #include <mutex>
 #include <tf/transform_broadcaster.h>
 
@@ -231,6 +232,8 @@ bool isValidCharInName(char c)
 std::string create_graph_resource_name(const std::string &original_name)
 {
   std::string fixed_name = original_name;
+  std::transform(fixed_name.begin(), fixed_name.end(), fixed_name.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
   std::replace_if(fixed_name.begin(), fixed_name.end(), [](const char c) { return !isValidCharInName(c); },
                   '_');
   return fixed_name;


### PR DESCRIPTION
This provides a fix for #609 that works as follows for each option:

- It sets the `option_name` to `create_graph_resource_name(rs2_option_to_string(option)))`. Same as before, which is used for both the `ddynamic_reconfigure` and ROS (static) param.
- It takes the default value from `sensor.get_option(option)`, which was passed to the `DD*` param constructors before. Now it's assigned to `option_value`.
- Then it tries to load a param from the `nh1` node handle namespace for the `option_name`, using `option_value` as default. If the param was set in the ROS param server, `nh1.param` returns `true`, in which case we set the option to that value in the sensor with `sensor.set_option(option, option_value)`. Without this the params are set but the sensor still runs with its own defaults.
- For options with `min` and `max`, if the value in the ROS param server is out of the `[min, max]` range, a `ROS_WARN` log message is reported and the default value from the sensor is used, as before.
- For enum options, if the value is greater than the number of enums supported, a `ROS_WARN` log message is reported and the default value from the sensor is used, as before.
- Finally, the `DD*` param is constructed and added to the `ddynamic_reconfigure`.

The fix is provided in this commit: https://github.com/intel-ros/realsense/commit/97dd66ee05326bb9b5b9070035bc437d906c3f73

A better fix would be to make `ddynamic_reconfigure` work as `dynamic_reconfigure`, implementing the behavior explained by @stwirth in https://github.com/intel-ros/realsense/issues/609#issuecomment-464836205. However, this repo has a copy of `ddynamic_reconfigure`, so I'm reluctant of making any changes to that package. I've already contacted @awesomebytes to see if we could implement some of those changes in https://github.com/awesomebytes/ddynamic_reconfigure, and more importantly, if we could add it to the official ROS distro https://github.com/ros/rosdistro/blob/master/melodic/distribution.yaml, so you don't have to copy it here, which makes it very hard to maintain and extend.

The two other commits are optional:

1. https://github.com/intel-ros/realsense/commit/1840901de6944a9c12aaebce8bf5dae8e4b459a4 provides a small change to follow the same code used in `ros::names`

2. https://github.com/intel-ros/realsense/commit/8866e8ac503fb9538c3d29d5f14d433951c081e2 transforms to lower case, which IMHO it's more correct because param names are usually lower case. This will require people to update the names of their params to lower case, but since this was already broken, this is probably a good time to get this done properly. Either way, I made this change in a separate commit so I can easily drop it from this PR if you don't like it.