### PR TITLE
Update nodelet.launch.xml

### DIFF
--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -8,6 +8,7 @@
   <arg name="json_file_path"      default=""/>
   <arg name="rosbag_filename"     default=""/>
   <arg name="required"            default="false"/>
+  <arg name="output"              default="screen"/>
 
   <arg name="fisheye_width"       default="0"/>
   <arg name="fisheye_height"      default="0"/>
@@ -92,7 +93,7 @@
   <arg name="allow_no_texture_points"  default="false"/>
 
 
-  <node unless="$(arg external_manager)" pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen" required="$(arg required)"/>
+  <node unless="$(arg external_manager)" pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="$(arg output)" required="$(arg required)"/>
   <node pkg="nodelet" type="nodelet" name="realsense2_camera" args="load realsense2_camera/RealSenseNodeFactory $(arg manager)" required="$(arg required)">
     <param name="serial_no"                type="str"  value="$(arg serial_no)"/>
     <param name="usb_port_id"              type="str"  value="$(arg usb_port_id)"/>


### PR DESCRIPTION
Provide to the use the possibility to disable the output argument, it allows to choose between the "screen" option (that gives on the shell the output messages from nodes) and the "log" option (hide the messages on the shell).
This option is useful for debugging purpose if the user would like to focus on another process messages, especially when running a launch file including many nodes/nodelets.
I would suggest also to do the same on every launch files in order to allow effectively this change.