### PR TITLE
catch failure on device creation.

### DIFF
--- a/realsense2_camera/include/realsense_node_factory.h
+++ b/realsense2_camera/include/realsense_node_factory.h
@@ -73,6 +73,7 @@ namespace realsense2_camera
         std::string _device_type;
         bool _initial_reset;
         std::thread _query_thread;
+        bool _is_alive;
 
     };
 }//end namespace


### PR DESCRIPTION
also, kill query_thread if closed before device is found.