### PR TITLE
fix bug: Conversion from milliseconds to nanoseconds.

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -146,7 +146,6 @@ namespace realsense2_camera
                 }
         };
 
-        rclcpp::Clock _ros_clock;
         std::string _base_frame_id;
         std::string _odom_frame_id;
         std::map<stream_index_pair, std::string> _frame_id;

--- a/realsense2_camera/src/t265_realsense_node.cpp
+++ b/realsense2_camera/src/t265_realsense_node.cpp
@@ -76,7 +76,7 @@ void T265RealsenseNode::calcAndPublishStaticTransform(const stream_index_pair& s
     quaternion_optical.setRPY(-M_PI / 2, 0.0, -M_PI / 2);
     float3 zero_trans{0, 0, 0};
 
-    rclcpp::Time transform_ts_ = _ros_clock.now();
+    rclcpp::Time transform_ts_ = _node.now();
 
     rs2_extrinsics ex;
     try


### PR DESCRIPTION
enable use of parameter: use_sim_time.
`ros2 run realsense2_node realsense2_node --ros-args -p use_sim_time:=True`