### PR TITLE
Get serial service

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,17 @@ After running the above command with D435i attached, the following list of topic
 The "/camera" prefix is the default and can be changed. Check the rs_multiple_devices.launch file for an example.
 If using D435 or D415, the gyro and accel topics wont be available. Likewise, other topics will be available when using T265 (see below).
 
-### Launch parameters
+### Advertised Services
+The camera node advertises a service to query the device serial number:
+- /camera/get_serial
+
+The service is of type [`std_srvs/Trigger`](http://docs.ros.org/melodic/api/std_srvs/html/srv/Trigger.html) and returns the serial number in the response `message` field. To call the service via the command line:
+```bash
+rosservice call /camera/get_serial
+```
+
+
+### Launch Parameters
 The following parameters are available by the wrapper:
 - **serial_no**: will attach to the device with the given serial number. Default, attach to available RealSense device in random.
 - **rosbag_filename**: Will publish topics from rosbag file.

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -15,6 +15,7 @@
 #include <nav_msgs/Odometry.h>
 #include <tf/transform_broadcaster.h>
 #include <tf2_ros/static_transform_broadcaster.h>
+#include <std_srvs/Trigger.h>
 
 #include <queue>
 #include <mutex>
@@ -185,6 +186,8 @@ namespace realsense2_camera
 
         static std::string getNamespaceStr();
         void getParameters();
+        void getSerial(std_srvs::Trigger::Request &req,
+                       std_srvs::Trigger::Response &res);
         void setupDevice();
         void setupErrorCallback();
         void setupPublishers();

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -288,6 +288,8 @@ namespace realsense2_camera
         std::map<stream_index_pair, ros::Publisher> _depth_to_other_extrinsics_publishers;
         std::map<stream_index_pair, rs2_extrinsics> _depth_to_other_extrinsics;
 
+        ros::ServiceServer _get_serial_service;
+
         const std::string _namespace;
 
     };//end class

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -186,7 +186,7 @@ namespace realsense2_camera
 
         static std::string getNamespaceStr();
         void getParameters();
-        void getSerial(std_srvs::Trigger::Request &req,
+        bool getSerial(std_srvs::Trigger::Request &req,
                        std_srvs::Trigger::Response &res);
         void setupDevice();
         void setupErrorCallback();

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -492,6 +492,12 @@ void BaseRealSenseNode::getParameters()
     _pnh.param("publish_odom_tf", _publish_odom_tf, PUBLISH_ODOM_TF);
 }
 
+void BaseRealSenseNode::getSerial(std_srvs::Trigger::Request &req,
+                                  std_srvs::Trigger::Response &res)
+{
+    ROS_INFO("getSerial...");
+}
+
 void BaseRealSenseNode::setupDevice()
 {
     ROS_INFO("setupDevice...");
@@ -679,6 +685,8 @@ void BaseRealSenseNode::setupPublishers()
                 _pointcloud_publisher = _node_handle.advertise<sensor_msgs::PointCloud2>("depth/color/points", 1);
             }
         }
+
+        ros::ServiceServer get_serial_service = _node_handle.advertiseService("get_serial", &BaseRealSenseNode::getSerial, &this);
     }
 
     _synced_imu_publisher = std::make_shared<SyncedImuPublisher>();

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -496,6 +496,9 @@ bool BaseRealSenseNode::getSerial(std_srvs::Trigger::Request &req,
                                   std_srvs::Trigger::Response &res)
 {
     ROS_INFO("getSerial...");
+    res.message = _serial_no;
+    res.success = true;
+    return true;
 }
 
 void BaseRealSenseNode::setupDevice()

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -492,7 +492,7 @@ void BaseRealSenseNode::getParameters()
     _pnh.param("publish_odom_tf", _publish_odom_tf, PUBLISH_ODOM_TF);
 }
 
-void BaseRealSenseNode::getSerial(std_srvs::Trigger::Request &req,
+bool BaseRealSenseNode::getSerial(std_srvs::Trigger::Request &req,
                                   std_srvs::Trigger::Response &res)
 {
     ROS_INFO("getSerial...");
@@ -686,7 +686,7 @@ void BaseRealSenseNode::setupPublishers()
             }
         }
 
-        ros::ServiceServer get_serial_service = _node_handle.advertiseService("get_serial", &BaseRealSenseNode::getSerial, &this);
+        ros::ServiceServer get_serial_service = _node_handle.advertiseService("get_serial", &BaseRealSenseNode::getSerial, this);
     }
 
     _synced_imu_publisher = std::make_shared<SyncedImuPublisher>();

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -495,7 +495,7 @@ void BaseRealSenseNode::getParameters()
 bool BaseRealSenseNode::getSerial(std_srvs::Trigger::Request &req,
                                   std_srvs::Trigger::Response &res)
 {
-    ROS_INFO("getSerial...");
+    ROS_INFO("getSerial... %s", _serial_no);
     res.message = _serial_no;
     res.success = true;
     return true;

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -688,8 +688,6 @@ void BaseRealSenseNode::setupPublishers()
                 _pointcloud_publisher = _node_handle.advertise<sensor_msgs::PointCloud2>("depth/color/points", 1);
             }
         }
-
-        ros::ServiceServer get_serial_service = _node_handle.advertiseService("get_serial", &BaseRealSenseNode::getSerial, this);
     }
 
     _synced_imu_publisher = std::make_shared<SyncedImuPublisher>();
@@ -740,6 +738,8 @@ void BaseRealSenseNode::setupPublishers()
     {
         _depth_to_other_extrinsics_publishers[INFRA2] = _node_handle.advertise<Extrinsics>("extrinsics/depth_to_infra2", 1, true);
     }
+
+    _get_serial_service = _node_handle.advertiseService("get_serial", &BaseRealSenseNode::getSerial, this);
 }
 
 void BaseRealSenseNode::publishAlignedDepthToOthers(rs2::frameset frames, const ros::Time& t)


### PR DESCRIPTION
Separate serial service feature of https://github.com/IntelRealSense/realsense-ros/pull/845

Example usage:

Using multiple robots with otherwise identical hardware configuration, one of the things included in log files to distinguish between the robots is the RealSense serial number. Previously I approached this by launching the RealSense node and manually copying the serial number from the terminal output, setting it as an environment variable on the robot computer, and querying that environment variable in the logging program. However, this is time-consuming and simply being able to query the serial number at runtime also makes swapping between cameras easier.