### PR TITLE
Feature/parametrized xacro

### DIFF
--- a/realsense2_description/CMakeLists.txt
+++ b/realsense2_description/CMakeLists.txt
@@ -11,3 +11,8 @@ catkin_package(
 # Install files
 install(DIRECTORY launch meshes rviz urdf
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+# Tests
+if (CATKIN_ENABLE_TESTING)
+  catkin_add_nosetests(tests)
+endif()

--- a/realsense2_description/tests/dual_d415.xacro
+++ b/realsense2_description/tests/dual_d415.xacro
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<robot name="realsense2_camera" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:include filename="../urdf/_d415.urdf.xacro" />
+  
+  <link name="base_link" />
+  <sensor_d415 parent="base_link" name="camera_bottom">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </sensor_d415>
+  <sensor_d415 parent="base_link" name="camera_top">
+    <origin xyz="0 0 0.2" rpy="0 0 0"/>
+  </sensor_d415>
+</robot>

--- a/realsense2_description/tests/dual_d435.xacro
+++ b/realsense2_description/tests/dual_d435.xacro
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<robot name="realsense2_camera" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:include filename="../urdf/_d435.urdf.xacro" />
+  
+  <link name="base_link" />
+  <sensor_d435 parent="base_link" name="camera_bottom">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </sensor_d435>
+  <sensor_d435 parent="base_link" name="camera_top">
+    <origin xyz="0 0 0.2" rpy="0 0 0"/>
+  </sensor_d435>
+</robot>

--- a/realsense2_description/tests/dual_r410.xacro
+++ b/realsense2_description/tests/dual_r410.xacro
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<robot name="realsense2_camera" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:include filename="../urdf/_r410.urdf.xacro" />
+  
+  <link name="base_link" />
+  <sensor_r410 parent="base_link" name="camera_bottom">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </sensor_r410>
+  <sensor_r410 parent="base_link" name="camera_top">
+    <origin xyz="0 0 0.2" rpy="0 0 0"/>
+  </sensor_r410>
+</robot>

--- a/realsense2_description/tests/dual_r430.xacro
+++ b/realsense2_description/tests/dual_r430.xacro
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<robot name="realsense2_camera" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:include filename="../urdf/_r430.urdf.xacro" />
+  
+  <link name="base_link" />
+  <sensor_r430 parent="base_link" name="camera_bottom">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </sensor_r430>
+  <sensor_r430 parent="base_link" name="camera_top">
+    <origin xyz="0 0 0.2" rpy="0 0 0"/>
+  </sensor_r430>
+</robot>

--- a/realsense2_description/tests/one_of_each.xacro
+++ b/realsense2_description/tests/one_of_each.xacro
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<robot name="realsense2_camera" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:include filename="../urdf/_d415.urdf.xacro" />
+  <xacro:include filename="../urdf/_d435.urdf.xacro" />
+  <xacro:include filename="../urdf/_r410.urdf.xacro" />
+  <xacro:include filename="../urdf/_r430.urdf.xacro" />
+  
+  <link name="base_link" />
+  <sensor_d415 parent="base_link" name="d415">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </sensor_d415>
+  <sensor_d435 parent="base_link" name="d435">
+    <origin xyz="0 0 0.1" rpy="0 0 0"/>
+  </sensor_d435>
+  <sensor_r410 parent="base_link" name="r410">
+    <origin xyz="0 0 0.2" rpy="0 0 0"/>
+  </sensor_r410>
+  <sensor_r430 parent="base_link" name="r430">
+    <origin xyz="0 0 0.3" rpy="0 0 0"/>
+  </sensor_r430>
+</robot>

--- a/realsense2_description/tests/test_xacro.py
+++ b/realsense2_description/tests/test_xacro.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import rospkg
+import subprocess
+import os
+
+r = rospkg.RosPack()
+path = r.get_path('realsense2_description')
+
+
+def run_xacro_in_file(filename):
+    assert(filename != "")
+    assert(subprocess.check_output(["xacro", "--inorder", "tests/{}".format(filename)],
+                                   cwd=path))
+
+
+def test_files():
+    for _, _, filenames in os.walk(os.path.join(path, "tests")):
+        for file in filenames:
+            if file.endswith(".xacro"):
+                yield run_xacro_in_file, file

--- a/realsense2_description/urdf/_d415.urdf.xacro
+++ b/realsense2_description/urdf/_d415.urdf.xacro
@@ -8,7 +8,10 @@ aluminum peripherial evaluation case.
 -->
 
 <robot name="sensor_d415" xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="sensor_d415" params="parent *origin">
+  <!-- Includes -->
+  <xacro:include filename="$(find realsense2_description)/urdf/_materials.urdf.xacro" />
+  
+  <xacro:macro name="sensor_d415" params="parent *origin  name:=camera">
     <xacro:property name="M_PI" value="3.1415926535897931" />
 
     <!-- The following values are approximate, and the camera node
@@ -31,27 +34,22 @@ aluminum peripherial evaluation case.
     <xacro:property name="d415_cam_depth_py" value="0.020"/>
     <xacro:property name="d415_cam_depth_pz" value="${d415_cam_height/2}"/>
 
-    <material name="aluminum">
-	     <color rgba="0.5 0.5 0.5 1"/>
-    </material>
-
-
     <!-- camera body, with origin at bottom screw mount -->
-    <joint name="camera_joint" type="fixed">
+    <joint name="${name}_joint" type="fixed">
       <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
-      <child link="camera_bottom_screw_frame" />
+      <child link="${name}_bottom_screw_frame" />
     </joint>
 
-    <link name="camera_bottom_screw_frame"/>
+    <link name="${name}_bottom_screw_frame"/>
 
-    <joint name="camera_link_joint" type="fixed">
+    <joint name="${name}_link_joint" type="fixed">
       <origin xyz="0 ${d415_cam_depth_py} ${d415_cam_depth_pz}" rpy="0 0 0"/>
-      <parent link="camera_bottom_screw_frame"/>
-      <child link="camera_link" />
+      <parent link="${name}_bottom_screw_frame"/>
+      <child link="${name}_link" />
     </joint>
 
-    <link name="camera_link">
+    <link name="${name}_link">
       <visual>
       <origin xyz="${d415_cam_mount_from_center_offset} ${-d415_cam_depth_py} 0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
         <geometry>
@@ -75,63 +73,63 @@ aluminum peripherial evaluation case.
     </link>
 
     <!-- camera depth joints and links -->
-    <joint name="camera_depth_joint" type="fixed">
+    <joint name="${name}_depth_joint" type="fixed">
       <origin xyz="0 0 0" rpy="0 0 0"/>
-      <parent link="camera_link"/>
-      <child link="camera_depth_frame" />
+      <parent link="${name}_link"/>
+      <child link="${name}_depth_frame" />
     </joint>
-    <link name="camera_depth_frame"/>
+    <link name="${name}_depth_frame"/>
 
-    <joint name="camera_depth_optical_joint" type="fixed">
+    <joint name="${name}_depth_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-      <parent link="camera_depth_frame" />
-      <child link="camera_depth_optical_frame" />
+      <parent link="${name}_depth_frame" />
+      <child link="${name}_depth_optical_frame" />
     </joint>
-    <link name="camera_depth_optical_frame"/>
+    <link name="${name}_depth_optical_frame"/>
 
     <!-- camera left IR joints and links -->
-    <joint name="camera_left_ir_joint" type="fixed">
+    <joint name="${name}_left_ir_joint" type="fixed">
       <origin xyz="0 ${d415_cam_depth_to_left_ir_offset} 0" rpy="0 0 0" />
-      <parent link="camera_depth_frame" />
-      <child link="camera_left_ir_frame" />
+      <parent link="${name}_depth_frame" />
+      <child link="${name}_left_ir_frame" />
     </joint>
-    <link name="camera_left_ir_frame"/>
+    <link name="${name}_left_ir_frame"/>
 
-    <joint name="camera_left_ir_optical_joint" type="fixed">
+    <joint name="${name}_left_ir_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-      <parent link="camera_left_ir_frame" />
-      <child link="camera_left_ir_optical_frame" />
+      <parent link="${name}_left_ir_frame" />
+      <child link="${name}_left_ir_optical_frame" />
     </joint>
-    <link name="camera_left_ir_optical_frame"/>
+    <link name="${name}_left_ir_optical_frame"/>
 
     <!-- camera right IR joints and links -->
-    <joint name="camera_right_ir_joint" type="fixed">
+    <joint name="${name}_right_ir_joint" type="fixed">
       <origin xyz="0 ${d415_cam_depth_to_right_ir_offset} 0" rpy="0 0 0" />
-      <parent link="camera_depth_frame" />
-      <child link="camera_right_ir_frame" />
+      <parent link="${name}_depth_frame" />
+      <child link="${name}_right_ir_frame" />
     </joint>
-    <link name="camera_right_ir_frame"/>
+    <link name="${name}_right_ir_frame"/>
 
-    <joint name="camera_right_ir_optical_joint" type="fixed">
+    <joint name="${name}_right_ir_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-      <parent link="camera_right_ir_frame" />
-      <child link="camera_right_ir_optical_frame" />
+      <parent link="${name}_right_ir_frame" />
+      <child link="${name}_right_ir_optical_frame" />
     </joint>
-    <link name="camera_right_ir_optical_frame"/>
+    <link name="${name}_right_ir_optical_frame"/>
 
     <!-- camera color joints and links -->
-    <joint name="camera_color_joint" type="fixed">
+    <joint name="${name}_color_joint" type="fixed">
       <origin xyz="0 ${d415_cam_depth_to_color_offset} 0" rpy="0 0 0" />
-      <parent link="camera_depth_frame" />
-      <child link="camera_color_frame" />
+      <parent link="${name}_depth_frame" />
+      <child link="${name}_color_frame" />
     </joint>
-    <link name="camera_color_frame"/>
+    <link name="${name}_color_frame"/>
 
-    <joint name="camera_color_optical_joint" type="fixed">
+    <joint name="${name}_color_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-      <parent link="camera_color_frame" />
-      <child link="camera_color_optical_frame" />
+      <parent link="${name}_color_frame" />
+      <child link="${name}_color_optical_frame" />
     </joint>
-    <link name="camera_color_optical_frame"/>
+    <link name="${name}_color_optical_frame"/>
   </xacro:macro>
 </robot>

--- a/realsense2_description/urdf/_d435.urdf.xacro
+++ b/realsense2_description/urdf/_d435.urdf.xacro
@@ -9,7 +9,10 @@ aluminum peripherial evaluation case.
 -->
 
 <robot name="sensor_d435" xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="sensor_d435" params="parent *origin">
+  <!-- Includes -->
+  <xacro:include filename="$(find realsense2_description)/urdf/_materials.urdf.xacro" />
+  
+  <xacro:macro name="sensor_d435" params="parent *origin name:=camera">
     <xacro:property name="M_PI" value="3.1415926535897931" />
   
     <!-- The following values are approximate, and the camera node
@@ -32,26 +35,21 @@ aluminum peripherial evaluation case.
     <xacro:property name="d435_cam_depth_py" value="0.0175"/>
     <xacro:property name="d435_cam_depth_pz" value="${d435_cam_height/2}"/>
 
-    <material name="aluminum">
-	  <color rgba="0.5 0.5 0.5 1"/>
-    </material>
-
-
     <!-- camera body, with origin at bottom screw mount -->
-    <joint name="camera_joint" type="fixed">
+    <joint name="${name}_joint" type="fixed">
       <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
-      <child link="camera_bottom_screw_frame" />
+      <child link="${name}_bottom_screw_frame" />
     </joint>
-    <link name="camera_bottom_screw_frame"/>
+    <link name="${name}_bottom_screw_frame"/>
 
-    <joint name="camera_link_joint" type="fixed">
+    <joint name="${name}_link_joint" type="fixed">
       <origin xyz="0 ${d435_cam_depth_py} ${d435_cam_depth_pz}" rpy="0 0 0"/>
-      <parent link="camera_bottom_screw_frame"/>
-      <child link="camera_link" />
+      <parent link="${name}_bottom_screw_frame"/>
+      <child link="${name}_link" />
     </joint>
 
-    <link name="camera_link">
+    <link name="${name}_link">
       <visual>
       <origin xyz="${d435_cam_mount_from_center_offset} ${-d435_cam_depth_py} 0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
         <geometry>
@@ -77,63 +75,63 @@ aluminum peripherial evaluation case.
     </link>
    
     <!-- camera depth joints and links -->
-    <joint name="camera_depth_joint" type="fixed">
+    <joint name="${name}_depth_joint" type="fixed">
       <origin xyz="0 0 0" rpy="0 0 0"/>
-      <parent link="camera_link"/>
-      <child link="camera_depth_frame" />
+      <parent link="${name}_link"/>
+      <child link="${name}_depth_frame" />
     </joint>
-    <link name="camera_depth_frame"/>
+    <link name="${name}_depth_frame"/>
 
-    <joint name="camera_depth_optical_joint" type="fixed">
+    <joint name="${name}_depth_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-      <parent link="camera_depth_frame" />
-      <child link="camera_depth_optical_frame" />
+      <parent link="${name}_depth_frame" />
+      <child link="${name}_depth_optical_frame" />
     </joint>
-    <link name="camera_depth_optical_frame"/>
+    <link name="${name}_depth_optical_frame"/>
       
     <!-- camera left IR joints and links -->
-    <joint name="camera_left_ir_joint" type="fixed">
+    <joint name="${name}_left_ir_joint" type="fixed">
       <origin xyz="0 ${d435_cam_depth_to_left_ir_offset} 0" rpy="0 0 0" />
-      <parent link="camera_depth_frame" />
-      <child link="camera_left_ir_frame" />
+      <parent link="${name}_depth_frame" />
+      <child link="${name}_left_ir_frame" />
     </joint>
-    <link name="camera_left_ir_frame"/>
+    <link name="${name}_left_ir_frame"/>
 
-    <joint name="camera_left_ir_optical_joint" type="fixed">
+    <joint name="${name}_left_ir_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-      <parent link="camera_left_ir_frame" />
-      <child link="camera_left_ir_optical_frame" />
+      <parent link="${name}_left_ir_frame" />
+      <child link="${name}_left_ir_optical_frame" />
     </joint>
-    <link name="camera_left_ir_optical_frame"/>
+    <link name="${name}_left_ir_optical_frame"/>
 
     <!-- camera right IR joints and links -->
-    <joint name="camera_right_ir_joint" type="fixed">
+    <joint name="${name}_right_ir_joint" type="fixed">
       <origin xyz="0 ${d435_cam_depth_to_right_ir_offset} 0" rpy="0 0 0" />
-      <parent link="camera_depth_frame" />
-      <child link="camera_right_ir_frame" />
+      <parent link="${name}_depth_frame" />
+      <child link="${name}_right_ir_frame" />
     </joint>
-    <link name="camera_right_ir_frame"/>
+    <link name="${name}_right_ir_frame"/>
 
-    <joint name="camera_right_ir_optical_joint" type="fixed">
+    <joint name="${name}_right_ir_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-      <parent link="camera_right_ir_frame" />
-      <child link="camera_right_ir_optical_frame" />
+      <parent link="${name}_right_ir_frame" />
+      <child link="${name}_right_ir_optical_frame" />
     </joint>
-    <link name="camera_right_ir_optical_frame"/>
+    <link name="${name}_right_ir_optical_frame"/>
 
     <!-- camera color joints and links -->
-    <joint name="camera_color_joint" type="fixed">
+    <joint name="${name}_color_joint" type="fixed">
       <origin xyz="0 ${d435_cam_depth_to_color_offset} 0" rpy="0 0 0" />
-      <parent link="camera_depth_frame" />
-      <child link="camera_color_frame" />
+      <parent link="${name}_depth_frame" />
+      <child link="${name}_color_frame" />
     </joint>
-    <link name="camera_color_frame"/>
+    <link name="${name}_color_frame"/>
 
-    <joint name="camera_color_optical_joint" type="fixed">
+    <joint name="${name}_color_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-      <parent link="camera_color_frame" />
-      <child link="camera_color_optical_frame" />
+      <parent link="${name}_color_frame" />
+      <child link="${name}_color_optical_frame" />
     </joint>
-    <link name="camera_color_optical_frame"/>
+    <link name="${name}_color_optical_frame"/>
   </xacro:macro>
 </robot>

--- a/realsense2_description/urdf/_materials.urdf.xacro
+++ b/realsense2_description/urdf/_materials.urdf.xacro
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+
+<!--
+License: Apache 2.0. See LICENSE file in root directory.
+Copyright(c) 2017 Intel Corporation. All Rights Reserved
+
+Collection of materials to be used in other macros.
+This avoids the redefinition of materials in case multple cameras are imported.
+-->
+
+<robot>
+  <material name="aluminum">
+    <color rgba="0.5 0.5 0.5 1"/>
+  </material>
+</robot>

--- a/realsense2_description/urdf/_r410.urdf.xacro
+++ b/realsense2_description/urdf/_r410.urdf.xacro
@@ -9,6 +9,9 @@ aluminum peripherial evalution case.
 -->
 
 <robot name="sensor_r410" xmlns:xacro="http://ros.org/wiki/xacro">
+  <!-- Includes -->
+  <xacro:include filename="$(find realsense2_description)/urdf/_materials.urdf.xacro" />
+
   <xacro:property name="M_PI" value="3.1415926535897931" />
 
   <!-- The following values are approximate, and the camera node
@@ -30,20 +33,16 @@ aluminum peripherial evalution case.
   <xacro:property name="r410_cam_depth_py" value="-0.0425"/>
   <xacro:property name="r410_cam_depth_pz" value="0.026"/>
 
-  <material name="aluminum">
-    <color rgba="0.5 0.5 0.5 1"/>
-  </material>
-
-  <xacro:macro name="sensor_r410" params="parent *origin">
+  <xacro:macro name="sensor_r410" params="parent *origin name:=camera">
 
     <!-- camera body, with origin at bottom screw mount -->
-    <joint name="camera_joint" type="fixed">
+    <joint name="${name}_joint" type="fixed">
       <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
-      <child link="camera_link" />
+      <child link="${name}_link" />
     </joint>
 
-    <link name="camera_link">
+    <link name="${name}_link">
       <visual>
       <origin xyz="0 ${-r410_cam_mount_from_center_offset} ${r410_cam_height/2}" rpy="${M_PI/2} 0 ${M_PI/2}"/>
         <geometry>
@@ -67,48 +66,48 @@ aluminum peripherial evalution case.
     </link>
    
     <!-- camera depth joints and links -->
-    <joint name="camera_depth_joint" type="fixed">
+    <joint name="${name}_depth_joint" type="fixed">
       <origin xyz="${r410_cam_depth_px} ${r410_cam_depth_py} ${r410_cam_depth_pz}" rpy="0 0 0"/>
-      <parent link="camera_link"/>
-      <child link="camera_depth_frame" />
+      <parent link="${name}_link"/>
+      <child link="${name}_depth_frame" />
     </joint>
-    <link name="camera_depth_frame"/>
+    <link name="${name}_depth_frame"/>
 
-    <joint name="camera_depth_optical_joint" type="fixed">
+    <joint name="${name}_depth_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-      <parent link="camera_depth_frame" />
-      <child link="camera_depth_optical_frame" />
+      <parent link="${name}_depth_frame" />
+      <child link="${name}_depth_optical_frame" />
     </joint>
-    <link name="camera_depth_optical_frame"/>
+    <link name="${name}_depth_optical_frame"/>
       
     <!-- camera left IR joints and links -->
-    <joint name="camera_left_ir_joint" type="fixed">
+    <joint name="${name}_left_ir_joint" type="fixed">
       <origin xyz="0 ${r410_cam_depth_to_left_ir_offset} 0" rpy="0 0 0" />
-      <parent link="camera_depth_frame" />
-      <child link="camera_left_ir_frame" />
+      <parent link="${name}_depth_frame" />
+      <child link="${name}_left_ir_frame" />
     </joint>
-    <link name="camera_left_ir_frame"/>
+    <link name="${name}_left_ir_frame"/>
 
-    <joint name="camera_left_ir_optical_joint" type="fixed">
+    <joint name="${name}_left_ir_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-      <parent link="camera_left_ir_frame" />
-      <child link="camera_left_ir_optical_frame" />
+      <parent link="${name}_left_ir_frame" />
+      <child link="${name}_left_ir_optical_frame" />
     </joint>
-    <link name="camera_left_ir_optical_frame"/>
+    <link name="${name}_left_ir_optical_frame"/>
 
     <!-- camera right IR joints and links -->
-    <joint name="camera_right_ir_joint" type="fixed">
+    <joint name="${name}_right_ir_joint" type="fixed">
       <origin xyz="0 ${r410_cam_depth_to_right_ir_offset} 0" rpy="0 0 0" />
-      <parent link="camera_depth_frame" />
-      <child link="camera_right_ir_frame" />
+      <parent link="${name}_depth_frame" />
+      <child link="${name}_right_ir_frame" />
     </joint>
-    <link name="camera_right_ir_frame"/>
+    <link name="${name}_right_ir_frame"/>
 
-    <joint name="camera_right_ir_optical_joint" type="fixed">
+    <joint name="${name}_right_ir_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-      <parent link="camera_right_ir_frame" />
-      <child link="camera_right_ir_optical_frame" />
+      <parent link="${name}_right_ir_frame" />
+      <child link="${name}_right_ir_optical_frame" />
     </joint>
-    <link name="camera_right_ir_optical_frame"/>
+    <link name="${name}_right_ir_optical_frame"/>
   </xacro:macro>
 </robot>

--- a/realsense2_description/urdf/_r430.urdf.xacro
+++ b/realsense2_description/urdf/_r430.urdf.xacro
@@ -9,6 +9,9 @@ aluminum peripherial evaluation case.
 -->
 
 <robot name="sensor_r430" xmlns:xacro="http://ros.org/wiki/xacro">
+  <!-- Includes -->
+  <xacro:include filename="$(find realsense2_description)/urdf/_materials.urdf.xacro" />
+
   <xacro:property name="M_PI" value="3.1415926535897931" />
 
   <!-- The following values are approximate, and the camera node
@@ -31,20 +34,16 @@ aluminum peripherial evaluation case.
   <xacro:property name="r430_cam_depth_py" value="-0.035"/>
   <xacro:property name="r430_cam_depth_pz" value="0.028"/>
 
-  <material name="aluminum">
-    <color rgba="0.5 0.5 0.5 1"/>
-  </material>
-
-  <xacro:macro name="sensor_r430" params="parent *origin">
+  <xacro:macro name="sensor_r430" params="parent *origin name:=camera">
 
     <!-- camera body, with origin at bottom screw mount -->
-    <joint name="camera_joint" type="fixed">
+    <joint name="${name}_joint" type="fixed">
       <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
-      <child link="camera_link" />
+      <child link="${name}_link" />
     </joint>
 
-    <link name="camera_link">
+    <link name="${name}_link">
       <visual>
       <origin xyz="0 ${-r430_cam_mount_from_center_offset} ${r430_cam_height/2}" rpy="${M_PI/2} 0 ${M_PI/2}"/>
         <geometry>
@@ -68,63 +67,63 @@ aluminum peripherial evaluation case.
     </link>
    
     <!-- camera depth joints and links -->
-    <joint name="camera_depth_joint" type="fixed">
+    <joint name="${name}_depth_joint" type="fixed">
       <origin xyz="${r430_cam_depth_px} ${r430_cam_depth_py} ${r430_cam_depth_pz}" rpy="0 0 0"/>
-      <parent link="camera_link"/>
-      <child link="camera_depth_frame" />
+      <parent link="${name}_link"/>
+      <child link="${name}_depth_frame" />
     </joint>
-    <link name="camera_depth_frame"/>
+    <link name="${name}_depth_frame"/>
 
-    <joint name="camera_depth_optical_joint" type="fixed">
+    <joint name="${name}_depth_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-      <parent link="camera_depth_frame" />
-      <child link="camera_depth_optical_frame" />
+      <parent link="${name}_depth_frame" />
+      <child link="${name}_depth_optical_frame" />
     </joint>
-    <link name="camera_depth_optical_frame"/>
+    <link name="${name}_depth_optical_frame"/>
       
     <!-- camera left IR joints and links -->
-    <joint name="camera_left_ir_joint" type="fixed">
+    <joint name="${name}_left_ir_joint" type="fixed">
       <origin xyz="0 ${r430_cam_depth_to_left_ir_offset} 0" rpy="0 0 0" />
-      <parent link="camera_depth_frame" />
-      <child link="camera_left_ir_frame" />
+      <parent link="${name}_depth_frame" />
+      <child link="${name}_left_ir_frame" />
     </joint>
-    <link name="camera_left_ir_frame"/>
+    <link name="${name}_left_ir_frame"/>
 
-    <joint name="camera_left_ir_optical_joint" type="fixed">
+    <joint name="${name}_left_ir_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-      <parent link="camera_left_ir_frame" />
-      <child link="camera_left_ir_optical_frame" />
+      <parent link="${name}_left_ir_frame" />
+      <child link="${name}_left_ir_optical_frame" />
     </joint>
-    <link name="camera_left_ir_optical_frame"/>
+    <link name="${name}_left_ir_optical_frame"/>
 
     <!-- camera right IR joints and links -->
-    <joint name="camera_right_ir_joint" type="fixed">
+    <joint name="${name}_right_ir_joint" type="fixed">
       <origin xyz="0 ${r430_cam_depth_to_right_ir_offset} 0" rpy="0 0 0" />
-      <parent link="camera_depth_frame" />
-      <child link="camera_right_ir_frame" />
+      <parent link="${name}_depth_frame" />
+      <child link="${name}_right_ir_frame" />
     </joint>
-    <link name="camera_right_ir_frame"/>
+    <link name="${name}_right_ir_frame"/>
 
-    <joint name="camera_right_ir_optical_joint" type="fixed">
+    <joint name="${name}_right_ir_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-      <parent link="camera_right_ir_frame" />
-      <child link="camera_right_ir_optical_frame" />
+      <parent link="${name}_right_ir_frame" />
+      <child link="${name}_right_ir_optical_frame" />
     </joint>
-    <link name="camera_right_ir_optical_frame"/>
+    <link name="${name}_right_ir_optical_frame"/>
 
     <!-- camera fisheye joints and links -->
-    <joint name="camera_fisheye_joint" type="fixed">
+    <joint name="${name}_fisheye_joint" type="fixed">
       <origin xyz="0 ${r430_cam_depth_to_fisheye_offset} 0" rpy="0 0 0" />
-      <parent link="camera_depth_frame" />
-      <child link="camera_fisheye_frame" />
+      <parent link="${name}_depth_frame" />
+      <child link="${name}_fisheye_frame" />
     </joint>
-    <link name="camera_fisheye_frame"/>
+    <link name="${name}_fisheye_frame"/>
 
-    <joint name="camera_fisheye_optical_joint" type="fixed">
+    <joint name="${name}_fisheye_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-      <parent link="camera_fisheye_frame" />
-      <child link="camera_fisheye_optical_frame" />
+      <parent link="${name}_fisheye_frame" />
+      <child link="${name}_fisheye_optical_frame" />
     </joint>
-    <link name="camera_fisheye_optical_frame"/>
+    <link name="${name}_fisheye_optical_frame"/>
   </xacro:macro>
 </robot>


### PR DESCRIPTION
I would like to import two models into my xacro but when I do there is a collision with the links. This PR turns the hardcoded name into a parameter and sets the default name to "camera" (thus, it is backwards compatible). 

I also added unit testing which so far only checks to well-formed xacros and not for the actual content but is better than nothing :smile: 

Note: I also move the material definition to another file that can be imported from other xacros. This is needed to avoid the redefinition of the materials when generating the urdf.