### PR TITLE
fixed t265 conflict

### DIFF
--- a/realsense2_camera/include/realsense_node_factory.h
+++ b/realsense2_camera/include/realsense_node_factory.h
@@ -21,6 +21,7 @@
 #include <csignal>
 #include <eigen3/Eigen/Geometry>
 #include <fstream>
+#include <thread>
 
 namespace realsense2_camera
 {
@@ -62,7 +63,7 @@ namespace realsense2_camera
         static void closeDevice();
         void StartDevice();
         void change_device_callback(rs2::event_information& info);
-        rs2::device getDevice();
+        void getDevice(rs2::device_list list);
         virtual void onInit() override;
         void tryGetLogSeverity(rs2_log_severity& severity) const;
 
@@ -70,5 +71,7 @@ namespace realsense2_camera
         rs2::context _ctx;
         std::string _serial_no;
         bool _initial_reset;
+        std::thread _query_thread;
+
     };
 }//end namespace

--- a/realsense2_camera/launch/rs_multiple_devices.launch
+++ b/realsense2_camera/launch/rs_multiple_devices.launch
@@ -1,10 +1,13 @@
 <launch>
   <arg name="serial_no_camera1"    			default=""/> 			<!-- Note: Replace with actual serial number -->
   <arg name="serial_no_camera2"    			default=""/> 			<!-- Note: Replace with actual serial number -->
+  <arg name="serial_no_camera3"    			default=""/> 			<!-- Note: Replace with actual serial number -->
   <arg name="camera1"              			default="camera1"/>		<!-- Note: Replace with camera name -->
   <arg name="camera2"              			default="camera2"/>		<!-- Note: Replace with camera name -->
+  <arg name="camera3"              			default="camera3"/>		<!-- Note: Replace with camera name -->
   <arg name="tf_prefix_camera1"         default="$(arg camera1)"/>
   <arg name="tf_prefix_camera2"         default="$(arg camera2)"/>
+  <arg name="tf_prefix_camera3"         default="$(arg camera3)"/>
   <arg name="initial_reset"             default="false"/>
 
   <group ns="$(arg camera1)">
@@ -19,6 +22,14 @@
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
       <arg name="serial_no"             value="$(arg serial_no_camera2)"/>
       <arg name="tf_prefix"		          value="$(arg tf_prefix_camera2)"/>
+      <arg name="initial_reset"         value="$(arg initial_reset)"/>
+    </include>
+  </group>
+
+  <group ns="$(arg camera3)" if="$(eval serial_no_camera3 != '')">
+    <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
+      <arg name="serial_no"             value="$(arg serial_no_camera3)"/>
+      <arg name="tf_prefix"		          value="$(arg tf_prefix_camera3)"/>
       <arg name="initial_reset"         value="$(arg initial_reset)"/>
     </include>
   </group>

--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -147,16 +147,18 @@ void RealSenseNodeFactory::onInit()
 		privateNh.param("rosbag_filename", rosbag_filename, std::string(""));
 		if (!rosbag_filename.empty())
 		{
-			ROS_INFO_STREAM("publish topics from rosbag file: " << rosbag_filename.c_str());
-			auto pipe = std::make_shared<rs2::pipeline>();
-			rs2::config cfg;
-			cfg.enable_device_from_file(rosbag_filename.c_str(), false);
-			cfg.enable_all_streams();
-			pipe->start(cfg); //File will be opened in read mode at this point
-			_device = pipe->get_active_profile().get_device();
-			_realSenseNode = std::unique_ptr<BaseRealSenseNode>(new BaseRealSenseNode(nh, privateNh, _device, _serial_no));
-			_realSenseNode->publishTopics();
-			_realSenseNode->registerDynamicReconfigCb(nh);
+			{
+				ROS_INFO_STREAM("publish topics from rosbag file: " << rosbag_filename.c_str());
+				auto pipe = std::make_shared<rs2::pipeline>();
+				rs2::config cfg;
+				cfg.enable_device_from_file(rosbag_filename.c_str(), false);
+				cfg.enable_all_streams();
+				pipe->start(cfg); //File will be opened in read mode at this point
+				_device = pipe->get_active_profile().get_device();
+				_realSenseNode = std::unique_ptr<BaseRealSenseNode>(new BaseRealSenseNode(nh, privateNh, _device, _serial_no));
+				_realSenseNode->publishTopics();
+				_realSenseNode->registerDynamicReconfigCb(nh);
+			}
 			if (_device)
 			{
 				StartDevice();


### PR DESCRIPTION
set_devices_changed_callback called AFTER getDevice()
Keep checking for devices until device is found - for cases where T265 was momentarily taken by another node at the time of query.

Add a 3rd, optional camera, to rs_multiple_devices.launch file.