### PR TITLE
Add filling correct Tx, Ty values in projection matrix of right camera.

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -1746,6 +1746,14 @@ void BaseRealSenseNode::updateStreamCalibData(const rs2::video_stream_profile& v
     _camera_info[stream_index].P.at(10) = 1;
     _camera_info[stream_index].P.at(11) = 0;
 
+    // Set Tx, Ty for right camera
+    if (stream_index == INFRA2 && _enable[INFRA1])
+    {
+        const auto& ex = getAProfile(INFRA2).get_extrinsics_to(getAProfile(INFRA1));
+        _camera_info[stream_index].P.at(3) = -intrinsic.fx * ex.translation[0]; // Tx
+        _camera_info[stream_index].P.at(7) = -intrinsic.fy * ex.translation[1]; // Ty
+    }
+
     _camera_info[stream_index].distortion_model = "plumb_bob";
 
     // set R (rotation matrix) values to identity matrix


### PR DESCRIPTION
Fixes https://github.com/intel-ros/realsense/issues/427