### PR TITLE
Better timestamp correction

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -193,7 +193,7 @@ namespace realsense2_camera
         double timestampFromFrame(const rs2::frame &frame);
 	double elapsedTimeFromFrame(const rs2::frame &frame);
 	double frameTime(const rs2::frame &frame);
-        void fix_depth_scale(rs2::depth_frame depth_frame);
+        cv::Mat& fix_depth_scale(const cv::Mat& from_image, cv::Mat& to_image);
         void clip_depth(rs2::depth_frame depth_frame, float clipping_dist);
         void updateStreamCalibData(const rs2::video_stream_profile& video_profile);
         void publishStaticTransforms();

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -189,7 +189,9 @@ namespace realsense2_camera
         void enable_devices();
         void setupFilters();
         void setupStreams();
-        void setBaseTime(double frame_time, bool warn_no_metadata);
+        double timestampFromFrame(const rs2::frame &frame);
+	double elapsedTimeFromFrame(const rs2::frame &frame);
+	double frameTime(const rs2::frame &frame);
         void fix_depth_scale(rs2::depth_frame depth_frame);
         void clip_depth(rs2::depth_frame depth_frame, float clipping_dist);
         void updateStreamCalibData(const rs2::video_stream_profile& video_profile);
@@ -257,12 +259,14 @@ namespace realsense2_camera
         std::map<stream_index_pair, int> _seq;
         std::map<rs2_stream, int> _unit_step_size;
         std::map<stream_index_pair, sensor_msgs::CameraInfo> _camera_info;
-        std::atomic_bool _is_initialized_time_base;
-        double _camera_time_base;
+        double _timestampDiff;
+        double _timestampStart;
+        enum TimestampSouce {TIMESTAMP_SOURCE_NONE,TIMESTAMP_SOURCE_METADATA,TIMESTAMP_SOURCE_TIMESTAMP};
+        TimestampSouce _timestampSource;
+        bool _skipTimestampCorrection;
         std::map<stream_index_pair, std::vector<rs2::stream_profile>> _enabled_profiles;
 
         ros::Publisher _pointcloud_publisher;
-        ros::Time _ros_time_base;
         bool _sync_frames;
         bool _pointcloud;
         imu_sync_method _imu_sync_method;

--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -158,8 +158,6 @@ void RealSenseNodeFactory::onInit()
 		}
 		else
 		{
-			std::function<void(rs2::event_information&)> change_device_callback_function = [this](rs2::event_information& info){change_device_callback(info);};
-			_ctx.set_devices_changed_callback(change_device_callback_function);
 			privateNh.param("initial_reset", _initial_reset, false);
 			_device = getDevice();
 		}
@@ -167,6 +165,11 @@ void RealSenseNodeFactory::onInit()
 		if (_device)
 		{
 			StartDevice();
+		}
+		if (rosbag_filename.empty())
+		{
+			std::function<void(rs2::event_information&)> change_device_callback_function = [this](rs2::event_information& info){change_device_callback(info);};
+			_ctx.set_devices_changed_callback(change_device_callback_function);
 		}
 	}
 	catch(const std::exception& ex)


### PR DESCRIPTION
1. Recent librealsense(on T265) returns timestamp of system time. 
 This is the change of librealsense.
https://github.com/IntelRealSense/librealsense/pull/3609/commits/5a6e1c4b691e1e142932f475c40c40a64db7b5e0

   So I got the WRAN message "Frame metadata isn't available!".
   In librealsense,You can get frame time by RS2_FRAME_METADATA_FRAME_TIMESTAMP.
   In "frame_time()" , I try to get FREAME_TIME,and use get_timestamp() as backup method.
   latest lirealsense dose not have the metadata yet , but you can get it by small patch.
https://github.com/akirayou/librealsense/commit/ecbcb32358dda9535ccd9e72146ea7178311b1ed

2.In case of T265 device clock seems to be  already corrected by librealsense.
 Additional time correction is bad idea.it makes more system latency. So I want to skip the time correction. 
 Please see: time correction part of librealsense(for T265)
  https://github.com/IntelRealSense/librealsense/blob/1148c9b4d50a653119fbb666e52acb8b850bb18c/third-party/libtm/libtm/src/Device.cpp#L230-L274

3.For other device (which have there own device timestamp)
Device's clock have slightly different speed.So periodic time correction is needed.
But in original implementation ,setBaseTime is called only one time. 
So I wrote continuous time correction with IIR filter in  "timestampFromFrame()"


4.To make it stable.
Original implimentation of  realsense_node_factory.cpp
Change_device_callback is enabled before StartDevice().
Sometimes it makes twice calling of StartDevice().
It makes my code unstable.
I workaround this( change_device_callback is enabled after the StartDevice).

