### PR TITLE
add enable (SetBool) service for disabling/enabling sensor streams

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -119,7 +119,7 @@ namespace realsense2_camera
                           rs2::device dev,
                           const std::string& serial_no);
 
-        void toggleSensors(bool enabled);
+        virtual void toggleSensors(bool enabled) override;
         virtual void publishTopics() override;
         virtual void registerDynamicReconfigCb(ros::NodeHandle& nh) override;
         virtual ~BaseRealSenseNode();

--- a/realsense2_camera/include/realsense_node_factory.h
+++ b/realsense2_camera/include/realsense_node_factory.h
@@ -8,6 +8,7 @@
 #include <image_transport/image_transport.h>
 #include <ros/ros.h>
 #include <ros/package.h>
+#include <std_srvs/SetBool.h>
 #include <librealsense2/rs.hpp>
 #include <librealsense2/rsutil.h>
 #include <librealsense2/hpp/rs_processing.hpp>
@@ -47,6 +48,7 @@ namespace realsense2_camera
     {
     public:
         virtual void publishTopics() = 0;
+        virtual void toggleSensors(bool enabled) = 0;
         virtual void registerDynamicReconfigCb(ros::NodeHandle& nh) = 0;
         virtual ~InterfaceRealSenseNode() = default;
     };
@@ -65,6 +67,7 @@ namespace realsense2_camera
         virtual void onInit() override;
         void tryGetLogSeverity(rs2_log_severity& severity) const;
         static std::string parse_usb_port(std::string line);
+        bool toggle_sensor_callback(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res);
 
         rs2::device _device;
         std::unique_ptr<InterfaceRealSenseNode> _realSenseNode;
@@ -75,6 +78,7 @@ namespace realsense2_camera
         bool _initial_reset;
         std::thread _query_thread;
         bool _is_alive;
+        ros::ServiceServer toggle_sensor_srv;
 
     };
 }//end namespace

--- a/realsense2_camera/include/t265_realsense_node.h
+++ b/realsense2_camera/include/t265_realsense_node.h
@@ -11,7 +11,8 @@ namespace realsense2_camera
                           ros::NodeHandle& privateNodeHandle,
                           rs2::device dev,
                           const std::string& serial_no);
-            void publishTopics();
+            virtual void toggleSensors(bool enabled) override;
+            virtual void publishTopics() override;
 
         protected:
             void calcAndPublishStaticTransform(const stream_index_pair& stream, const rs2::stream_profile& base_profile) override;

--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -230,6 +230,17 @@ void RealSenseNodeFactory::change_device_callback(rs2::event_information& info)
 	}
 }
 
+bool RealSenseNodeFactory::toggle_sensor_callback(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res)
+{
+  if (req.data)
+    ROS_INFO_STREAM("toggling sensor : ON");
+  else
+    ROS_INFO_STREAM("toggling sensor : OFF");
+  _realSenseNode->toggleSensors(req.data);
+  res.success=true;
+  return true;
+}
+
 void RealSenseNodeFactory::onInit()
 {
 	try
@@ -244,9 +255,10 @@ void RealSenseNodeFactory::onInit()
 		privateNh.param("serial_no", _serial_no, std::string(""));
     	privateNh.param("usb_port_id", _usb_port_id, std::string(""));
     	privateNh.param("device_type", _device_type, std::string(""));
-
+    toggle_sensor_srv = nh.advertiseService("enable", &RealSenseNodeFactory::toggle_sensor_callback, this);
 		std::string rosbag_filename("");
 		privateNh.param("rosbag_filename", rosbag_filename, std::string(""));
+
 		if (!rosbag_filename.empty())
 		{
 			{

--- a/realsense2_camera/src/t265_realsense_node.cpp
+++ b/realsense2_camera/src/t265_realsense_node.cpp
@@ -41,6 +41,11 @@ void T265RealsenseNode::initializeOdometryInput()
     _use_odom_in = true;
 }
 
+void T265RealsenseNode::toggleSensors(bool enabled)
+{
+  ROS_WARN_STREAM("toggleSensors method not implemented for T265");
+}
+
 void T265RealsenseNode::publishTopics()
 {
     BaseRealSenseNode::publishTopics();


### PR DESCRIPTION
Tested on a D435. More work needed for the T265.
Rewritted the non working toggleSensors method (which was used nowhere) and exposed it as a SetBool enable service.
Addresses https://github.com/IntelRealSense/realsense-ros/issues/1195 and https://github.com/IntelRealSense/librealsense/issues/6413