### PR TITLE
Fix xacro macro call for ros Noetic (compatible with melodic)

### DIFF
--- a/realsense2_camera/launch/rs_d435_camera_with_model.launch
+++ b/realsense2_camera/launch/rs_d435_camera_with_model.launch
@@ -104,6 +104,6 @@
   <!-- Loads the camera model -->
   <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find realsense2_description)/urdf/test_d435_camera.urdf.xacro' use_nominal_extrinsics:=false"/>
 
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher"/>
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find realsense2_description)/rviz/urdf.rviz" required="true"/>
 </launch>

--- a/realsense2_description/launch/view_d415_model.launch
+++ b/realsense2_description/launch/view_d415_model.launch
@@ -1,6 +1,6 @@
 <launch>
     <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find realsense2_description)/urdf/test_d415_camera.urdf.xacro' use_nominal_extrinsics:=true" />
-    <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+    <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 
     <arg name="gui" default="True" />
     <param name="use_gui" value="$(arg gui)" />

--- a/realsense2_description/launch/view_d435_model.launch
+++ b/realsense2_description/launch/view_d435_model.launch
@@ -1,6 +1,6 @@
 <launch>
     <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find realsense2_description)/urdf/test_d435_camera.urdf.xacro' use_nominal_extrinsics:=true" />
-    <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+    <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 
     <arg name="gui" default="True" />
     <param name="use_gui" value="$(arg gui)" />

--- a/realsense2_description/launch/view_multiple_d435_models.launch
+++ b/realsense2_description/launch/view_multiple_d435_models.launch
@@ -1,6 +1,6 @@
 <launch>
     <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find realsense2_description)/urdf/test_d435_multiple_cameras.urdf.xacro' use_nominal_extrinsics:=true" />
-    <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+    <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 
     <arg name="gui" default="True" />
     <param name="use_gui" value="$(arg gui)" />

--- a/realsense2_description/launch/view_r410_model.launch
+++ b/realsense2_description/launch/view_r410_model.launch
@@ -1,6 +1,6 @@
 <launch>
     <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find realsense2_description)/urdf/test_r410_camera.urdf.xacro' use_nominal_extrinsics:=true" />
-    <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+    <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 
     <arg name="gui" default="True" />
     <param name="use_gui" value="$(arg gui)" />

--- a/realsense2_description/launch/view_r430_model.launch
+++ b/realsense2_description/launch/view_r430_model.launch
@@ -1,6 +1,6 @@
 <launch>
     <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find realsense2_description)/urdf/test_r430_camera.urdf.xacro' use_nominal_extrinsics:=true" />
-    <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+    <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 
     <arg name="gui" default="True" />
     <param name="use_gui" value="$(arg gui)" />

--- a/realsense2_description/tests/dual_d415.xacro
+++ b/realsense2_description/tests/dual_d415.xacro
@@ -4,10 +4,10 @@
   
   <xacro:arg name="use_nominal_extrinsics" default="True" />
   <link name="base_link" />
-  <sensor_d415 parent="base_link" name="camera_bottom">
+  <xacro:sensor_d415 parent="base_link" name="camera_bottom">
     <origin xyz="0 0 0" rpy="0 0 0"/>
-  </sensor_d415>
-  <sensor_d415 parent="base_link" name="camera_top">
+  </xacro:sensor_d415>
+  <xacro:sensor_d415 parent="base_link" name="camera_top">
     <origin xyz="0 0 0.2" rpy="0 0 0"/>
-  </sensor_d415>
+  </xacro:sensor_d415>
 </robot>

--- a/realsense2_description/tests/dual_d435.xacro
+++ b/realsense2_description/tests/dual_d435.xacro
@@ -4,10 +4,10 @@
   
   <xacro:arg name="use_nominal_extrinsics" default="True" />
   <link name="base_link" />
-  <sensor_d435 parent="base_link" name="camera_bottom">
+  <xacro:sensor_d435 parent="base_link" name="camera_bottom">
     <origin xyz="0 0 0" rpy="0 0 0"/>
-  </sensor_d435>
-  <sensor_d435 parent="base_link" name="camera_top">
+  </xacro:sensor_d435>
+  <xacro:sensor_d435 parent="base_link" name="camera_top">
     <origin xyz="0 0 0.2" rpy="0 0 0"/>
-  </sensor_d435>
+  </xacro:sensor_d435>
 </robot>

--- a/realsense2_description/tests/dual_r410.xacro
+++ b/realsense2_description/tests/dual_r410.xacro
@@ -4,10 +4,10 @@
   
   <xacro:arg name="use_nominal_extrinsics" default="True" />
   <link name="base_link" />
-  <sensor_r410 parent="base_link" name="camera_bottom" >
+  <xacro:sensor_r410 parent="base_link" name="camera_bottom" >
     <origin xyz="0 0 0" rpy="0 0 0"/>
-  </sensor_r410>
-  <sensor_r410 parent="base_link" name="camera_top">
+  </xacro:sensor_r410>
+  <xacro:sensor_r410 parent="base_link" name="camera_top">
     <origin xyz="0 0 0.2" rpy="0 0 0"/>
-  </sensor_r410>
+  </xacro:sensor_r410>
 </robot>

--- a/realsense2_description/tests/dual_r430.xacro
+++ b/realsense2_description/tests/dual_r430.xacro
@@ -4,10 +4,10 @@
   
   <xacro:arg name="use_nominal_extrinsics" default="True" />
   <link name="base_link" />
-  <sensor_r430 parent="base_link" name="camera_bottom">
+  <xacro:sensor_r430 parent="base_link" name="camera_bottom">
     <origin xyz="0 0 0" rpy="0 0 0"/>
-  </sensor_r430>
-  <sensor_r430 parent="base_link" name="camera_top">
+  </xacro:sensor_r430>
+  <xacro:sensor_r430 parent="base_link" name="camera_top">
     <origin xyz="0 0 0.2" rpy="0 0 0"/>
-  </sensor_r430>
+  </xacro:sensor_r430>
 </robot>

--- a/realsense2_description/tests/one_of_each.xacro
+++ b/realsense2_description/tests/one_of_each.xacro
@@ -7,16 +7,16 @@
   
   <xacro:arg name="use_nominal_extrinsics" default="True" />
   <link name="base_link" />
-  <sensor_d415 parent="base_link" name="d415">
+  <xacro:sensor_d415 parent="base_link" name="d415">
     <origin xyz="0 0 0" rpy="0 0 0"/>
-  </sensor_d415>
-  <sensor_d435 parent="base_link" name="d435">
+  </xacro:sensor_d415>
+  <xacro:sensor_d435 parent="base_link" name="d435">
     <origin xyz="0 0 0.1" rpy="0 0 0"/>
-  </sensor_d435>
-  <sensor_r410 parent="base_link" name="r410">
+  </xacro:sensor_d435>
+  <xacro:sensor_r410 parent="base_link" name="r410">
     <origin xyz="0 0 0.2" rpy="0 0 0"/>
-  </sensor_r410>
-  <sensor_r430 parent="base_link" name="r430">
+  </xacro:sensor_r410>
+  <xacro:sensor_r430 parent="base_link" name="r430">
     <origin xyz="0 0 0.3" rpy="0 0 0"/>
-  </sensor_r430>
+  </xacro:sensor_r430>
 </robot>

--- a/realsense2_description/urdf/test_d415_camera.urdf.xacro
+++ b/realsense2_description/urdf/test_d415_camera.urdf.xacro
@@ -3,7 +3,7 @@
   <xacro:include filename="$(find realsense2_description)/urdf/_d415.urdf.xacro" />
 
   <link name="base_link" />
-  <sensor_d415 parent="base_link">
+  <xacro:sensor_d415 parent="base_link">
     <origin xyz="0 0 0" rpy="0 0 0"/>
-  </sensor_d415>
+  </xacro:sensor_d415>
 </robot>

--- a/realsense2_description/urdf/test_d435_camera.urdf.xacro
+++ b/realsense2_description/urdf/test_d435_camera.urdf.xacro
@@ -3,7 +3,7 @@
   <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro" />
   
   <link name="base_link" />
-  <sensor_d435 parent="base_link">
+  <xacro:sensor_d435 parent="base_link">
     <origin xyz="0 0 0" rpy="0 0 0"/>
-  </sensor_d435>
+  </xacro:sensor_d435>
 </robot>

--- a/realsense2_description/urdf/test_d435_multiple_cameras.urdf.xacro
+++ b/realsense2_description/urdf/test_d435_multiple_cameras.urdf.xacro
@@ -3,11 +3,11 @@
   <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro" />
 
   <link name="base_link" />
-  <sensor_d435 parent="base_link" name="camera1">
+  <xacro:sensor_d435 parent="base_link" name="camera1">
     <origin xyz="0.1 0 0" rpy="0 0 0"/>
-  </sensor_d435>
+  </xacro:sensor_d435>
 
-  <sensor_d435 parent="base_link" name="camera2">
+  <xacro:sensor_d435 parent="base_link" name="camera2">
     <origin xyz="-0.1 0 0" rpy="0 0 3.1456"/>
-  </sensor_d435>
+  </xacro:sensor_d435>
 </robot>

--- a/realsense2_description/urdf/test_r410_camera.urdf.xacro
+++ b/realsense2_description/urdf/test_r410_camera.urdf.xacro
@@ -3,7 +3,7 @@
   <xacro:include filename="$(find realsense2_description)/urdf/_r410.urdf.xacro" />
   
   <link name="base_link" />
-  <sensor_r410 parent="base_link">
+  <xacro:sensor_r410 parent="base_link">
     <origin xyz="0 0 0" rpy="0 0 0"/>
-  </sensor_r410>
+  </xacro:sensor_r410>
 </robot>

--- a/realsense2_description/urdf/test_r430_camera.urdf.xacro
+++ b/realsense2_description/urdf/test_r430_camera.urdf.xacro
@@ -3,7 +3,7 @@
   <xacro:include filename="$(find realsense2_description)/urdf/_r430.urdf.xacro" />
   
   <link name="base_link" />
-  <sensor_r430 parent="base_link">
+  <xacro:sensor_r430 parent="base_link">
     <origin xyz="0 0 0" rpy="0 0 0"/>
-  </sensor_r430>
+  </xacro:sensor_r430>
 </robot>


### PR DESCRIPTION
When using Ros Noetic, the /tf created from the URDF files doesn't appear.
It was because of xacro macro call `<ensor_...>` instead of `<xacro:sensor_...>`
I added it in all xacro files. The fix is compatible with Ros melodic!

I also took the opportunity to change state_pulisher into robot_state_publisher that is removed from Noetic and deprecated in melodic.

FIx Issue #1216

> 