### PR TITLE
Fix wrong PointField Type for Colored Point Cloud Messages

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -2071,7 +2071,7 @@ void BaseRealSenseNode::publishPointCloud(rs2::points pc, const ros::Time& t, co
             default:
                 throw std::runtime_error("Unhandled texture format passed in pointcloud " + std::to_string(texture_frame.get_profile().format()));
         }
-        msg_pointcloud.point_step = addPointField(msg_pointcloud, format_str.c_str(), 1, sensor_msgs::PointField::UINT32, msg_pointcloud.point_step);
+        msg_pointcloud.point_step = addPointField(msg_pointcloud, format_str.c_str(), 1, sensor_msgs::PointField::FLOAT32, msg_pointcloud.point_step);
         msg_pointcloud.row_step = msg_pointcloud.width * msg_pointcloud.point_step;
         msg_pointcloud.data.resize(msg_pointcloud.height * msg_pointcloud.row_step);
 


### PR DESCRIPTION
* Related issue: #680
* Use `FLOAT32` for `sensor_msgs::PointField` when preparing the point cloud message,
in case where texture is available and chosen.