### PR TITLE
Add base_frame_id argument to rs_camera.launch

### DIFF
--- a/realsense2_camera/launch/rs_camera.launch
+++ b/realsense2_camera/launch/rs_camera.launch
@@ -42,6 +42,8 @@
   <arg name="enable_sync"               default="false"/>
   <arg name="align_depth"               default="false"/>
 
+  <arg name="base_frame_id"             default="$(arg tf_prefix)_link"/>
+
   <arg name="publish_tf"                default="true"/>
   <arg name="tf_publish_rate"           default="0"/>
 
@@ -97,6 +99,8 @@
       <arg name="accel_fps"                value="$(arg accel_fps)"/>
       <arg name="enable_gyro"              value="$(arg enable_gyro)"/>
       <arg name="enable_accel"             value="$(arg enable_accel)"/>
+
+      <arg name="base_frame_id"            value="$(arg base_frame_id)"/>
 
       <arg name="publish_tf"               value="$(arg publish_tf)"/>
       <arg name="tf_publish_rate"          value="$(arg tf_publish_rate)"/>


### PR DESCRIPTION
This allows to override the base frame id if it does not correspond with $(arg tf_prefix)_link.