### PR TITLE
correct offset between camera_link and base_link

### DIFF
--- a/realsense2_description/urdf/_d435.urdf.xacro
+++ b/realsense2_description/urdf/_d435.urdf.xacro
@@ -28,6 +28,12 @@ aluminum peripherial evaluation case.
     <xacro:property name="d435_cam_height" value="0.025"/>
     <xacro:property name="d435_cam_depth" value="0.02505"/>
     <xacro:property name="d435_cam_mount_from_center_offset" value="0.0149"/>
+    <!-- glass cover is 0.1 mm inwards from front aluminium plate -->
+    <xacro:property name="d435_glass_to_front" value="0.1e-3"/>
+    <!-- see datasheet Revision 007, Fig. 4-4 page 65 -->
+    <xacro:property name="d435_zero_depth_to_glass" value="4.2e-3"/>
+    <!-- convenience precomputation to avoid clutter-->
+    <xacro:property name="d435_mesh_x_offset" value="${d435_cam_mount_from_center_offset-d435_glass_to_front-d435_zero_depth_to_glass}"/>
 
     <!-- The following offset is relative the the physical D435 camera peripherial
   	camera tripod mount -->
@@ -44,14 +50,15 @@ aluminum peripherial evaluation case.
     <link name="${name}_bottom_screw_frame"/>
 
     <joint name="${name}_link_joint" type="fixed">
-      <origin xyz="0 ${d435_cam_depth_py} ${d435_cam_depth_pz}" rpy="0 0 0"/>
+      <origin xyz="${d435_mesh_x_offset} ${d435_cam_depth_py} ${d435_cam_depth_pz}" rpy="0 0 0"/>
       <parent link="${name}_bottom_screw_frame"/>
       <child link="${name}_link" />
     </joint>
 
     <link name="${name}_link">
       <visual>
-        <origin xyz="${d435_cam_mount_from_center_offset} ${-d435_cam_depth_py} 0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
+        <!-- the mesh origin is at front plate in between the two infrared camera axes -->
+        <origin xyz="${d435_zero_depth_to_glass + d435_glass_to_front} ${-d435_cam_depth_py} 0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
         <geometry>
           <!-- <box size="${d435_cam_width} ${d435_cam_height} ${d435_cam_depth}"/> -->
 	        <mesh filename="package://realsense2_description/meshes/d435.dae" />


### PR DESCRIPTION
As discussed in #999, the `camera_link` frame has x coordinates that are coincident with the one of the `camera_bottom_screw_frame`. 

The extrinsic parameters stored inside the device (correct me if I'm wrong) should have no knowledge of the distance between the optical frame and the bottom screw hole. The extrinsics are indeed retrieved by calibration with a checkerboard and can only provide the mutual location between the two camera optical frames and the IMU.

Therefore, the `camera_link` should be coincident with the `infra1_frame`, as confirmed by RViz
![image](https://user-images.githubusercontent.com/13381545/76687460-05c2ee80-661c-11ea-947e-dffb6b907f3d.png)

This PR adjusts the offset of the mesh and of the `camera_link` from `camera_bottom_screw_hole` by introducing new parametric quantities retrieved from the datasheet. In this way, the `camera_link` frame and their children are at the right offset from the front plate:
![image](https://user-images.githubusercontent.com/13381545/76687566-04de8c80-661d-11ea-9bff-d84fc993d012.png)

