### PR TITLE
Add QoS in realsense parameters list

### DIFF
--- a/realsense2_camera/config/d435i.yaml
+++ b/realsense2_camera/config/d435i.yaml
@@ -8,13 +8,16 @@ camera1:
         color_fps: 30.0
         color_height: 480
         color_width: 640
+        color_qos: "SENSOR_DATA"
 
         depth_fps: 30.0
         depth_height: 720
         depth_width: 1280
+        depth_qos: "SENSOR_DATA"
 
         infra_height: 720
         infra_width: 1280
+        infra_qos: "SENSOR_DATA"
 
         gyro_fps: 0.0
 

--- a/realsense2_camera/include/realsense2_camera/base_realsense_node.h
+++ b/realsense2_camera/include/realsense2_camera/base_realsense_node.h
@@ -238,6 +238,7 @@ namespace realsense2_camera
         void registerAutoExposureROIOptions();
         void set_auto_exposure_roi(const std::string variable_name, rs2::sensor sensor, const std::vector<rclcpp::Parameter> & parameters);
         void set_sensor_auto_exposure_roi(rs2::sensor sensor);
+        const rmw_qos_profile_t qos_string_to_qos(std::string str);
         rs2_stream rs2_string_to_stream(std::string str);
         void clean();
 
@@ -259,6 +260,7 @@ namespace realsense2_camera
         std::map<stream_index_pair, int> _width;
         std::map<stream_index_pair, int> _height;
         std::map<stream_index_pair, double> _fps;
+        std::map<stream_index_pair, std::string> _qos;
         std::map<rs2_stream, rs2_format>  _format;
         std::map<stream_index_pair, bool> _enable;
         std::map<rs2_stream, std::string> _stream_name;

--- a/realsense2_camera/include/realsense2_camera/constants.h
+++ b/realsense2_camera/include/realsense2_camera/constants.h
@@ -62,9 +62,10 @@ namespace realsense2_camera
     const bool PUBLISH_TF        = true;
     const double TF_PUBLISH_RATE = 0; // Static transform
 
-    const int IMAGE_WIDTH     = 640;
-    const int IMAGE_HEIGHT    = 480;
-    const double IMAGE_FPS    = 30;
+    const int IMAGE_WIDTH          = 640;
+    const int IMAGE_HEIGHT         = 480;
+    const double IMAGE_FPS         = 30;
+    const std::string IMAGE_QOS    = "SENSOR_DATA";
 
     const double IMU_FPS      = 0;
 


### PR DESCRIPTION
Hi,

In the current version of the ROS2 foxy realsense node, the Quality of Service (QoS) is set to ["sensor data"](https://github.com/IntelRealSense/realsense-ros/blob/foxy/realsense2_camera/src/base_realsense_node.cpp#L934).

I'm not sure this choice is motivated by technical considerations about the sensor streaming capabilities, but there are many more [QoS profiles available](https://github.com/ros2/rmw/blob/master/rmw/include/rmw/qos_profiles.h).

Moreover, the "sensor data" profile defines a "best effort" reliability policy, which is generally incompatible with default configurations of subscribing nodes, such as [rviz](https://github.com/ros2/rviz), [image_view](https://github.com/ros-perception/image_pipeline/blob/ros2/image_view/src/image_view_node.cpp), [rqt_image_view](https://github.com/ros-visualization/rqt_image_view/tree/foxy-devel), [depth_image_proc](https://github.com/ros-perception/image_pipeline/tree/ros2/depth_image_proc) (for 3D pointcloud reconstruction), and so forth... This could hold adoption of the realsense sensors in ROS2 as they cannot be visualized without setting up complex QoS policies.

Either I am missing something, either I suppose it could be useful to let the user choose itself another QoS profile from the yaml parameter file, as suggested in the commits attached to this PR.