### PR TITLE
update dependancies for d400 line

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ The following instructions are written for ROS Kinetic, on **Ubuntu 16.04** but 
     * The version of librealsense2 is almost always behind the one availeable in RealSense&trade; official repository.
     * librealsense2 is not built to use native v4l2 driver but the less stable RS-USB protocol. That is because the last is more general and operational on a larger variety of platforms.
 
+    realsense2_description is available as a debian package of ROS distribution. It is necessary for running some of the RealSense&trade; d400 series. It can be installed by typing:
+
+    `sudo apt-get install ros-kinetic-realsense2-description`
+
+    This will install both realsense2_description and its dependents
+
 * ### Method 2: The RealSense&trade; distribution:
 
    #### This option is demonstrated in the [.travis.yml](https://github.com/intel-ros/realsense/blob/development/.travis.yml) file. It basically summerize the elaborate instructions in the following 2 steps:


### PR DESCRIPTION
In the process of downloading and using this, I came across an issue when running: `roslaunch realsense2_camera rs_d435_camera_with_model.launch` this is because the dependency *ros-melodic-realsense2-description* was not installed. This simply makes it easier for the users with the d400 line of sensors not have the same problem that I had. 

