### PR TITLE
[capability] Option to enable infrared RGB frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ Setting *unite_imu_method* creates a new topic, *imu*, that replaces the default
 - **publish_tf**: boolean, publish or not TF at all. Defaults to True.
 - **tf_publish_rate**: double, positive values mean dynamic transform publication with specified rate, all other values mean static transform publication. Defaults to 0 
 - **publish_odom_tf**: If True (default) publish TF from odom_frame to pose_frame.
+- **infrargb**: When set to True (default: False), it configures the infrared camera to stream in RGB (color) mode, thus enabling the use of a RGB image in the same frame as the depth image, potentially avoiding frame transformation related errors. When this feature is required, you are additionally required to also enable `enable_infra:=true` for the infrared stream to be enabled.
+  - **NOTE** The configuration required for `enable_infra` is independent of `enable_depth`
+  - **NOTE** To enable the Infrared stream, you should enable `enable_infra:=true` NOT `enable_infra1:=true` nor `enable_infra2:=true`
+  - **NOTE** This feature is only supported by Realsense sensors with RGB streams available from the `infra` cameras, which can be checked by observing the output of `rs-enumerate-devices`
 
 
 ### RGBD Point Cloud

--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -24,6 +24,7 @@
   <arg name="enable_infra"        default="false"/>
   <arg name="enable_infra1"       default="false"/>
   <arg name="enable_infra2"       default="false"/>
+  <arg name="enable_infrargb"    default="false"/>
 
   <arg name="color_width"         default="640"/>
   <arg name="color_height"        default="480"/>
@@ -125,6 +126,7 @@
     <param name="enable_infra"             type="bool" value="$(arg enable_infra)"/>
     <param name="enable_infra1"            type="bool" value="$(arg enable_infra1)"/>
     <param name="enable_infra2"            type="bool" value="$(arg enable_infra2)"/>
+    <param name="infrargb"                 type="bool" value="$(arg enable_infrargb)"/>
 
     <param name="fisheye_fps"              type="int"  value="$(arg fisheye_fps)"/>
     <param name="depth_fps"                type="int"  value="$(arg depth_fps)"/>

--- a/realsense2_camera/launch/rs_camera.launch
+++ b/realsense2_camera/launch/rs_camera.launch
@@ -21,6 +21,7 @@
   <arg name="enable_infra"        default="false"/>
   <arg name="enable_infra1"       default="false"/>
   <arg name="enable_infra2"       default="false"/>
+  <arg name="enable_infrargb"    default="false"/>
 
   <arg name="color_width"         default="640"/>
   <arg name="color_height"        default="480"/>
@@ -88,6 +89,7 @@
       <arg name="enable_infra"            value="$(arg enable_infra)"/>
       <arg name="enable_infra1"            value="$(arg enable_infra1)"/>
       <arg name="enable_infra2"            value="$(arg enable_infra2)"/>
+      <arg name="enable_infrargb"         value="$(arg enable_infrargb)"/>
 
       <arg name="fisheye_fps"              value="$(arg fisheye_fps)"/>
       <arg name="depth_fps"                value="$(arg depth_fps)"/>

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -553,6 +553,18 @@ void BaseRealSenseNode::getParameters()
 {
     ROS_INFO("getParameters...");
 
+    // Setup system to use RGB image from the infra stream if configured by user
+    bool infrargb;
+    _pnh.param("infrargb", infrargb, false);
+    if (infrargb)
+    {
+      _format[RS2_STREAM_INFRARED] = RS2_FORMAT_RGB8;
+      _image_format[RS2_STREAM_INFRARED] = CV_8UC3;    // CVBridge type
+      _encoding[RS2_STREAM_INFRARED] = sensor_msgs::image_encodings::RGB8; // ROS message type
+      _unit_step_size[RS2_STREAM_INFRARED] = 3 * sizeof(uint8_t); // sensor_msgs::ImagePtr row step size
+      ROS_INFO_STREAM("Infrared RGB stream enabled");
+    }
+
     _pnh.param("align_depth", _align_depth, ALIGN_DEPTH);
     _pnh.param("enable_pointcloud", _pointcloud, POINTCLOUD);
     std::string pc_texture_stream("");


### PR DESCRIPTION
I'm opening this PR in place of the author @abhijitmajumdar

## Problem(s) this PR aims to resolve

Transformation between depth and RGB frames relies on both transforms (camera extrinsics) and camera info (camera intrinsics) to be accurate. Some points were seen missing when either one of them isn't as accurate.

## Proposed approach
- Although improving accuracy of the in/extrinsic parameters might be the most direct approach, we ruled it out as it might be in Intel's proprietary domain.
- Avoid transformation b/w depth and RBG where the 1-to-1 mapping between the point cloud and the RGB image happens, which requires high accuracy.
   - Since depth (in most realsenses') is infrared through the frame of reference of the IR camera, obtaining RGB from the infrared frame should actually work.

Currently although Realsense SDK / librealsense supports this, the ROS driver does not have a way to enable this. This PR suggests that.

## Changes in this PR
- Adds a new ROS param `infrargb` flag to the realsense node, which enables the a realsense camera to configure the infrared camera (which is usually used for depth estimation) to also be used as the RGB camera.
  - Limitations:
    - This is only possible with realsense cameras which use infrared cameras that support RGB stream (for example the `realsense D415` does, but the `realsense D435` and `realsense L515` do not).
  - Advantages:
    - This is helpful because the frame of reference for the depth frame and the RGB frame is the same eliminating frame conversion errors
  - Disadvantages:
    - The depth exposure is the same as the RGB exposure so fixing color image and fixing point cloud through exposure may have contradictory results and require figuring out a happy medium.
    - The RGB image now will have the infrared pattern in it since the infrared cameras do not have a filter for IR for the obvious reason

## Test

In private commercial applications in industrial material handling in logistics, this change has been extensively used in the production system for 12+ months.

(Btw thank you intelrealsense.com for the [nice blog post about the Realsense integration at us, Plus One Robotics](https://www.intelrealsense.com/plus-one-robotics/).)

## Open questions
- Would usage documentation be required? If so which one is the appropriate files to add such an info?
