### PR TITLE
move ddynamic_reconfigure settings prior to start streaming.

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -169,6 +169,7 @@ void BaseRealSenseNode::publishTopics()
 {
     getParameters();
     setupDevice();
+    registerDynamicReconfigCb(_node_handle);
     setupErrorCallback();
     enable_devices();
     setupPublishers();
@@ -296,7 +297,7 @@ void BaseRealSenseNode::registerDynamicOption(ros::NodeHandle& nh, rs2::options 
             {
                 if (option_value < op_range.min || op_range.max < option_value)
                 {
-                    ROS_WARN_STREAM("Param '" << nh1.resolveName(option_name) << "' has value " << option
+                    ROS_WARN_STREAM("Param '" << nh1.resolveName(option_name) << "' has value " << option_value
                             << " outside the range [" << op_range.min << ", " << op_range.max
                             << "]. Using current sensor value " << sensor_option_value << " instead.");
                     option_value = sensor_option_value;

--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -229,7 +229,6 @@ void RealSenseNodeFactory::StartDevice()
 	}
 	assert(_realSenseNode);
 	_realSenseNode->publishTopics();
-	_realSenseNode->registerDynamicReconfigCb(nh);
 }
 
 void RealSenseNodeFactory::tryGetLogSeverity(rs2_log_severity& severity) const


### PR DESCRIPTION
Allowing configuration of parameters that needs setting before streaming starts, such as inter_cam_sync_mode