### PR TITLE
Update rs_camera.launch RGB camera resolution to include L515.

### DIFF
--- a/realsense2_camera/launch/rs_camera.launch
+++ b/realsense2_camera/launch/rs_camera.launch
@@ -21,8 +21,8 @@
   <arg name="enable_infra1"       default="false"/>
   <arg name="enable_infra2"       default="false"/>
 
-  <arg name="color_width"         default="640"/>
-  <arg name="color_height"        default="480"/>
+  <arg name="color_width"         default="1280"/>
+  <arg name="color_height"        default="720"/>
   <arg name="enable_color"        default="true"/>
 
   <arg name="fisheye_fps"         default="30"/>


### PR DESCRIPTION
Currently 640x480 is not supported on L515. Update default RGB resolution to one that's supported across all RealSense cameras.