### PR TITLE
Fix mass of d415

### DIFF
--- a/realsense2_description/urdf/_d415.urdf.xacro
+++ b/realsense2_description/urdf/_d415.urdf.xacro
@@ -66,8 +66,8 @@ aluminum peripherial evaluation case.
         </geometry>
       </collision>
       <inertial>
+        <mass value="0.072" />
         <!-- The following are not reliable values, and should not be used for modeling -->
-        <mass value="0.564" />
         <origin xyz="0 0 0" />
         <inertia ixx="0.003881243" ixy="0.0" ixz="0.0" iyy="0.000498940" iyz="0.0" izz="0.003879257" />
       </inertial>


### PR DESCRIPTION
Corrected mass is taken from https://www.intelrealsense.com/wp-content/uploads/2020/06/Intel-RealSense-D400-Series-Datasheet-June-2020.pdf, Table 3-43.