### PR TITLE
fixed usage of use_nominal_extrinsics parameter

### DIFF
--- a/realsense2_description/tests/dual_d415.xacro
+++ b/realsense2_description/tests/dual_d415.xacro
@@ -1,10 +1,9 @@
 <?xml version="1.0"?>
 <robot name="realsense2_camera" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:include filename="../urdf/_d415.urdf.xacro" />
-  
-  <xacro:arg name="use_nominal_extrinsics" default="True" />
+
   <link name="base_link" />
-  <sensor_d415 parent="base_link" name="camera_bottom">
+  <sensor_d415 parent="base_link" name="camera_bottom" use_nominal_extrinsics="true">
     <origin xyz="0 0 0" rpy="0 0 0"/>
   </sensor_d415>
   <sensor_d415 parent="base_link" name="camera_top">

--- a/realsense2_description/tests/dual_d435.xacro
+++ b/realsense2_description/tests/dual_d435.xacro
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <robot name="realsense2_camera" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:include filename="../urdf/_d435.urdf.xacro" />
-  
+
   <xacro:arg name="use_nominal_extrinsics" default="True" />
   <link name="base_link" />
-  <sensor_d435 parent="base_link" name="camera_bottom">
+  <sensor_d435 parent="base_link" name="camera_bottom" use_nominal_extrinsics="true">
     <origin xyz="0 0 0" rpy="0 0 0"/>
   </sensor_d435>
   <sensor_d435 parent="base_link" name="camera_top">

--- a/realsense2_description/tests/dual_r410.xacro
+++ b/realsense2_description/tests/dual_r410.xacro
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <robot name="realsense2_camera" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:include filename="../urdf/_r410.urdf.xacro" />
-  
+
   <xacro:arg name="use_nominal_extrinsics" default="True" />
   <link name="base_link" />
-  <sensor_r410 parent="base_link" name="camera_bottom" >
+  <sensor_r410 parent="base_link" name="camera_bottom" use_nominal_extrinsics="true" >
     <origin xyz="0 0 0" rpy="0 0 0"/>
   </sensor_r410>
   <sensor_r410 parent="base_link" name="camera_top">

--- a/realsense2_description/tests/dual_r430.xacro
+++ b/realsense2_description/tests/dual_r430.xacro
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <robot name="realsense2_camera" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:include filename="../urdf/_r430.urdf.xacro" />
-  
+
   <xacro:arg name="use_nominal_extrinsics" default="True" />
   <link name="base_link" />
-  <sensor_r430 parent="base_link" name="camera_bottom">
+  <sensor_r430 parent="base_link" name="camera_bottom" use_nominal_extrinsics="true">
     <origin xyz="0 0 0" rpy="0 0 0"/>
   </sensor_r430>
   <sensor_r430 parent="base_link" name="camera_top">

--- a/realsense2_description/urdf/_d415.urdf.xacro
+++ b/realsense2_description/urdf/_d415.urdf.xacro
@@ -10,7 +10,7 @@ aluminum peripherial evaluation case.
 <robot name="sensor_d415" xmlns:xacro="http://ros.org/wiki/xacro">
   <!-- Includes -->
   <xacro:include filename="$(find realsense2_description)/urdf/_materials.urdf.xacro" />
-  
+
   <xacro:macro name="sensor_d415" params="parent *origin  name:=camera  use_nominal_extrinsics:=false">
     <xacro:property name="M_PI" value="3.1415926535897931" />
 
@@ -73,7 +73,7 @@ aluminum peripherial evaluation case.
     </link>
 
     <!-- Use the nominal extrinsics between camera frames if the calibrated extrinsics aren't being published. e.g. running the device in simulation  -->
-    <xacro:if value="$(arg use_nominal_extrinsics)">
+    <xacro:if value="${use_nominal_extrinsics}">
       <!-- camera depth joints and links -->
       <joint name="${name}_depth_joint" type="fixed">
         <origin xyz="0 0 0" rpy="0 0 0"/>

--- a/realsense2_description/urdf/_d435.urdf.xacro
+++ b/realsense2_description/urdf/_d435.urdf.xacro
@@ -11,10 +11,10 @@ aluminum peripherial evaluation case.
 <robot name="sensor_d435" xmlns:xacro="http://ros.org/wiki/xacro">
   <!-- Includes -->
   <xacro:include filename="$(find realsense2_description)/urdf/_materials.urdf.xacro" />
-  
+
   <xacro:macro name="sensor_d435" params="parent *origin name:=camera use_nominal_extrinsics:=false">
     <xacro:property name="M_PI" value="3.1415926535897931" />
-  
+
     <!-- The following values are approximate, and the camera node
      publishing TF values with actual calibrated camera extrinsic values -->
     <xacro:property name="d435_cam_depth_to_infra1_offset" value="0.0"/>
@@ -72,7 +72,7 @@ aluminum peripherial evaluation case.
     </link>
 
     <!-- Use the nominal extrinsics between camera frames if the calibrated extrinsics aren't being published. e.g. running the device in simulation  -->
-    <xacro:if value="$(arg use_nominal_extrinsics)">
+    <xacro:if value="${use_nominal_extrinsics}">
       <!-- camera depth joints and links -->
       <joint name="${name}_depth_joint" type="fixed">
         <origin xyz="0 0 0" rpy="0 0 0"/>

--- a/realsense2_description/urdf/_r410.urdf.xacro
+++ b/realsense2_description/urdf/_r410.urdf.xacro
@@ -11,7 +11,7 @@ aluminum peripherial evaluation case.
 <robot name="sensor_r410" xmlns:xacro="http://ros.org/wiki/xacro">
   <!-- Includes -->
   <xacro:include filename="$(find realsense2_description)/urdf/_materials.urdf.xacro" />
-  
+
   <xacro:macro name="sensor_r410" params="parent *origin  name:=camera  use_nominal_extrinsics:=false">
     <xacro:property name="M_PI" value="3.1415926535897931" />
 
@@ -21,7 +21,7 @@ aluminum peripherial evaluation case.
     <xacro:property name="r410_cam_depth_to_infra2_offset" value="0.0275"/>
 
     <!-- The following values model the aluminum peripherial case for the
-      R410 camera, with the camera joint represented by the actual 
+      R410 camera, with the camera joint represented by the actual
       peripherial camera tripod mount -->
     <xacro:property name="r410_cam_width" value="0.099"/>
     <xacro:property name="r410_cam_height" value="0.035"/>
@@ -63,9 +63,9 @@ aluminum peripherial evaluation case.
         <inertia ixx="0.003881243" ixy="0.0" ixz="0.0" iyy="0.000498940" iyz="0.0" izz="0.003879257" />
       </inertial>
     </link>
-   
+
     <!-- Use the nominal extrinsics between camera frames if the calibrated extrinsics aren't being published. e.g. running the device in simulation  -->
-    <xacro:if value="$(arg use_nominal_extrinsics)">
+    <xacro:if value="${use_nominal_extrinsics}">
       <!-- camera depth joints and links -->
       <joint name="${name}_depth_joint" type="fixed">
         <origin xyz="${r410_cam_depth_px} ${r410_cam_depth_py} ${r410_cam_depth_pz}" rpy="0 0 0"/>

--- a/realsense2_description/urdf/_r430.urdf.xacro
+++ b/realsense2_description/urdf/_r430.urdf.xacro
@@ -22,7 +22,7 @@ aluminum peripherial evaluation case.
   <xacro:property name="r430_cam_depth_to_fisheye_offset" value="0.042"/>
 
   <!-- The following values model the aluminum peripherial case for the
-    R430 camera, with the camera joint represented by the actual 
+    R430 camera, with the camera joint represented by the actual
     peripherial camera tripod mount -->
   <xacro:property name="r430_cam_width" value="0.105"/>
   <xacro:property name="r430_cam_height" value="0.039"/>
@@ -66,7 +66,7 @@ aluminum peripherial evaluation case.
     </link>
 
     <!-- Use the nominal extrinsics between camera frames if the calibrated extrinsics aren't being published. e.g. running the device in simulation  -->
-    <xacro:if value="$(arg use_nominal_extrinsics)">
+    <xacro:if value="${use_nominal_extrinsics}">
       <!-- camera depth joints and links -->
       <joint name="${name}_depth_joint" type="fixed">
         <origin xyz="${r430_cam_depth_px} ${r430_cam_depth_py} ${r430_cam_depth_pz}" rpy="0 0 0"/>


### PR DESCRIPTION
this parameter was being incorrectly parsed.
its value was not taken into account in each device's xacro.

this PR fixed the parameter usage and update the tests to use it properly.