### PR TITLE
fixed unite_imu_method copy to transmit at gyro's rate.

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -171,38 +171,19 @@ namespace realsense2_camera
 
 
     private:
-        class CIMUHistory
+        class CimuData
         {
             public:
-                enum sensor_name {mGYRO, mACCEL};
-                class imuData
-                {
-                    public:
-                        imuData(const imuData& other):
-                            imuData(other.m_reading, other.m_time)
-                            {};
-                        imuData(const float3 reading, double time):
-                            m_reading(reading),
-                            m_time(time)
-                            {};
-                        imuData operator*(const double factor);
-                        imuData operator+(const imuData& other);
-                    public:
-                        BaseRealSenseNode::float3 m_reading;
-                        double                    m_time;
-                };
-                
-            private:
-                size_t m_max_size;
-                std::map<sensor_name, std::list<imuData> > m_map;
-
+                CimuData() : m_time(-1) {};
+                CimuData(const stream_index_pair type, Eigen::Vector3d data, double time):
+                    m_type(type),
+                    m_data(data),
+                    m_time(time){};
+                bool is_set() {return m_time > 0;};
             public:
-                CIMUHistory(size_t size);
-                void add_data(sensor_name module, imuData data);
-                bool is_all_data(sensor_name);
-                bool is_data(sensor_name);
-                const std::list<imuData>& get_data(sensor_name module);
-                imuData last_data(sensor_name module);
+                stream_index_pair m_type;
+                Eigen::Vector3d m_data;
+                double          m_time;
         };
 
         static std::string getNamespaceStr();
@@ -239,8 +220,11 @@ namespace realsense2_camera
         bool getEnabledProfile(const stream_index_pair& stream_index, rs2::stream_profile& profile);
 
         void publishAlignedDepthToOthers(rs2::frameset frames, const ros::Time& t);
-        double FillImuData_Copy(const stream_index_pair stream_index, const CIMUHistory::imuData imu_data, sensor_msgs::Imu& imu_msg);
-        double FillImuData_LinearInterpolation(const stream_index_pair stream_index, const CIMUHistory::imuData imu_data, sensor_msgs::Imu& imu_msg);
+        sensor_msgs::Imu CreateUnitedMessage(const CimuData accel_data, const CimuData gyro_data);
+
+        void FillImuData_Copy(const CimuData imu_data, std::deque<sensor_msgs::Imu>& imu_msgs);
+        void ImuMessage_AddDefaultValues(sensor_msgs::Imu& imu_msg);
+        void FillImuData_LinearInterpolation(const CimuData imu_data, std::deque<sensor_msgs::Imu>& imu_msgs);
         void imu_callback(rs2::frame frame);
         void imu_callback_sync(rs2::frame frame, imu_sync_method sync_method=imu_sync_method::COPY);
         void pose_callback(rs2::frame frame);

--- a/realsense2_camera/scripts/rs2_listener.py
+++ b/realsense2_camera/scripts/rs2_listener.py
@@ -3,7 +3,6 @@ import time
 import rospy
 from sensor_msgs.msg import Image as msg_Image
 from sensor_msgs.msg import PointCloud2 as msg_PointCloud2
-from theora_image_transport.msg import Packet as msg_theora
 import sensor_msgs.point_cloud2 as pc2
 from sensor_msgs.msg import Imu as msg_Imu
 import numpy as np
@@ -12,6 +11,10 @@ import inspect
 import ctypes
 import struct
 import tf
+try:
+    from theora_image_transport.msg import Packet as msg_theora
+except Exception
+    pass
 
 
 def pc2_to_xyzrgb(point):
@@ -231,7 +234,11 @@ def main():
     elif 'imu' in wanted_topic:
         msg_type = msg_Imu
     elif 'theora' in wanted_topic:
-        msg_type = msg_theora
+        try:
+            msg_type = msg_theora
+        except NameError as e:
+            print ('theora_image_transport is not installed. \nType "sudo apt-get install ros-kinetic-theora-image-transport" to enable registering on messages of type theora.')
+            raise
     else:
         msg_type = msg_Image
 

--- a/realsense2_camera/scripts/rs2_listener.py
+++ b/realsense2_camera/scripts/rs2_listener.py
@@ -13,7 +13,7 @@ import struct
 import tf
 try:
     from theora_image_transport.msg import Packet as msg_theora
-except Exception
+except Exception:
     pass
 
 

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -1223,21 +1223,24 @@ double BaseRealSenseNode::FillImuData_LinearInterpolation(const stream_index_pai
     return that_last_data.m_time;
 }
 
-
 double BaseRealSenseNode::FillImuData_Copy(const stream_index_pair stream_index, const BaseRealSenseNode::CIMUHistory::imuData imu_data, sensor_msgs::Imu& imu_msg)
 {
-    if (GYRO == stream_index)
+    static CIMUHistory::imuData _accel_data({0,0,0}, -1.0);
+    if (ACCEL == stream_index)
     {
-        imu_msg.angular_velocity.x = imu_data.m_reading.x;
-        imu_msg.angular_velocity.y = imu_data.m_reading.y;
-        imu_msg.angular_velocity.z = imu_data.m_reading.z;
+        _accel_data = imu_data;
+        return -1;
     }
-    else if (ACCEL == stream_index)
-    {
-        imu_msg.linear_acceleration.x = imu_data.m_reading.x;
-        imu_msg.linear_acceleration.y = imu_data.m_reading.y;
-        imu_msg.linear_acceleration.z = imu_data.m_reading.z;
-    }
+    if (_accel_data.m_time < 0)
+        return -1;
+        
+    imu_msg.angular_velocity.x = imu_data.m_reading.x;
+    imu_msg.angular_velocity.y = imu_data.m_reading.y;
+    imu_msg.angular_velocity.z = imu_data.m_reading.z;
+
+    imu_msg.linear_acceleration.x = _accel_data.m_reading.x;
+    imu_msg.linear_acceleration.y = _accel_data.m_reading.y;
+    imu_msg.linear_acceleration.z = _accel_data.m_reading.z;
     return imu_data.m_time;
 }
 

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -811,7 +811,7 @@ void BaseRealSenseNode::setupPublishers()
     if (_imu_sync_method > imu_sync_method::NONE && _enable[GYRO] && _enable[ACCEL])
     {
         ROS_INFO("Start publisher IMU");
-        _synced_imu_publisher = std::make_shared<SyncedImuPublisher>(_node_handle.advertise<sensor_msgs::Imu>("imu", 1));
+        _synced_imu_publisher = std::make_shared<SyncedImuPublisher>(_node_handle.advertise<sensor_msgs::Imu>("imu", 5));
         _synced_imu_publisher->Enable(_hold_back_imu_for_frames);
     }
     else
@@ -1145,114 +1145,91 @@ void BaseRealSenseNode::clip_depth(rs2::depth_frame depth_frame, float clipping_
     }
 }
 
-BaseRealSenseNode::CIMUHistory::CIMUHistory(size_t size)
+sensor_msgs::Imu BaseRealSenseNode::CreateUnitedMessage(const CimuData accel_data, const CimuData gyro_data)
 {
-    m_max_size = size;
-}
-void BaseRealSenseNode::CIMUHistory::add_data(sensor_name module, BaseRealSenseNode::CIMUHistory::imuData data)
-{
-    m_map[module].push_front(data);
-    if (m_map[module].size() > m_max_size)
-        m_map[module].pop_back();
-}
-bool BaseRealSenseNode::CIMUHistory::is_all_data(sensor_name module)
-{
-    return m_map[module].size() == m_max_size;
-}
-bool BaseRealSenseNode::CIMUHistory::is_data(sensor_name module)
-{
-    return m_map[module].size() > 0;
-}
-const std::list<BaseRealSenseNode::CIMUHistory::imuData>& BaseRealSenseNode::CIMUHistory::get_data(sensor_name module)
-{
-    return m_map[module];
-}
-BaseRealSenseNode::CIMUHistory::imuData BaseRealSenseNode::CIMUHistory::last_data(sensor_name module)
-{
-    return m_map[module].front();
-}
-BaseRealSenseNode::CIMUHistory::imuData BaseRealSenseNode::CIMUHistory::imuData::operator*(const double factor)
-{
-    BaseRealSenseNode::CIMUHistory::imuData new_data(*this);
-    new_data.m_reading *= factor;
-    new_data.m_time *= factor;
-    return new_data;
+    sensor_msgs::Imu imu_msg;
+    ros::Time t(gyro_data.m_time);
+    imu_msg.header.seq = 0;
+    imu_msg.header.stamp = t;
+
+    imu_msg.angular_velocity.x = gyro_data.m_data.x();
+    imu_msg.angular_velocity.y = gyro_data.m_data.y();
+    imu_msg.angular_velocity.z = gyro_data.m_data.z();
+
+    imu_msg.linear_acceleration.x = accel_data.m_data.x();
+    imu_msg.linear_acceleration.y = accel_data.m_data.y();
+    imu_msg.linear_acceleration.z = accel_data.m_data.z();
+    return imu_msg;
 }
 
-BaseRealSenseNode::CIMUHistory::imuData BaseRealSenseNode::CIMUHistory::imuData::operator+(const BaseRealSenseNode::CIMUHistory::imuData& other)
-{
-    BaseRealSenseNode::CIMUHistory::imuData new_data(*this);
-    new_data.m_reading += other.m_reading;
-    new_data.m_time += other.m_time;
-    return new_data;
+template <typename T> T lerp(const T &a, const T &b, const double t) {
+  return a * (1.0 - t) + b * t;
 }
 
-double BaseRealSenseNode::FillImuData_LinearInterpolation(const stream_index_pair stream_index, const BaseRealSenseNode::CIMUHistory::imuData imu_data, sensor_msgs::Imu& imu_msg)
+void BaseRealSenseNode::FillImuData_LinearInterpolation(const CimuData imu_data, std::deque<sensor_msgs::Imu>& imu_msgs)
 {
-    static CIMUHistory _imu_history(2);
-    CIMUHistory::sensor_name this_sensor(static_cast<CIMUHistory::sensor_name>(ACCEL == stream_index));
-    CIMUHistory::sensor_name that_sensor(static_cast<CIMUHistory::sensor_name>(!this_sensor));
-    _imu_history.add_data(this_sensor, imu_data);
+    static std::deque<CimuData> _imu_history;
+    _imu_history.push_back(imu_data);
+    stream_index_pair type(imu_data.m_type);
+    imu_msgs.clear();
 
-    if (!_imu_history.is_all_data(this_sensor) || !_imu_history.is_data(that_sensor) )
-        return -1;
-    const std::list<CIMUHistory::imuData> this_data = _imu_history.get_data(this_sensor);
-    CIMUHistory::imuData that_last_data = _imu_history.last_data(that_sensor);
-    std::list<CIMUHistory::imuData>::const_iterator this_data_iter = this_data.begin();
-    CIMUHistory::imuData this_last_data(*this_data_iter);
-    this_data_iter++;
-    CIMUHistory::imuData this_prev_data(*this_data_iter);
-    if (this_prev_data.m_time > that_last_data.m_time)
-        return -1;  // "that" data was already sent.
-    double factor( (that_last_data.m_time - this_prev_data.m_time) / (this_last_data.m_time - this_prev_data.m_time) );
-    CIMUHistory::imuData interp_data = this_prev_data*(1-factor) + this_last_data*factor;
+    if ((type != ACCEL) || _imu_history.size() < 3)
+        return;
+    
+    std::deque<CimuData> gyros_data;
+    CimuData accel0, accel1, crnt_imu;
 
-    CIMUHistory::imuData accel_data = that_last_data;
-    CIMUHistory::imuData gyro_data = interp_data;
-    if (this_sensor == CIMUHistory::sensor_name::mACCEL)
+    while (_imu_history.size()) 
     {
-        std::swap(accel_data, gyro_data);
-    }
-    imu_msg.angular_velocity.x = gyro_data.m_reading.x;
-    imu_msg.angular_velocity.y = gyro_data.m_reading.y;
-    imu_msg.angular_velocity.z = gyro_data.m_reading.z;
+        crnt_imu = _imu_history.front();
+        _imu_history.pop_front();
+        if (!accel0.is_set() && crnt_imu.m_type == ACCEL) 
+        {
+            accel0 = crnt_imu;
+        } 
+        else if (accel0.is_set() && crnt_imu.m_type == ACCEL) 
+        {
+            accel1 = crnt_imu;
+            const double dt = accel1.m_time - accel0.m_time;
 
-    imu_msg.linear_acceleration.x = accel_data.m_reading.x;
-    imu_msg.linear_acceleration.y = accel_data.m_reading.y;
-    imu_msg.linear_acceleration.z = accel_data.m_reading.z;
-    return that_last_data.m_time;
+            while (gyros_data.size())
+            {
+                CimuData crnt_gyro = gyros_data.front();
+                gyros_data.pop_front();
+                const double alpha = (crnt_gyro.m_time - accel0.m_time) / dt;
+                CimuData crnt_accel(ACCEL, lerp(accel0.m_data, accel1.m_data, alpha), crnt_gyro.m_time);
+                imu_msgs.push_back(CreateUnitedMessage(crnt_accel, crnt_gyro));
+            }
+            accel0 = accel1;
+        } 
+        else if (accel0.is_set() && crnt_imu.m_time >= accel0.m_time && crnt_imu.m_type == GYRO)
+        {
+            gyros_data.push_back(crnt_imu);
+        }
+    }
+    _imu_history.push_back(crnt_imu);
+    return;
 }
 
-double BaseRealSenseNode::FillImuData_Copy(const stream_index_pair stream_index, const BaseRealSenseNode::CIMUHistory::imuData imu_data, sensor_msgs::Imu& imu_msg)
+void BaseRealSenseNode::FillImuData_Copy(const CimuData imu_data, std::deque<sensor_msgs::Imu>& imu_msgs)
 {
-    static CIMUHistory::imuData _accel_data({0,0,0}, -1.0);
-    if (ACCEL == stream_index)
+    stream_index_pair type(imu_data.m_type);
+
+    static CimuData _accel_data(ACCEL, {0,0,0}, -1.0);
+    if (ACCEL == type)
     {
         _accel_data = imu_data;
-        return -1;
+        return;
     }
     if (_accel_data.m_time < 0)
-        return -1;
-        
-    imu_msg.angular_velocity.x = imu_data.m_reading.x;
-    imu_msg.angular_velocity.y = imu_data.m_reading.y;
-    imu_msg.angular_velocity.z = imu_data.m_reading.z;
+        return;
 
-    imu_msg.linear_acceleration.x = _accel_data.m_reading.x;
-    imu_msg.linear_acceleration.y = _accel_data.m_reading.y;
-    imu_msg.linear_acceleration.z = _accel_data.m_reading.z;
-    return imu_data.m_time;
+    imu_msgs.push_back(CreateUnitedMessage(_accel_data, imu_data));
 }
 
-void BaseRealSenseNode::imu_callback_sync(rs2::frame frame, imu_sync_method sync_method)
+void BaseRealSenseNode::ImuMessage_AddDefaultValues(sensor_msgs::Imu& imu_msg)
 {
-    static std::mutex m_mutex;
-    static const stream_index_pair stream_imu = GYRO;
-    static sensor_msgs::Imu imu_msg = sensor_msgs::Imu();
-    static int seq = 0;
-    static bool init_gyro(false), init_accel(false);
-    static double accel_factor(0);
-    imu_msg.header.frame_id = _optical_frame_id[stream_imu];
+    imu_msg.header.frame_id = _optical_frame_id[GYRO];
     imu_msg.orientation.x = 0.0;
     imu_msg.orientation.y = 0.0;
     imu_msg.orientation.z = 0.0;
@@ -1261,6 +1238,14 @@ void BaseRealSenseNode::imu_callback_sync(rs2::frame frame, imu_sync_method sync
     imu_msg.orientation_covariance = { -1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
     imu_msg.linear_acceleration_covariance = { _linear_accel_cov, 0.0, 0.0, 0.0, _linear_accel_cov, 0.0, 0.0, 0.0, _linear_accel_cov};
     imu_msg.angular_velocity_covariance = { _angular_velocity_cov, 0.0, 0.0, 0.0, _angular_velocity_cov, 0.0, 0.0, 0.0, _angular_velocity_cov};
+}
+
+void BaseRealSenseNode::imu_callback_sync(rs2::frame frame, imu_sync_method sync_method)
+{
+    static std::mutex m_mutex;
+    static int seq = 0;
+    static bool init_accel(false);
+    static double accel_factor(0);
 
     m_mutex.lock();
 
@@ -1282,10 +1267,6 @@ void BaseRealSenseNode::imu_callback_sync(rs2::frame frame, imu_sync_method sync
         if (0 != _synced_imu_publisher->getNumSubscribers())
         {
             auto crnt_reading = *(reinterpret_cast<const float3*>(frame.get_data()));
-            if (GYRO == stream_index)
-            {
-                init_gyro = true;
-            }
             if (ACCEL == stream_index)
             {
                 if (!init_accel)
@@ -1305,26 +1286,30 @@ void BaseRealSenseNode::imu_callback_sync(rs2::frame frame, imu_sync_method sync
                     crnt_reading.z = v.z();
                 }
             }
-            CIMUHistory::imuData imu_data(crnt_reading, elapsed_camera_ms);
+            Eigen::Vector3d v(crnt_reading.x, crnt_reading.y, crnt_reading.z);
+            CimuData imu_data(stream_index, v, elapsed_camera_ms);
+            std::deque<sensor_msgs::Imu> imu_msgs;
             switch (sync_method)
             {
                 case NONE: //Cannot really be NONE. Just to avoid compilation warning.
                 case COPY:
-                    elapsed_camera_ms = FillImuData_Copy(stream_index, imu_data, imu_msg);
+                    FillImuData_Copy(imu_data, imu_msgs);
                     break;
                 case LINEAR_INTERPOLATION:
-                    elapsed_camera_ms = FillImuData_LinearInterpolation(stream_index, imu_data, imu_msg);
+                    FillImuData_LinearInterpolation(imu_data, imu_msgs);
                     break;
             }
-            if (elapsed_camera_ms < 0)
-                break;
-            ros::Time t(_ros_time_base.toSec() + elapsed_camera_ms);
-            imu_msg.header.seq = seq;
-            imu_msg.header.stamp = t;
-            if (!(init_gyro && init_accel))
-                break;
-            _synced_imu_publisher->Publish(imu_msg);
-            ROS_DEBUG("Publish united %s stream", rs2_stream_to_string(frame.get_profile().stream_type()));
+            while (imu_msgs.size())
+            {
+                sensor_msgs::Imu imu_msg = imu_msgs.front();
+                ros::Time t(_ros_time_base.toSec() + imu_msg.header.stamp.toSec());
+                imu_msg.header.seq = seq;
+                imu_msg.header.stamp = t;
+                ImuMessage_AddDefaultValues(imu_msg);
+                _synced_imu_publisher->Publish(imu_msg);
+                ROS_DEBUG("Publish united %s stream", rs2_stream_to_string(frame.get_profile().stream_type()));
+                imu_msgs.pop_front();
+            }
         }
         break;
     }

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -1313,14 +1313,8 @@ void BaseRealSenseNode::imu_callback(rs2::frame frame)
         ros::Time t(_ros_time_base.toSec() + elapsed_camera_ms);
 
         auto imu_msg = sensor_msgs::Imu();
+        ImuMessage_AddDefaultValues(imu_msg);
         imu_msg.header.frame_id = _optical_frame_id[stream_index];
-        imu_msg.orientation.x = 0.0;
-        imu_msg.orientation.y = 0.0;
-        imu_msg.orientation.z = 0.0;
-        imu_msg.orientation.w = 0.0;
-        imu_msg.orientation_covariance = { -1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-        imu_msg.linear_acceleration_covariance = { _linear_accel_cov, 0.0, 0.0, 0.0, _linear_accel_cov, 0.0, 0.0, 0.0, _linear_accel_cov};
-        imu_msg.angular_velocity_covariance = { _angular_velocity_cov, 0.0, 0.0, 0.0, _angular_velocity_cov, 0.0, 0.0, 0.0, _angular_velocity_cov};
 
         auto crnt_reading = *(reinterpret_cast<const float3*>(frame.get_data()));
         if (GYRO == stream_index)


### PR DESCRIPTION
Fix issues #987, #1000 of timestamps going backwards when using "unite_imu_method:=copy"
Also sends messages at the fixed rate of the gyro. Accel information is the last one arrived at the time the message is sent.