### PR TITLE
Allow to use usb port number to connect to devices (continue from Brice renaudeau)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,10 @@ If using D435 or D415, the gyro and accel topics wont be available. Likewise, ot
 
 ### Launch parameters
 The following parameters are available by the wrapper:
-- **serial_no**: will attach to the device with the given serial number. Default, attach to available RealSense device in random.
+- **serial_no**: will attach to the device with the given serial number (*serial_no*) number. Default, attach to available RealSense device in random.
+- **port_no**: will attach to the device with the given USB port (*port_no*). i.e 4-1, 4-2 etc. Default, ignore USB port when choosing a device.
+- **device_type**: will attach to a device whose name includes the given *device_type* regular expression pattern. Default, ignore device type. For example, device_type:=d435 will match d435 and d435i. device_type=d435(?!i) will match d435 but not d435i.
+
 - **rosbag_filename**: Will publish topics from rosbag file.
 - **initial_reset**: On occasions the device was not closed properly and due to firmware issues needs to reset. If set to true, the device will reset prior to usage.
 - **align_depth**: If set to true, will publish additional topics with the all the images aligned to the depth image.</br>

--- a/realsense2_camera/include/realsense_node_factory.h
+++ b/realsense2_camera/include/realsense_node_factory.h
@@ -69,6 +69,7 @@ namespace realsense2_camera
         rs2::context _ctx;
         std::string _serial_no;
         std::string _port_no;
+        std::string _device_type;
         bool _initial_reset;
         std::thread _query_thread;
 

--- a/realsense2_camera/include/realsense_node_factory.h
+++ b/realsense2_camera/include/realsense_node_factory.h
@@ -68,6 +68,7 @@ namespace realsense2_camera
         std::unique_ptr<InterfaceRealSenseNode> _realSenseNode;
         rs2::context _ctx;
         std::string _serial_no;
+        std::string _port_no;
         bool _initial_reset;
         std::thread _query_thread;
 

--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -2,7 +2,8 @@
   <arg name="external_manager"    default="false"/>
   <arg name="manager"             default="realsense2_camera_manager"/>
   <arg name="serial_no"           default=""/>
-  <arg name="port_no"           default=""/>
+  <arg name="port_no"             default=""/>
+  <arg name="device_type"         default=""/>
   <arg name="tf_prefix"           default=""/>
   <arg name="json_file_path"      default=""/>
   <arg name="rosbag_filename"     default=""/>
@@ -93,6 +94,7 @@
   <node pkg="nodelet" type="nodelet" name="realsense2_camera" args="load realsense2_camera/RealSenseNodeFactory $(arg manager)" required="$(arg required)">
     <param name="serial_no"                type="str"  value="$(arg serial_no)"/>
     <param name="port_no"                  type="str"  value="$(arg port_no)"/>
+    <param name="device_type"              type="str"  value="$(arg device_type)"/>
     <param name="json_file_path"           type="str"  value="$(arg json_file_path)"/>
     <param name="rosbag_filename"          type="str"  value="$(arg rosbag_filename)"/>
 

--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -2,6 +2,7 @@
   <arg name="external_manager"    default="false"/>
   <arg name="manager"             default="realsense2_camera_manager"/>
   <arg name="serial_no"           default=""/>
+  <arg name="port_no"           default=""/>
   <arg name="tf_prefix"           default=""/>
   <arg name="json_file_path"      default=""/>
   <arg name="rosbag_filename"     default=""/>
@@ -91,6 +92,7 @@
   <node unless="$(arg external_manager)" pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen" required="$(arg required)"/>
   <node pkg="nodelet" type="nodelet" name="realsense2_camera" args="load realsense2_camera/RealSenseNodeFactory $(arg manager)" required="$(arg required)">
     <param name="serial_no"                type="str"  value="$(arg serial_no)"/>
+    <param name="port_no"                  type="str"  value="$(arg port_no)"/>
     <param name="json_file_path"           type="str"  value="$(arg json_file_path)"/>
     <param name="rosbag_filename"          type="str"  value="$(arg rosbag_filename)"/>
 

--- a/realsense2_camera/launch/rs_camera.launch
+++ b/realsense2_camera/launch/rs_camera.launch
@@ -1,5 +1,6 @@
 <launch>
   <arg name="serial_no"           default=""/>
+  <arg name="port_no"             default=""/>
   <arg name="json_file_path"      default=""/>
   <arg name="camera"              default="camera"/>
   <arg name="tf_prefix"           default="$(arg camera)"/>
@@ -58,6 +59,7 @@
       <arg name="external_manager"         value="$(arg external_manager)"/>
       <arg name="manager"                  value="$(arg manager)"/>
       <arg name="serial_no"                value="$(arg serial_no)"/>
+      <arg name="port_no"                  value="$(arg port_no)"/>
       <arg name="json_file_path"           value="$(arg json_file_path)"/>
 
       <arg name="enable_pointcloud"        value="$(arg enable_pointcloud)"/>

--- a/realsense2_camera/launch/rs_camera.launch
+++ b/realsense2_camera/launch/rs_camera.launch
@@ -1,6 +1,7 @@
 <launch>
   <arg name="serial_no"           default=""/>
   <arg name="port_no"             default=""/>
+  <arg name="device_type"         default=""/>
   <arg name="json_file_path"      default=""/>
   <arg name="camera"              default="camera"/>
   <arg name="tf_prefix"           default="$(arg camera)"/>
@@ -60,6 +61,7 @@
       <arg name="manager"                  value="$(arg manager)"/>
       <arg name="serial_no"                value="$(arg serial_no)"/>
       <arg name="port_no"                  value="$(arg port_no)"/>
+      <arg name="device_type"              value="$(arg device_type)"/>
       <arg name="json_file_path"           value="$(arg json_file_path)"/>
 
       <arg name="enable_pointcloud"        value="$(arg enable_pointcloud)"/>

--- a/realsense2_camera/launch/rs_d400_and_t265.launch
+++ b/realsense2_camera/launch/rs_d400_and_t265.launch
@@ -1,8 +1,10 @@
 <launch>
-  <arg name="serial_no_camera1"    			default=""/> 			<!-- Note: Replace with actual serial number -->
-  <arg name="serial_no_camera2"    			default=""/> 			<!-- Note: Replace with actual serial number -->
-  <arg name="camera1"              			default="t265"/>		<!-- Note: Replace with camera name -->
-  <arg name="camera2"              			default="d400"/>		<!-- Note: Replace with camera name -->
+  <arg name="device_type_camera1"    		default="t265"/>
+  <arg name="device_type_camera2"    		default="d4.5"/>		<!-- Note: using regular expression. match D435, D435i, D415... -->
+  <arg name="serial_no_camera1"    			default=""/>
+  <arg name="serial_no_camera2"    			default=""/>
+  <arg name="camera1"              			default="t265"/>
+  <arg name="camera2"              			default="d400"/>
   <arg name="tf_prefix_camera1"         default="$(arg camera1)"/>
   <arg name="tf_prefix_camera2"         default="$(arg camera2)"/>
   <arg name="initial_reset"             default="false"/>
@@ -17,6 +19,7 @@
 
   <group ns="$(arg camera1)">
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
+      <arg name="device_type"           value="$(arg device_type_camera1)"/>
       <arg name="serial_no"             value="$(arg serial_no_camera1)"/>
       <arg name="tf_prefix"         		value="$(arg tf_prefix_camera1)"/>
       <arg name="initial_reset"         value="$(arg initial_reset)"/>
@@ -29,6 +32,7 @@
 
   <group ns="$(arg camera2)">
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
+      <arg name="device_type"           value="$(arg device_type_camera2)"/>
       <arg name="serial_no"             value="$(arg serial_no_camera2)"/>
       <arg name="tf_prefix"		          value="$(arg tf_prefix_camera2)"/>
       <arg name="initial_reset"         value="$(arg initial_reset)"/>

--- a/realsense2_camera/launch/rs_rgbd.launch
+++ b/realsense2_camera/launch/rs_rgbd.launch
@@ -49,6 +49,7 @@ Processing enabled by this node:
 
   <arg name="serial_no"           default=""/>
   <arg name="port_no"             default=""/>
+  <arg name="device_type"         default=""/>
   <arg name="json_file_path"      default=""/>
 
   <arg name="fisheye_width"       default="640"/>
@@ -119,6 +120,7 @@ Processing enabled by this node:
       <arg name="tf_prefix"                value="$(arg tf_prefix)"/>
       <arg name="serial_no"                value="$(arg serial_no)"/>
       <arg name="port_no"                  value="$(arg port_no)"/>
+      <arg name="device_type"              value="$(arg device_type)"/>
       <arg name="json_file_path"           value="$(arg json_file_path)"/>
 
       <arg name="enable_pointcloud"        value="$(arg enable_pointcloud)"/>

--- a/realsense2_camera/launch/rs_rgbd.launch
+++ b/realsense2_camera/launch/rs_rgbd.launch
@@ -48,6 +48,7 @@ Processing enabled by this node:
   <!-- Camera device specific arguments -->
 
   <arg name="serial_no"           default=""/>
+  <arg name="port_no"             default=""/>
   <arg name="json_file_path"      default=""/>
 
   <arg name="fisheye_width"       default="640"/>
@@ -117,6 +118,7 @@ Processing enabled by this node:
       <arg name="manager"                  value="$(arg manager)"/>
       <arg name="tf_prefix"                value="$(arg tf_prefix)"/>
       <arg name="serial_no"                value="$(arg serial_no)"/>
+      <arg name="port_no"                  value="$(arg port_no)"/>
       <arg name="json_file_path"           value="$(arg json_file_path)"/>
 
       <arg name="enable_pointcloud"        value="$(arg enable_pointcloud)"/>

--- a/realsense2_camera/launch/rs_rtabmap.launch
+++ b/realsense2_camera/launch/rs_rtabmap.launch
@@ -4,8 +4,10 @@
                   For installation type:
                         apt-get install ros-kinetic-rtabmap-ros
     -->
-    <arg name="serial_no_camera1"    			default=""/> 			<!-- Note: Replace with actual serial number -->
-    <arg name="serial_no_camera2"    			default=""/> 			<!-- Note: Replace with actual serial number -->
+    <arg name="device_type_camera1"    		default="t265"/>
+    <arg name="device_type_camera2"    		default="d4.5"/>	<!-- Note: using regular expression. match D435, D435i, D415... -->
+    <arg name="serial_no_camera1"    			default=""/>
+    <arg name="serial_no_camera2"    			default=""/>
     <arg name="camera1"              			default="t265"/>		<!-- Note: Replace with camera name -->
     <arg name="camera2"              			default="d400"/>		<!-- Note: Replace with camera name -->
     <arg name="clip_distance"             default="-2"/>
@@ -14,6 +16,8 @@
     
 
     <include file="$(find realsense2_camera)/launch/rs_d400_and_t265.launch">
+            <arg name="device_type_camera1"             value="$(arg device_type_camera1)"/>
+            <arg name="device_type_camera2"             value="$(arg device_type_camera2)"/>
             <arg name="serial_no_camera1"               value="$(arg serial_no_camera1)"/>
             <arg name="serial_no_camera2"               value="$(arg serial_no_camera2)"/>
             <arg name="camera1"                         value="$(arg camera1)"/>

--- a/realsense2_camera/launch/rs_t265.launch
+++ b/realsense2_camera/launch/rs_t265.launch
@@ -6,6 +6,7 @@ https://github.com/IntelRealSense/librealsense/blob/master/third-party/libtm/lib
 -->
 <launch>
   <arg name="serial_no"           default=""/>
+  <arg name="port_no"             default=""/>
   <arg name="json_file_path"      default=""/>
   <arg name="camera"              default="camera"/>
   <arg name="tf_prefix"           default="$(arg camera)"/>
@@ -34,6 +35,7 @@ https://github.com/IntelRealSense/librealsense/blob/master/third-party/libtm/lib
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
       <arg name="tf_prefix"                value="$(arg tf_prefix)"/>
       <arg name="serial_no"                value="$(arg serial_no)"/>
+      <arg name="port_no"                  value="$(arg port_no)"/>
       <arg name="json_file_path"           value="$(arg json_file_path)"/>
 
       <arg name="enable_sync"              value="$(arg enable_sync)"/>

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -649,6 +649,10 @@ void BaseRealSenseNode::setupDevice()
 
         ROS_INFO_STREAM("Device Serial No: " << _serial_no);
 
+        auto camera_id = _dev.get_info(RS2_CAMERA_INFO_PHYSICAL_PORT);
+
+        ROS_INFO_STREAM("Device physical port: " << camera_id);
+
         auto fw_ver = _dev.get_info(RS2_CAMERA_INFO_FIRMWARE_VERSION);
         ROS_INFO_STREAM("Device FW version: " << fw_ver);
 


### PR DESCRIPTION
Thanks for #960 . This PR is based on it and replaces it.
I replaced the string compare with regular expression because it didn't fit the strings on my machine (number of : was different).
I also took the liberty to add the accompanied option device_type and added entries in the README.md file.
