### PR TITLE
add accel/imu_info and gyro/imu_info as services, instead of topics.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 install:
   # install ROS:
   - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-  - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
   - sudo apt-get update -qq
   - sudo apt-get install ros-kinetic-ros-base -y
   - sudo rosdep init

--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(catkin REQUIRED COMPONENTS
     tf
     ddynamic_reconfigure
     diagnostic_updater
+    std_srvs
     )
 
 if(BUILD_WITH_OPENMP)
@@ -50,9 +51,13 @@ set(CMAKE_CXX_FLAGS "-fPIE -fPIC -std=c++11 -D_FORTIFY_SOURCE=2 -fstack-protecto
 
 add_message_files(
     FILES
-    IMUInfo.msg
     Extrinsics.msg
     )
+
+add_service_files(
+    FILES
+    IMUInfo.srv
+)
 
 generate_messages(
     DEPENDENCIES

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -13,6 +13,7 @@
 #include <sensor_msgs/point_cloud2_iterator.h>
 #include <sensor_msgs/Imu.h>
 #include <nav_msgs/Odometry.h>
+#include <realsense2_camera/IMUInfo.h>
 
 #include <queue>
 #include <mutex>
@@ -197,7 +198,7 @@ namespace realsense2_camera
         void publishPointCloud(rs2::points f, const ros::Time& t, const rs2::frameset& frameset);
         Extrinsics rsExtrinsicsToMsg(const rs2_extrinsics& extrinsics, const std::string& frame_id) const;
 
-        IMUInfo getImuInfo(const stream_index_pair& stream_index);
+        IMUInfoResponse getImuInfo(const stream_index_pair& stream_index);
         void publishFrame(rs2::frame f, const ros::Time& t,
                           const stream_index_pair& stream,
                           std::map<stream_index_pair, cv::Mat>& images,
@@ -220,6 +221,10 @@ namespace realsense2_camera
         void frame_callback(rs2::frame frame);
         void registerDynamicOption(ros::NodeHandle& nh, rs2::options sensor, std::string& module_name);
         rs2_stream rs2_string_to_stream(std::string str);
+        bool service_accel_info(realsense2_camera::IMUInfoRequest &req,
+                                realsense2_camera::IMUInfoResponse &res);
+        bool service_gyro_info(realsense2_camera::IMUInfoRequest &req,
+                                realsense2_camera::IMUInfoResponse &res);
 
         rs2::device _dev;
         std::map<stream_index_pair, rs2::sensor> _sensors;
@@ -249,6 +254,7 @@ namespace realsense2_camera
         std::shared_ptr<SyncedImuPublisher> _synced_imu_publisher;
         std::map<rs2_stream, int> _image_format;
         std::map<stream_index_pair, ros::Publisher> _info_publisher;
+        std::map<stream_index_pair, ros::ServiceServer > _info_service;
         std::map<stream_index_pair, cv::Mat> _image;
         std::map<rs2_stream, std::string> _encoding;
 

--- a/realsense2_camera/include/realsense_node_factory.h
+++ b/realsense2_camera/include/realsense_node_factory.h
@@ -17,7 +17,6 @@
 #include <realsense2_camera/Extrinsics.h>
 #include <tf/transform_broadcaster.h>
 #include <tf2_ros/static_transform_broadcaster.h>
-#include <realsense2_camera/IMUInfo.h>
 #include <csignal>
 #include <eigen3/Eigen/Geometry>
 #include <fstream>

--- a/realsense2_camera/msg/IMUInfo.msg
+++ b/realsense2_camera/msg/IMUInfo.msg
@@ -1,6 +1,0 @@
-# header.frame_id is either set to "imu_accel" or "imu_gyro"
-# to distinguish between "accel" and "gyro" info.
-std_msgs/Header header
-float64[12] data
-float64[3] noise_variances
-float64[3] bias_variances

--- a/realsense2_camera/srv/IMUInfo.srv
+++ b/realsense2_camera/srv/IMUInfo.srv
@@ -1,0 +1,5 @@
+---
+string frame_id
+float64[12] data
+float64[3] noise_variances
+float64[3] bias_variances


### PR DESCRIPTION
Since the intrinsics for the IMU never change, there is no point in sending it every frame.
Convert them to services.
Can be called like that:
`rosservice call /camera/gyro/imu_info`
