### PR TITLE
fixed bug: advertise unsupported streams.

### DIFF
--- a/realsense2_camera/scripts/rs2_test.py
+++ b/realsense2_camera/scripts/rs2_test.py
@@ -39,7 +39,7 @@ def AccelGetData(rec_filename):
 def AccelGetDataDeviceStandStraight(rec_filename):
     gt_data = AccelGetData(rec_filename)
     gt_data['ros_value'] = np.array([0.63839424, 0.05380408, 9.85343552])
-    gt_data['ros_max_diff'] = np.array([1.97013582e-02, 4.65862500e-09, 2.06165277e-02])
+    gt_data['ros_max_diff'] = np.array([1.97013582e-02, 4.65862500e-09, 4.06165277e-02])
     return gt_data
 
 def ImuTest(data, gt_data):

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -170,8 +170,8 @@ void BaseRealSenseNode::publishTopics()
     getParameters();
     setupDevice();
     setupErrorCallback();
-    setupPublishers();
     setupStreams();
+    setupPublishers();
     setupFilters();
     publishStaticTransforms();
     ROS_INFO_STREAM("RealSense Node Is Up!");

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -170,8 +170,9 @@ void BaseRealSenseNode::publishTopics()
     getParameters();
     setupDevice();
     setupErrorCallback();
-    setupStreams();
+    enable_devices();
     setupPublishers();
+    setupStreams();
     setupFilters();
     publishStaticTransforms();
     ROS_INFO_STREAM("RealSense Node Is Up!");
@@ -866,6 +867,7 @@ void BaseRealSenseNode::enable_devices()
                     if (profile.stream_type() != elem.first) continue;
                     ROS_WARN_STREAM("fps: " << profile.fps() << ". format: " << profile.format());
                 }
+                _enable[elem] = false;
             }
         }
     }
@@ -1550,7 +1552,6 @@ void BaseRealSenseNode::setBaseTime(double frame_time, bool warn_no_metadata)
 void BaseRealSenseNode::setupStreams()
 {
 	ROS_INFO("setupStreams...");
-	enable_devices();
     try{
 		// Publish image stream info
         for (auto& profiles : _enabled_profiles)


### PR DESCRIPTION
Currently, if an unsupported stream is requested, say fisheye image of 640x480 with T265, the topic is advertised but no messages are sent.
This PR fix this issue by not advertising unavailable topics.
