### PR TITLE
set a false default value for add_plug

### DIFF
--- a/realsense2_description/urdf/_d435.urdf.xacro
+++ b/realsense2_description/urdf/_d435.urdf.xacro
@@ -14,6 +14,7 @@ aluminum peripherial evaluation case.
   <xacro:include filename="$(find realsense2_description)/urdf/_usb_plug.urdf.xacro" />
 
   <xacro:macro name="sensor_d435" params="parent *origin name:=camera use_nominal_extrinsics:=false">
+    <xacro:arg name="add_plug" default="false" />
     <xacro:property name="M_PI" value="3.1415926535897931" />
 
     <!-- The following values are approximate, and the camera node


### PR DESCRIPTION
This seems to solve #1305. 
I tested it by launching `roslaunch realsense2_description view_d435_model.launch` which uses `add_plug:=true` at line 2 and `roslaunch realsense2_description view_d435i_model.launch` which does not define `add_plug`.