### PR TITLE
Allow to use usb port number to connect to devices

### DIFF
--- a/realsense2_camera/include/realsense_node_factory.h
+++ b/realsense2_camera/include/realsense_node_factory.h
@@ -68,6 +68,7 @@ namespace realsense2_camera
         std::unique_ptr<InterfaceRealSenseNode> _realSenseNode;
         rs2::context _ctx;
         std::string _serial_no;
+        std::string _port_no;
         bool _initial_reset;
         std::thread _query_thread;
 

--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -2,6 +2,7 @@
   <arg name="external_manager"    default="false"/>
   <arg name="manager"             default="realsense2_camera_manager"/>
   <arg name="serial_no"           default=""/>
+  <arg name="port_no"           default=""/>
   <arg name="tf_prefix"           default=""/>
   <arg name="json_file_path"      default=""/>
   <arg name="rosbag_filename"     default=""/>
@@ -91,6 +92,7 @@
   <node unless="$(arg external_manager)" pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen" required="$(arg required)"/>
   <node pkg="nodelet" type="nodelet" name="realsense2_camera" args="load realsense2_camera/RealSenseNodeFactory $(arg manager)" required="$(arg required)">
     <param name="serial_no"                type="str"  value="$(arg serial_no)"/>
+    <param name="port_no"                  type="str"  value="$(arg port_no)"/>
     <param name="json_file_path"           type="str"  value="$(arg json_file_path)"/>
     <param name="rosbag_filename"          type="str"  value="$(arg rosbag_filename)"/>
 

--- a/realsense2_camera/launch/rs_rgbd.launch
+++ b/realsense2_camera/launch/rs_rgbd.launch
@@ -48,6 +48,7 @@ Processing enabled by this node:
   <!-- Camera device specific arguments -->
 
   <arg name="serial_no"           default=""/>
+  <arg name="port_no"             default=""/>
   <arg name="json_file_path"      default=""/>
 
   <arg name="fisheye_width"       default="640"/>
@@ -117,6 +118,7 @@ Processing enabled by this node:
       <arg name="manager"                  value="$(arg manager)"/>
       <arg name="tf_prefix"                value="$(arg tf_prefix)"/>
       <arg name="serial_no"                value="$(arg serial_no)"/>
+      <arg name="port_no"                  value="$(arg port_no)"/>
       <arg name="json_file_path"           value="$(arg json_file_path)"/>
 
       <arg name="enable_pointcloud"        value="$(arg enable_pointcloud)"/>

--- a/realsense2_camera/launch/rs_t265.launch
+++ b/realsense2_camera/launch/rs_t265.launch
@@ -6,6 +6,7 @@ https://github.com/IntelRealSense/librealsense/blob/master/third-party/libtm/lib
 -->
 <launch>
   <arg name="serial_no"           default=""/>
+  <arg name="port_no"             default=""/>
   <arg name="json_file_path"      default=""/>
   <arg name="camera"              default="camera"/>
   <arg name="tf_prefix"           default="$(arg camera)"/>
@@ -34,6 +35,7 @@ https://github.com/IntelRealSense/librealsense/blob/master/third-party/libtm/lib
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
       <arg name="tf_prefix"                value="$(arg tf_prefix)"/>
       <arg name="serial_no"                value="$(arg serial_no)"/>
+      <arg name="port_no"                  value="$(arg port_no)"/>
       <arg name="json_file_path"           value="$(arg json_file_path)"/>
 
       <arg name="enable_sync"              value="$(arg enable_sync)"/>

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -649,6 +649,10 @@ void BaseRealSenseNode::setupDevice()
 
         ROS_INFO_STREAM("Device Serial No: " << _serial_no);
 
+        auto camera_id = _dev.get_info(RS2_CAMERA_INFO_PHYSICAL_PORT);
+
+        ROS_INFO_STREAM("Device physical port: " << camera_id);
+
         auto fw_ver = _dev.get_info(RS2_CAMERA_INFO_FIRMWARE_VERSION);
         ROS_INFO_STREAM("Device FW version: " << fw_ver);
 


### PR DESCRIPTION
This PR replies to some issues :
- https://github.com/IntelRealSense/realsense-ros/issues/904
- https://github.com/IntelRealSense/realsense-ros/issues/931

While detecting devices, the changes will extract the usb port number from the device info _RS_CAMERA_INFO_PHYSICAL_PORT_.
This was tested on D435 and T265 cameras.
This works well for D435 with or without usb hub.
This works well for T265 WITHOUT usb hub.
You will have to wait untill the PR on librealsense to see it works with hubs : https://github.com/IntelRealSense/librealsense/pull/5109

This needs to be tested/changed on the other devices that I don't have.