### PR TITLE
fix depth scale

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -190,7 +190,8 @@ namespace realsense2_camera
         void setupFilters();
         void setupStreams();
         void setBaseTime(double frame_time, bool warn_no_metadata);
-        void clip_depth(rs2::depth_frame& depth_frame, float depth_scale, float clipping_dist);
+        void fix_depth_scale(rs2::depth_frame& depth_frame);
+        void clip_depth(rs2::depth_frame& depth_frame, float clipping_dist);
         void updateStreamCalibData(const rs2::video_stream_profile& video_profile);
         void publishStaticTransforms();
         void publishPointCloud(rs2::points f, const ros::Time& t, const rs2::frameset& frameset);

--- a/realsense2_camera/include/constants.h
+++ b/realsense2_camera/include/constants.h
@@ -81,5 +81,6 @@ namespace realsense2_camera
     const std::string DEFAULT_UNITE_IMU_METHOD         = "";
     const std::string DEFAULT_FILTERS                  = "";
 
+    const float ROS_DEPTH_SCALE = 0.001;
     using stream_index_pair = std::pair<rs2_stream, int>;
 }  // namespace realsense2_camera

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -255,7 +255,21 @@ void BaseRealSenseNode::registerDynamicOption(ros::NodeHandle& nh, rs2::options 
             }
             else
             {
-                ddynrec->add(new DDDouble(option_name, i, sensor.get_option_description(option), sensor.get_option(option), op_range.min, op_range.max));
+                if (i == RS2_OPTION_DEPTH_UNITS)
+                {
+                    if (ROS_DEPTH_SCALE >= op_range.min && ROS_DEPTH_SCALE <= op_range.max)
+                    {
+                        sensor.set_option(option, ROS_DEPTH_SCALE);
+                        op_range.min = ROS_DEPTH_SCALE;
+                        op_range.max = ROS_DEPTH_SCALE;
+
+                        _depth_scale_meters = ROS_DEPTH_SCALE;
+                    }
+                }
+                else
+                {
+                    ddynrec->add(new DDDouble(option_name, i, sensor.get_option_description(option), sensor.get_option(option), op_range.min, op_range.max));
+                }
             }
         }
         else
@@ -305,6 +319,10 @@ void BaseRealSenseNode::callback(const ddynamic_reconfigure::DDMap& map, int lev
     double value = get(map, option_name.c_str()).toDouble();
     ROS_DEBUG_STREAM("option: " << option_name << ". value: " << value);
     sensor.set_option(option, value);
+    // if (option == RS2_OPTION_DEPTH_UNITS)
+    // {
+    //     _depth_scale_meters = ROS_DEPTH_SCALE;
+    // }
 }
 
 rs2_stream BaseRealSenseNode::rs2_string_to_stream(std::string str)
@@ -861,9 +879,13 @@ void BaseRealSenseNode::setupFilters()
     ROS_INFO("num_filters: %d", static_cast<int>(_filters.size()));
 }
 
-void BaseRealSenseNode::clip_depth(rs2::depth_frame& depth_frame, float depth_scale, float clipping_dist)
+void BaseRealSenseNode::fix_depth_scale(rs2::depth_frame& depth_frame)
 {
     uint16_t* p_depth_frame = reinterpret_cast<uint16_t*>(const_cast<void*>(depth_frame.get_data()));
+
+    static const auto meter_to_mm = 0.001f;
+    if (abs(_depth_scale_meters - meter_to_mm) < 1e-6)
+        return;
 
     int width = depth_frame.get_width();
     int height = depth_frame.get_height();
@@ -876,13 +898,31 @@ void BaseRealSenseNode::clip_depth(rs2::depth_frame& depth_frame, float depth_sc
         auto depth_pixel_index = y * width;
         for (int x = 0; x < width; x++, ++depth_pixel_index)
         {
-            // Get the depth value of the current pixel
-            auto pixels_distance = depth_scale * p_depth_frame[depth_pixel_index];
+            p_depth_frame[depth_pixel_index] *= _depth_scale_meters / meter_to_mm;
+        }
+    }
+}
 
+void BaseRealSenseNode::clip_depth(rs2::depth_frame& depth_frame, float clipping_dist)
+{
+    uint16_t* p_depth_frame = reinterpret_cast<uint16_t*>(const_cast<void*>(depth_frame.get_data()));
+
+    int width = depth_frame.get_width();
+    int height = depth_frame.get_height();
+
+    #ifdef _OPENMP
+    #pragma omp parallel for schedule(dynamic) //Using OpenMP to try to parallelise the loop
+    #endif
+    uint16_t clipping_value = static_cast<uint16_t>(clipping_dist / _depth_scale_meters);
+    for (int y = 0; y < height; y++)
+    {
+        auto depth_pixel_index = y * width;
+        for (int x = 0; x < width; x++, ++depth_pixel_index)
+        {
             // Check if the depth value is greater than the threashold
-            if (pixels_distance > clipping_dist)
+            if (p_depth_frame[depth_pixel_index] > clipping_value)
             {
-                p_depth_frame[depth_pixel_index] = -1; //Set to invalid (<=0) value.
+                p_depth_frame[depth_pixel_index] = 0; //Set to invalid (<=0) value.
             }
         }
     }
@@ -1257,7 +1297,6 @@ void BaseRealSenseNode::frame_callback(rs2::frame frame)
         {
             ROS_DEBUG("Frameset arrived.");
             bool is_depth_arrived = false;
-            rs2::frame depth_frame;
             auto frameset = frame.as<rs2::frameset>();
             ROS_DEBUG("List of frameset before applying filters: size: %d", static_cast<int>(frameset.size()));
             for (auto it = frameset.begin(); it != frameset.end(); ++it)
@@ -1272,11 +1311,14 @@ void BaseRealSenseNode::frame_callback(rs2::frame frame)
                             rs2_stream_to_string(stream_type), stream_index, rs2_format_to_string(stream_format), stream_unique_id, frame.get_frame_number(), frame_time, t.toNSec());
             }
             // Clip depth_frame for max range:
-            if (_clipping_distance > 0)
+            rs2::depth_frame depth_frame = frameset.get_depth_frame();
+            if (depth_frame)
             {
-                rs2::depth_frame depth_frame = frameset.get_depth_frame();
-                if (depth_frame)
-                    this->clip_depth(depth_frame,_depth_scale_meters, _clipping_distance);
+                fix_depth_scale(depth_frame);
+                if (_clipping_distance > 0)
+                {
+                    this->clip_depth(depth_frame, _clipping_distance);
+                }
             }
 
 
@@ -1334,7 +1376,6 @@ void BaseRealSenseNode::frame_callback(rs2::frame frame)
                 }
                 if (_align_depth && stream_type == RS2_STREAM_DEPTH && stream_format == RS2_FORMAT_Z16)
                 {
-                    depth_frame = f;
                     is_depth_arrived = true;
                 }
             }

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -319,10 +319,6 @@ void BaseRealSenseNode::callback(const ddynamic_reconfigure::DDMap& map, int lev
     double value = get(map, option_name.c_str()).toDouble();
     ROS_DEBUG_STREAM("option: " << option_name << ". value: " << value);
     sensor.set_option(option, value);
-    // if (option == RS2_OPTION_DEPTH_UNITS)
-    // {
-    //     _depth_scale_meters = ROS_DEPTH_SCALE;
-    // }
 }
 
 rs2_stream BaseRealSenseNode::rs2_string_to_stream(std::string str)


### PR DESCRIPTION
For the D400 series, the default depth scale was 1mm which complies with ROS standard.
No handling was done to take care of situations where the depth scale was changed using dynamic reconfigure or an SR300 camera was used.
Since ROS dictates fixed depth scale of 1mm there is no point of leaving the option to change it and therefor it was disabled.
For devices that don't support the 1mm scale (SR300), a calibration is activated.
