### PR TITLE
Adding respawn option on the nodelet launch

### DIFF
--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -8,6 +8,7 @@
   <arg name="json_file_path"      default=""/>
   <arg name="rosbag_filename"     default=""/>
   <arg name="required"            default="false"/>
+  <arg name="respawn"             default="false"/>
 
   <arg name="fisheye_width"       default="0"/>
   <arg name="fisheye_height"      default="0"/>
@@ -90,8 +91,8 @@
   <arg name="allow_no_texture_points"  default="false"/>
 
 
-  <node unless="$(arg external_manager)" pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen" required="$(arg required)"/>
-  <node pkg="nodelet" type="nodelet" name="realsense2_camera" args="load realsense2_camera/RealSenseNodeFactory $(arg manager)" required="$(arg required)">
+  <node unless="$(arg external_manager)" pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen" required="$(arg required)" respawn="$(arg respawn)"/>
+  <node pkg="nodelet" type="nodelet" name="realsense2_camera" args="load realsense2_camera/RealSenseNodeFactory $(arg manager)" required="$(arg required)" respawn="$(arg respawn)">
     <param name="serial_no"                type="str"  value="$(arg serial_no)"/>
     <param name="usb_port_id"              type="str"  value="$(arg usb_port_id)"/>
     <param name="device_type"              type="str"  value="$(arg device_type)"/>


### PR DESCRIPTION
The realsense node dies occasionally. Respawn should be available for this kind of scenario, much like required already is.