### PR TITLE
[feature] Reset driver node on the fly

### DIFF
--- a/realsense2_camera/include/realsense_node_factory.h
+++ b/realsense2_camera/include/realsense_node_factory.h
@@ -21,6 +21,7 @@
 #include <eigen3/Eigen/Geometry>
 #include <fstream>
 #include <thread>
+#include <std_srvs/Empty.h>
 
 namespace realsense2_camera
 {
@@ -65,12 +66,15 @@ namespace realsense2_camera
         void change_device_callback(rs2::event_information& info);
         void getDevice(rs2::device_list list);
         virtual void onInit() override;
+        void initialize(const ros::WallTimerEvent &ignored);
         void tryGetLogSeverity(rs2_log_severity& severity) const;
+        bool reset();
+        bool handleReset(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response);
         static std::string parse_usb_port(std::string line);
         bool toggle_sensor_callback(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res);
 
         rs2::device _device;
-        std::unique_ptr<InterfaceRealSenseNode> _realSenseNode;
+        std::shared_ptr<InterfaceRealSenseNode> _realSenseNode;
         rs2::context _ctx;
         std::string _serial_no;
         std::string _usb_port_id;
@@ -79,6 +83,9 @@ namespace realsense2_camera
         std::thread _query_thread;
         bool _is_alive;
         ros::ServiceServer toggle_sensor_srv;
+        bool _initialized;
+        ros::WallTimer _init_timer;
+        ros::ServiceServer _reset_srv;
 
     };
 }//end namespace

--- a/realsense2_camera/include/realsense_node_factory.h
+++ b/realsense2_camera/include/realsense_node_factory.h
@@ -68,7 +68,7 @@ namespace realsense2_camera
         virtual void onInit() override;
         void initialize(const ros::WallTimerEvent &ignored);
         void tryGetLogSeverity(rs2_log_severity& severity) const;
-        bool reset();
+        void reset();
         bool handleReset(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response);
         static std::string parse_usb_port(std::string line);
         bool toggle_sensor_callback(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res);
@@ -83,7 +83,6 @@ namespace realsense2_camera
         std::thread _query_thread;
         bool _is_alive;
         ros::ServiceServer toggle_sensor_srv;
-        bool _initialized;
         ros::WallTimer _init_timer;
         ros::ServiceServer _reset_srv;
 

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -150,18 +150,19 @@ BaseRealSenseNode::~BaseRealSenseNode()
     std::set<std::string> module_names;
     for (const std::pair<stream_index_pair, std::vector<rs2::stream_profile>>& profile : _enabled_profiles)
     {
-        std::string module_name = _sensors[profile.first].get_info(RS2_CAMERA_INFO_NAME);
-        std::pair< std::set<std::string>::iterator, bool> res = module_names.insert(module_name);
-        if (res.second)
+        try
         {
-            try
+            std::string module_name = _sensors[profile.first].get_info(RS2_CAMERA_INFO_NAME);
+            std::pair< std::set<std::string>::iterator, bool> res = module_names.insert(module_name);
+            if (res.second)
             {
                 _sensors[profile.first].stop();
                 _sensors[profile.first].close();
             }
-            catch(const rs2::wrong_api_call_sequence_error& e)
-            {
-            }
+        }
+        catch (const rs2::error& e)
+        {
+            ROS_ERROR_STREAM("Exception: " << e.what());
         }
     }
 }

--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -30,7 +30,8 @@ std::string api_version_to_string(int version)
 }
 
 RealSenseNodeFactory::RealSenseNodeFactory():
-	_is_alive(true)
+	_is_alive(true),
+	_initialized(false)
 {
 	rs2_error* e = nullptr;
 	std::string running_librealsense_version(api_version_to_string(rs2_get_api_version(&e)));
@@ -55,10 +56,25 @@ RealSenseNodeFactory::RealSenseNodeFactory():
 
 RealSenseNodeFactory::~RealSenseNodeFactory()
 {
+	_initialized = false;
 	_is_alive = false;
 	if (_query_thread.joinable())
 	{
 		_query_thread.join();
+	}
+
+	try
+	{
+		_realSenseNode.reset();
+		if (_device)
+		{
+			_device.hardware_reset();
+			_device = rs2::device();
+		}
+	}
+	catch (const rs2::error& e)
+	{
+		ROS_ERROR_STREAM("Exception: " << e.what());
 	}
 }
 
@@ -220,23 +236,12 @@ void RealSenseNodeFactory::getDevice(rs2::device_list list)
 
 void RealSenseNodeFactory::change_device_callback(rs2::event_information& info)
 {
-	if (info.was_removed(_device))
+	if (_initialized)
 	{
-		ROS_ERROR("The device has been disconnected!");
-		_realSenseNode.reset(nullptr);
-		_device = rs2::device();
-	}
-	if (!_device)
-	{
-		rs2::device_list new_devices = info.get_new_devices();
-		if (new_devices.size() > 0)
+		if (info.was_removed(_device))
 		{
-			ROS_INFO("Checking new devices...");
-			getDevice(new_devices);
-			if (_device)
-			{
-				StartDevice();
-			}
+			ROS_ERROR("The device has been disconnected!");
+			reset();
 		}
 	}
 }
@@ -254,6 +259,13 @@ bool RealSenseNodeFactory::toggle_sensor_callback(std_srvs::SetBool::Request &re
 
 void RealSenseNodeFactory::onInit()
 {
+	auto nh = getNodeHandle();
+	_init_timer = nh.createWallTimer(ros::WallDuration(0.01), &RealSenseNodeFactory::initialize, this, true);
+}
+
+void RealSenseNodeFactory::initialize(const ros::WallTimerEvent &ignored)
+{
+	_device = rs2::device();
 	try
 	{
 #ifdef BPDEBUG
@@ -291,6 +303,7 @@ void RealSenseNodeFactory::onInit()
 		{
 			privateNh.param("initial_reset", _initial_reset, false);
 
+			_is_alive = true;
 			_query_thread = std::thread([=]()
 						{
 							std::chrono::milliseconds timespan(6000);
@@ -309,6 +322,10 @@ void RealSenseNodeFactory::onInit()
 								}
 							}
 						});
+			if (!_reset_srv)
+			{
+				_reset_srv = privateNh.advertiseService("reset", &RealSenseNodeFactory::handleReset, this);
+			}
 		}
 	}
 	catch(const std::exception& ex)
@@ -326,44 +343,90 @@ void RealSenseNodeFactory::onInit()
 void RealSenseNodeFactory::StartDevice()
 {
 	if (_realSenseNode) _realSenseNode.reset();
-	ros::NodeHandle nh = getNodeHandle();
-	ros::NodeHandle privateNh = getPrivateNodeHandle();
-	// TODO
-	std::string pid_str(_device.get_info(RS2_CAMERA_INFO_PRODUCT_ID));
-	uint16_t pid = std::stoi(pid_str, 0, 16);
-	switch(pid)
+	try
 	{
-	case SR300_PID:
-	case SR300v2_PID:
-	case RS400_PID:
-	case RS405_PID:
-	case RS410_PID:
-	case RS460_PID:
-	case RS415_PID:
-	case RS420_PID:
-	case RS420_MM_PID:
-	case RS430_PID:
-	case RS430_MM_PID:
-	case RS430_MM_RGB_PID:
-	case RS435_RGB_PID:
-	case RS435i_RGB_PID:
-	case RS455_PID:
-	case RS465_PID:
-	case RS_USB2_PID:
-	case RS_L515_PID_PRE_PRQ:
-	case RS_L515_PID:
-		_realSenseNode = std::unique_ptr<BaseRealSenseNode>(new BaseRealSenseNode(nh, privateNh, _device, _serial_no));
-		break;
-	case RS_T265_PID:
-		_realSenseNode = std::unique_ptr<T265RealsenseNode>(new T265RealsenseNode(nh, privateNh, _device, _serial_no));
-		break;
-	default:
-		ROS_FATAL_STREAM("Unsupported device!" << " Product ID: 0x" << pid_str);
-		ros::shutdown();
-		exit(1);
+		ros::NodeHandle nh = getNodeHandle();
+		ros::NodeHandle privateNh = getPrivateNodeHandle();
+		// TODO
+		std::string pid_str(_device.get_info(RS2_CAMERA_INFO_PRODUCT_ID));
+		uint16_t pid = std::stoi(pid_str, 0, 16);
+		switch(pid)
+		{
+		case SR300_PID:
+		case SR300v2_PID:
+		case RS400_PID:
+		case RS405_PID:
+		case RS410_PID:
+		case RS460_PID:
+		case RS415_PID:
+		case RS420_PID:
+		case RS420_MM_PID:
+		case RS430_PID:
+		case RS430_MM_PID:
+		case RS430_MM_RGB_PID:
+		case RS435_RGB_PID:
+		case RS435i_RGB_PID:
+		case RS455_PID:
+		case RS465_PID:
+		case RS_USB2_PID:
+		case RS_L515_PID_PRE_PRQ:
+		case RS_L515_PID:
+			_realSenseNode = std::shared_ptr<BaseRealSenseNode>(new BaseRealSenseNode(nh, privateNh, _device, _serial_no));
+			break;
+		case RS_T265_PID:
+			_realSenseNode = std::shared_ptr<T265RealsenseNode>(new T265RealsenseNode(nh, privateNh, _device, _serial_no));
+			break;
+		default:
+			ROS_FATAL_STREAM("Unsupported device!" << " Product ID: 0x" << pid_str);
+			ros::shutdown();
+			exit(1);
+		}
+		assert(_realSenseNode);
+		_realSenseNode->publishTopics();
+		_initialized = true;
 	}
-	assert(_realSenseNode);
-	_realSenseNode->publishTopics();
+	catch (const rs2::error& e)
+	{
+		ROS_ERROR_STREAM("Exception: " << e.what());
+	}
+}
+
+bool RealSenseNodeFactory::reset()
+{
+	if (!_initialized)
+	{
+		return false;
+	}
+
+	_initialized = false;
+
+	_is_alive = false;
+	if (_query_thread.joinable())
+	{
+		_query_thread.join();
+	}
+
+	try
+	{
+	_realSenseNode.reset();
+		if (_device)
+		{
+			_device.hardware_reset();
+			_device = rs2::device();
+		}
+	}
+	catch (const rs2::error& e)
+	{
+		ROS_ERROR_STREAM("Exception: " << e.what());
+	}
+
+	_init_timer = getNodeHandle().createWallTimer(ros::WallDuration(1.0), &RealSenseNodeFactory::initialize, this, true);
+	return true;
+}
+
+bool RealSenseNodeFactory::handleReset(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response)
+{
+	return reset();
 }
 
 void RealSenseNodeFactory::tryGetLogSeverity(rs2_log_severity& severity) const

--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -64,11 +64,7 @@ RealSenseNodeFactory::~RealSenseNodeFactory()
 	try
 	{
 		_realSenseNode.reset();
-		if (_device)
-		{
-			_device.hardware_reset();
-			_device = rs2::device();
-		}
+		_device = rs2::device();
 	}
 	catch (const rs2::error& e)
 	{


### PR DESCRIPTION
# Background of PR
This PR includes changes made by @malban and is an alternative to https://github.com/IntelRealSense/realsense-ros/pull/1504, which consists of more changes. To make review easier this PR aims to provide a more granular change.

# Target problem
- For whatever the cause (due to software/hardware reason), there can be cases where 2D or 3D image topics aren't published (e.g. the one described in https://github.com/IntelRealSense/librealsense/issues/7151).
- During runtime, when the device somehow gets disconnected and re-connected back in in the USB device level, Realsense node won't function (haven't found a ticket about this issue).

For automated system that relies on the images published by the Realsense, once that issue happens the system stops functioning.

# Approach

Detail is dscribed in https://github.com/IntelRealSense/librealsense/issues/7151#issuecomment-686404580. In short,
- We at Plus One Robotics found resetting the realsense node fixes the issue in question 99% time.
   
Note as mentioned there, this PR offers NOT a fix for the mentioned issue but aims to offer a better workaround.
