### PR TITLE
Asynchronous stream frequency diagnostics

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -36,9 +36,13 @@ namespace realsense2_camera
         diagnostic_updater_.add(frequency_status_);
       }
 
-      void update()
+      void tick()
       {
         frequency_status_.tick();
+      }
+
+      void update()
+      {
         diagnostic_updater_.update();
       }
 

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -242,6 +242,7 @@ namespace realsense2_camera
         rs2_stream rs2_string_to_stream(std::string str);
         void startMonitoring();
         void publish_temperature();
+        void publish_frequency_update();
 
         rs2::device _dev;
         std::map<stream_index_pair, rs2::sensor> _sensors;

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -2322,7 +2322,7 @@ void BaseRealSenseNode::startMonitoring()
         _temperature_nodes.push_back({option, std::make_shared<TemperatureDiagnostics>(rs2_option_to_string(option), _serial_no )});
     }
 
-    int time_interval(10000);
+    int time_interval(1000);
     std::function<void()> func = [this, time_interval](){
         std::mutex mu;
         std::unique_lock<std::mutex> lock(mu);
@@ -2331,6 +2331,7 @@ void BaseRealSenseNode::startMonitoring()
             if (_is_running)
             {
                 publish_temperature();
+                publish_frequency_update();
             }
         }
     };
@@ -2355,6 +2356,14 @@ void BaseRealSenseNode::publish_temperature()
                 ROS_DEBUG_STREAM("Failed checking for temperature." << std::endl << e.what());
             }
         }
+    }
+}
+
+void BaseRealSenseNode::publish_frequency_update()
+{
+    for (auto &image_publisher : _image_publishers)
+    {
+        image_publisher.second.second->update();
     }
 }
 

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -2271,6 +2271,8 @@ void BaseRealSenseNode::publishFrame(rs2::frame f, const ros::Time& t,
     ++(seq[stream]);
     auto& info_publisher = info_publishers.at(stream);
     auto& image_publisher = image_publishers.at(stream);
+
+    image_publisher.second->tick();
     if(0 != info_publisher.getNumSubscribers() ||
        0 != image_publisher.first.getNumSubscribers())
     {
@@ -2294,7 +2296,6 @@ void BaseRealSenseNode::publishFrame(rs2::frame f, const ros::Time& t,
         info_publisher.publish(cam_info);
 
         image_publisher.first.publish(img);
-        image_publisher.second->update();
         // ROS_INFO_STREAM("fid: " << cam_info.header.seq << ", time: " << std::setprecision (20) << t.toSec());
         ROS_DEBUG("%s stream published", rs2_stream_to_string(f.get_profile().stream_type()));
     }


### PR DESCRIPTION
- This pull request modifies frequency diagnostics to run independently from the frame callbacks. In the current implementation, frequency is updated with frame callback when nodes were subscribed. The asynchronous setup is more suitable for sensor health monitoring and enables to detect that there is a connection issue even when no node is subscribed. The argument was also made in issue #1417 .
- The diagnostics messages for each stream are published alongside the temperature diagnostics update. The loop update rate was lowered from 10s to 1s.
- The function was tested with Intel Realsense D435i.
