### PR TITLE
set auto_exposure ROI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ After running the above command with D435i attached, the following list of topic
 - /camera/gyro/sample
 - /camera/accel/imu_info
 - /camera/accel/sample
+- /diagnostics
 
 The "/camera" prefix is the default and can be changed. Check the rs_multiple_devices.launch file for an example.
 If using D435 or D415, the gyro and accel topics wont be available. Likewise, other topics will be available when using T265 (see below).

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -197,6 +197,7 @@ namespace realsense2_camera
         void updateStreamCalibData(const rs2::video_stream_profile& video_profile);
         void publishStaticTransforms();
         void publishIntrinsics();
+        void runFirstFrameInitialization(rs2_stream stream_type);
         void publishPointCloud(rs2::points f, const ros::Time& t, const rs2::frameset& frameset);
         Extrinsics rsExtrinsicsToMsg(const rs2_extrinsics& extrinsics, const std::string& frame_id) const;
 
@@ -222,6 +223,10 @@ namespace realsense2_camera
         void multiple_message_callback(rs2::frame frame, imu_sync_method sync_method);
         void frame_callback(rs2::frame frame);
         void registerDynamicOption(ros::NodeHandle& nh, rs2::options sensor, std::string& module_name);
+        void readAndSetDynamicParam(ros::NodeHandle& nh1, std::shared_ptr<ddynamic_reconfigure::DDynamicReconfigure> ddynrec, const std::string option_name, const int min_val, const int max_val, rs2::sensor sensor, int* option_value);
+        void registerAutoExposureROIOptions(ros::NodeHandle& nh);
+        void set_auto_exposure_roi(const std::string option_name, rs2::sensor sensor, int new_value);
+        void set_sensor_auto_exposure_roi(rs2::sensor sensor);
         rs2_stream rs2_string_to_stream(std::string str);
 
         rs2::device _dev;
@@ -284,6 +289,9 @@ namespace realsense2_camera
         std::map<stream_index_pair, ImagePublisherWithFrequencyDiagnostics> _depth_aligned_image_publishers;
         std::map<stream_index_pair, ros::Publisher> _depth_to_other_extrinsics_publishers;
         std::map<stream_index_pair, rs2_extrinsics> _depth_to_other_extrinsics;
+        std::map<std::string, rs2::region_of_interest> _auto_exposure_roi;
+        std::map<rs2_stream, bool> _is_first_frame;
+        std::map<rs2_stream, std::vector<std::function<void()> > > _video_functions_stack;
 
         const std::string _namespace;
 

--- a/realsense2_camera/launch/rs_camera.launch
+++ b/realsense2_camera/launch/rs_camera.launch
@@ -49,7 +49,6 @@
   <arg name="publish_odom_tf"           default="true"/>
   <arg name="allow_no_texture_points"   default="false"/>
 
-  
   <group ns="$(arg camera)">
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
       <arg name="tf_prefix"                value="$(arg tf_prefix)"/>

--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -149,8 +149,6 @@ void RealSenseNodeFactory::onInit()
 				pipe->start(cfg); //File will be opened in read mode at this point
 				_device = pipe->get_active_profile().get_device();
 				_realSenseNode = std::unique_ptr<BaseRealSenseNode>(new BaseRealSenseNode(nh, privateNh, _device, _serial_no));
-				_realSenseNode->publishTopics();
-				_realSenseNode->registerDynamicReconfigCb(nh);
 			}
 			if (_device)
 			{

--- a/realsense2_camera/src/t265_realsense_node.cpp
+++ b/realsense2_camera/src/t265_realsense_node.cpp
@@ -10,6 +10,7 @@ T265RealsenseNode::T265RealsenseNode(ros::NodeHandle& nodeHandle,
                                      _wo_snr(dev.first<rs2::wheel_odometer>()),
                                      _use_odom_in(false) 
                                      {
+                                         _monitor_options = {RS2_OPTION_ASIC_TEMPERATURE, RS2_OPTION_MOTION_MODULE_TEMPERATURE};
                                          initializeOdometryInput();
                                      }
 


### PR DESCRIPTION
Add the ability to set auto_exposure ROI.
Available using dynamic reconfigure parameters or by setting the following to the launch file:
```
<rosparam>
  /camera/rgb_camera/auto_exposure_roi/right: 250
  /camera/stereo_module/auto_exposure_roi/top: 50
</rosparam>
```