### PR TITLE
Rename usb port

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If using D435 or D415, the gyro and accel topics wont be available. Likewise, ot
 ### Launch parameters
 The following parameters are available by the wrapper:
 - **serial_no**: will attach to the device with the given serial number (*serial_no*) number. Default, attach to available RealSense device in random.
-- **port_no**: will attach to the device with the given USB port (*port_no*). i.e 4-1, 4-2 etc. Default, ignore USB port when choosing a device.
+- **usb_port_id**: will attach to the device with the given USB port (*usb_port_id*). i.e 4-1, 4-2 etc. Default, ignore USB port when choosing a device.
 - **device_type**: will attach to a device whose name includes the given *device_type* regular expression pattern. Default, ignore device type. For example, device_type:=d435 will match d435 and d435i. device_type=d435(?!i) will match d435 but not d435i.
 
 - **rosbag_filename**: Will publish topics from rosbag file.

--- a/realsense2_camera/include/realsense_node_factory.h
+++ b/realsense2_camera/include/realsense_node_factory.h
@@ -68,7 +68,7 @@ namespace realsense2_camera
         std::unique_ptr<InterfaceRealSenseNode> _realSenseNode;
         rs2::context _ctx;
         std::string _serial_no;
-        std::string _port_no;
+        std::string _usb_port_id;
         std::string _device_type;
         bool _initial_reset;
         std::thread _query_thread;

--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -2,7 +2,7 @@
   <arg name="external_manager"    default="false"/>
   <arg name="manager"             default="realsense2_camera_manager"/>
   <arg name="serial_no"           default=""/>
-  <arg name="port_no"             default=""/>
+  <arg name="usb_port_id"         default=""/>
   <arg name="device_type"         default=""/>
   <arg name="tf_prefix"           default=""/>
   <arg name="json_file_path"      default=""/>
@@ -93,7 +93,7 @@
   <node unless="$(arg external_manager)" pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen" required="$(arg required)"/>
   <node pkg="nodelet" type="nodelet" name="realsense2_camera" args="load realsense2_camera/RealSenseNodeFactory $(arg manager)" required="$(arg required)">
     <param name="serial_no"                type="str"  value="$(arg serial_no)"/>
-    <param name="port_no"                  type="str"  value="$(arg port_no)"/>
+    <param name="usb_port_id"              type="str"  value="$(arg usb_port_id)"/>
     <param name="device_type"              type="str"  value="$(arg device_type)"/>
     <param name="json_file_path"           type="str"  value="$(arg json_file_path)"/>
     <param name="rosbag_filename"          type="str"  value="$(arg rosbag_filename)"/>

--- a/realsense2_camera/launch/rs_camera.launch
+++ b/realsense2_camera/launch/rs_camera.launch
@@ -1,6 +1,6 @@
 <launch>
   <arg name="serial_no"           default=""/>
-  <arg name="port_no"             default=""/>
+  <arg name="usb_port_id"         default=""/>
   <arg name="device_type"         default=""/>
   <arg name="json_file_path"      default=""/>
   <arg name="camera"              default="camera"/>
@@ -60,7 +60,7 @@
       <arg name="external_manager"         value="$(arg external_manager)"/>
       <arg name="manager"                  value="$(arg manager)"/>
       <arg name="serial_no"                value="$(arg serial_no)"/>
-      <arg name="port_no"                  value="$(arg port_no)"/>
+      <arg name="usb_port_id"              value="$(arg usb_port_id)"/>
       <arg name="device_type"              value="$(arg device_type)"/>
       <arg name="json_file_path"           value="$(arg json_file_path)"/>
 

--- a/realsense2_camera/launch/rs_rgbd.launch
+++ b/realsense2_camera/launch/rs_rgbd.launch
@@ -48,7 +48,7 @@ Processing enabled by this node:
   <!-- Camera device specific arguments -->
 
   <arg name="serial_no"           default=""/>
-  <arg name="port_no"             default=""/>
+  <arg name="usb_port_id"         default=""/>
   <arg name="device_type"         default=""/>
   <arg name="json_file_path"      default=""/>
 
@@ -119,7 +119,7 @@ Processing enabled by this node:
       <arg name="manager"                  value="$(arg manager)"/>
       <arg name="tf_prefix"                value="$(arg tf_prefix)"/>
       <arg name="serial_no"                value="$(arg serial_no)"/>
-      <arg name="port_no"                  value="$(arg port_no)"/>
+      <arg name="usb_port_id"              value="$(arg usb_port_id)"/>
       <arg name="device_type"              value="$(arg device_type)"/>
       <arg name="json_file_path"           value="$(arg json_file_path)"/>
 

--- a/realsense2_camera/launch/rs_t265.launch
+++ b/realsense2_camera/launch/rs_t265.launch
@@ -6,7 +6,7 @@ https://github.com/IntelRealSense/librealsense/blob/master/third-party/libtm/lib
 -->
 <launch>
   <arg name="serial_no"           default=""/>
-  <arg name="port_no"             default=""/>
+  <arg name="usb_port_id"         default=""/>
   <arg name="json_file_path"      default=""/>
   <arg name="camera"              default="camera"/>
   <arg name="tf_prefix"           default="$(arg camera)"/>
@@ -35,7 +35,7 @@ https://github.com/IntelRealSense/librealsense/blob/master/third-party/libtm/lib
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
       <arg name="tf_prefix"                value="$(arg tf_prefix)"/>
       <arg name="serial_no"                value="$(arg serial_no)"/>
-      <arg name="port_no"                  value="$(arg port_no)"/>
+      <arg name="usb_port_id"              value="$(arg usb_port_id)"/>
       <arg name="json_file_path"           value="$(arg json_file_path)"/>
 
       <arg name="enable_sync"              value="$(arg enable_sync)"/>

--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -95,7 +95,7 @@ void RealSenseNodeFactory::getDevice(rs2::device_list list)
 				{
 					std::stringstream msg;
 					msg << "Error extracting usb port from device with physical ID: " << pn << std::endl << "Please report on github issue at https://github.com/IntelRealSense/realsense-ros";
-					if (_port_no.empty())
+					if (_usb_port_id.empty())
 					{
 						ROS_WARN_STREAM(msg.str());
 					}
@@ -112,7 +112,7 @@ void RealSenseNodeFactory::getDevice(rs2::device_list list)
 					found_device_type = std::regex_search(name, base_match, device_type_regex);
 				}
 
-				if ((_serial_no.empty() || sn == _serial_no) && (_port_no.empty() || port_id == _port_no) && found_device_type)
+				if ((_serial_no.empty() || sn == _serial_no) && (_usb_port_id.empty() || port_id == _usb_port_id) && found_device_type)
 				{
 					_device = dev;
 					_serial_no = sn;
@@ -130,13 +130,13 @@ void RealSenseNodeFactory::getDevice(rs2::device_list list)
 					msg += "serial number " + _serial_no;
 					add_and = true;
 				}
-				if (!_port_no.empty())
+				if (!_usb_port_id.empty())
 				{
 					if (add_and)
 					{
 						msg += " and ";
 					}
-					msg += "port number " + _port_no;
+					msg += "usb port id " + _usb_port_id;
 					add_and = true;
 				}
 				if (!_device_type.empty())
@@ -211,7 +211,7 @@ void RealSenseNodeFactory::onInit()
 		ros::NodeHandle nh = getNodeHandle();
 		auto privateNh = getPrivateNodeHandle();
 		privateNh.param("serial_no", _serial_no, std::string(""));
-    	privateNh.param("port_no", _port_no, std::string(""));
+    	privateNh.param("usb_port_id", _usb_port_id, std::string(""));
     	privateNh.param("device_type", _device_type, std::string(""));
 
 		std::string rosbag_filename("");


### PR DESCRIPTION
renamed port_no to usb_port_id. More accurate, informative and match legacy versions.