### PR TITLE
Add dependency on nav_msgs

### DIFF
--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -7,6 +7,7 @@ option(SET_USER_BREAK_AT_STARTUP "Set user wait point in startup (for debug)" OF
 
 find_package(catkin REQUIRED COMPONENTS
     message_generation
+    nav_msgs
     roscpp
     sensor_msgs
     std_msgs
@@ -73,6 +74,7 @@ catkin_package(
     cv_bridge
     image_transport
     ddynamic_reconfigure
+    nav_msgs
     )
 
 add_library(${PROJECT_NAME}

--- a/realsense2_camera/package.xml
+++ b/realsense2_camera/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <depend>image_transport</depend>
   <depend>cv_bridge</depend>
+  <depend>nav_msgs</depend>
   <depend>nodelet</depend>  
   <depend>genmsg</depend>
   <depend>roscpp</depend>


### PR DESCRIPTION
`nav_msgs` is used in:

``` bash
realsense2_camera/include/base_realsense_node.h
16:#include <nav_msgs/Odometry.h>

realsense2_camera/src/base_realsense_node.cpp
627:        _imu_publishers[POSE] = _node_handle.advertise<nav_msgs::Odometry>("odom/sample", 100);
1203:        nav_msgs::Odometry odom_msg;
```