### PR TITLE
fix use_nominal_extrinsics arg/parameter usage

### DIFF
--- a/realsense2_description/urdf/_d415.urdf.xacro
+++ b/realsense2_description/urdf/_d415.urdf.xacro
@@ -73,7 +73,7 @@ aluminum peripherial evaluation case.
     </link>
 
     <!-- Use the nominal extrinsics between camera frames if the calibrated extrinsics aren't being published. e.g. running the device in simulation  -->
-    <xacro:if value="$(arg use_nominal_extrinsics)">
+    <xacro:if value="${use_nominal_extrinsics}">
       <!-- camera depth joints and links -->
       <joint name="${name}_depth_joint" type="fixed">
         <origin xyz="0 0 0" rpy="0 0 0"/>

--- a/realsense2_description/urdf/_d435.urdf.xacro
+++ b/realsense2_description/urdf/_d435.urdf.xacro
@@ -72,7 +72,7 @@ aluminum peripherial evaluation case.
     </link>
 
     <!-- Use the nominal extrinsics between camera frames if the calibrated extrinsics aren't being published. e.g. running the device in simulation  -->
-    <xacro:if value="$(arg use_nominal_extrinsics)">
+    <xacro:if value="${use_nominal_extrinsics}">
       <!-- camera depth joints and links -->
       <joint name="${name}_depth_joint" type="fixed">
         <origin xyz="0 0 0" rpy="0 0 0"/>

--- a/realsense2_description/urdf/_r410.urdf.xacro
+++ b/realsense2_description/urdf/_r410.urdf.xacro
@@ -65,7 +65,7 @@ aluminum peripherial evaluation case.
     </link>
    
     <!-- Use the nominal extrinsics between camera frames if the calibrated extrinsics aren't being published. e.g. running the device in simulation  -->
-    <xacro:if value="$(arg use_nominal_extrinsics)">
+    <xacro:if value="${use_nominal_extrinsics}">
       <!-- camera depth joints and links -->
       <joint name="${name}_depth_joint" type="fixed">
         <origin xyz="${r410_cam_depth_px} ${r410_cam_depth_py} ${r410_cam_depth_pz}" rpy="0 0 0"/>

--- a/realsense2_description/urdf/_r430.urdf.xacro
+++ b/realsense2_description/urdf/_r430.urdf.xacro
@@ -66,7 +66,7 @@ aluminum peripherial evaluation case.
     </link>
 
     <!-- Use the nominal extrinsics between camera frames if the calibrated extrinsics aren't being published. e.g. running the device in simulation  -->
-    <xacro:if value="$(arg use_nominal_extrinsics)">
+    <xacro:if value="${use_nominal_extrinsics}">
       <!-- camera depth joints and links -->
       <joint name="${name}_depth_joint" type="fixed">
         <origin xyz="${r430_cam_depth_px} ${r430_cam_depth_py} ${r430_cam_depth_pz}" rpy="0 0 0"/>

--- a/realsense2_description/urdf/test_d415_camera.urdf.xacro
+++ b/realsense2_description/urdf/test_d415_camera.urdf.xacro
@@ -1,9 +1,10 @@
 <?xml version="1.0"?>
 <robot name="realsense2_camera" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:arg name="use_nominal_extrinsics" default="false" />
   <xacro:include filename="$(find realsense2_description)/urdf/_d415.urdf.xacro" />
 
   <link name="base_link" />
-  <sensor_d415 parent="base_link">
+  <sensor_d415 parent="base_link" use_nominal_extrinsics="$(arg use_nominal_extrinsics)">
     <origin xyz="0 0 0" rpy="0 0 0"/>
   </sensor_d415>
 </robot>

--- a/realsense2_description/urdf/test_d435_camera.urdf.xacro
+++ b/realsense2_description/urdf/test_d435_camera.urdf.xacro
@@ -1,9 +1,10 @@
 <?xml version="1.0"?>
 <robot name="realsense2_camera" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:arg name="use_nominal_extrinsics" default="false"/>
   <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro" />
   
   <link name="base_link" />
-  <sensor_d435 parent="base_link">
+  <sensor_d435 parent="base_link" use_nominal_extrinsics="$(arg use_nominal_extrinsics)">
     <origin xyz="0 0 0" rpy="0 0 0"/>
   </sensor_d435>
 </robot>

--- a/realsense2_description/urdf/test_d435_multiple_cameras.urdf.xacro
+++ b/realsense2_description/urdf/test_d435_multiple_cameras.urdf.xacro
@@ -1,13 +1,14 @@
 <?xml version="1.0"?>
 <robot name="realsense2_camera" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:arg name="use_nominal_extrinsics" default="false"/>
   <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro" />
 
   <link name="base_link" />
-  <sensor_d435 parent="base_link" name="camera1">
+  <sensor_d435 parent="base_link" name="camera1" use_nominal_extrinsics="$(arg use_nominal_extrinsics)">
     <origin xyz="0.1 0 0" rpy="0 0 0"/>
   </sensor_d435>
 
-  <sensor_d435 parent="base_link" name="camera2">
+  <sensor_d435 parent="base_link" name="camera2" use_nominal_extrinsics="$(arg use_nominal_extrinsics)">
     <origin xyz="-0.1 0 0" rpy="0 0 3.1456"/>
   </sensor_d435>
 </robot>

--- a/realsense2_description/urdf/test_r410_camera.urdf.xacro
+++ b/realsense2_description/urdf/test_r410_camera.urdf.xacro
@@ -1,9 +1,10 @@
 <?xml version="1.0"?>
 <robot name="realsense2_camera" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:arg name="use_nominal_extrinsics" default="false"/>
   <xacro:include filename="$(find realsense2_description)/urdf/_r410.urdf.xacro" />
   
   <link name="base_link" />
-  <sensor_r410 parent="base_link">
+  <sensor_r410 parent="base_link" use_nominal_extrinsics="$(arg use_nominal_extrinsics)">
     <origin xyz="0 0 0" rpy="0 0 0"/>
   </sensor_r410>
 </robot>

--- a/realsense2_description/urdf/test_r430_camera.urdf.xacro
+++ b/realsense2_description/urdf/test_r430_camera.urdf.xacro
@@ -1,9 +1,10 @@
 <?xml version="1.0"?>
 <robot name="realsense2_camera" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:arg name="use_nominal_extrinsics" default="false"/>
   <xacro:include filename="$(find realsense2_description)/urdf/_r430.urdf.xacro" />
   
   <link name="base_link" />
-  <sensor_r430 parent="base_link">
+  <sensor_r430 parent="base_link" use_nominal_extrinsics="$(arg use_nominal_extrinsics)">
     <origin xyz="0 0 0" rpy="0 0 0"/>
   </sensor_r430>
 </robot>


### PR DESCRIPTION
The macros defined in the device files e.g.,  `_d435.urdf.xacro` have a parameter called `use_nominal_extrinsics`, but they are also dependent on an undefined argument [with the same name](https://github.com/IntelRealSense/realsense-ros/blob/development/realsense2_description/urdf/_d435.urdf.xacro#L75).

The `test_*_camera.urdf.xacro` files which are responsible for instantiating the macro do not define the argument either.

This works as long as the `xacro` command is called from a launchfile with the argument defined, but when called in isolation without any argument they fail.

There is no reason to depend on a argument in the macro definition files (e.g., `_d435.urdf.xacro`). Only the test files should depend on arguments, as calling `xacro` on the `_d435.urdf.xacro` has no effect because the macro is defined but not instantiated. 

This PR fixes that by removing the argument dependency on the `_d435.urdf.xacro` and other models, and introducing it in the `test_d435_camera.urdf.xacro` and other models.

In this way, calling `xacro` on either of the two with no arguments produces no error.

This PR was tested by launching all the `view_*_model.launch` files provided.

