### PR TITLE
Fix empty cmake variable and dependency on librealsense

### DIFF
--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -59,10 +59,11 @@ generate_messages(
     std_msgs
     )
 
+set(CMAKE_NO_SYSTEM_FROM_IMPORTED true)
 include_directories(
     include
+    ${realsense2_INCLUDE_DIR}
     ${catkin_INCLUDE_DIRS}
-    ${realsense_INCLUDE_DIR}
     )
 
 # RealSense ROS Node
@@ -88,9 +89,8 @@ add_library(${PROJECT_NAME}
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_generate_messages_cpp)
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 
-
 target_include_directories(${PROJECT_NAME}
-  PRIVATE ${realsense_INCLUDE_DIR})
+  PRIVATE ${realsense2_INCLUDE_DIR})
 
 target_link_libraries(${PROJECT_NAME}
     ${realsense2_LIBRARY}

--- a/realsense2_camera/package.xml
+++ b/realsense2_camera/package.xml
@@ -24,6 +24,7 @@
   <depend>tf</depend>
   <depend>ddynamic_reconfigure</depend>
   <depend>diagnostic_updater</depend>
+  <depend>librealsense2</depend>
   <export>
     <nodelet plugin="${prefix}/nodelet_plugins.xml" />
   </export>


### PR DESCRIPTION
This pull requests fixes the following issues:
- the CMake variable `realsense_INCLUDE_DIR` was empty. The correct one is `realsense2_INCLUDE_DIR`.
- the catkin package `librealsense` was not listed as dependency for the package `realsense2_camera`
- the include for `librealsense` was forced to be `-isystem` by CMake. We force to use the local import. This was necessary when an old version of the library is installed system wide and a newer version is available in the local catkin workspace. CMakes attempts to use the system wide includes with the local library binary file.