### PR TITLE
Add include guard to materials

### DIFF
--- a/realsense2_description/urdf/_materials.urdf.xacro
+++ b/realsense2_description/urdf/_materials.urdf.xacro
@@ -8,11 +8,15 @@ Collection of materials to be used in other macros.
 This avoids the redefinition of materials in case multple cameras are imported.
 -->
 
-<robot>
-  <material name="aluminum">
-    <color rgba="0.5 0.5 0.5 1"/>
-  </material>
-  <material name="plastic">
-    <color rgba="0.1 0.1 0.1 1"/>
-  </material>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:property name="realsense_materials_defined" default="false" />
+  <xacro:unless value="${realsense_materials_defined}">
+    <xacro:property name="realsense_materials_defined" value="true" />
+    <material name="aluminum">
+      <color rgba="0.5 0.5 0.5 1"/>
+    </material>
+    <material name="plastic">
+      <color rgba="0.1 0.1 0.1 1"/>
+    </material>
+ </xacro:unless>
 </robot>


### PR DESCRIPTION
Prevents material already defined errors when adding multiple types of camera to a robot.

I was making a URDF for the d455 based on the d435 as I have a robot with both on and I ran into a material is not unique error. This fixes that.

I think it would actually be better if the materials were macros like
```
<xacro:macro name="aluminum_material">
  <material name="aluminum">
    <color rgba="0.5 0.5 0.5 1"/>
  </material>
<xacro:macro name="plastic_material">
    <material name="plastic">
      <color rgba="0.1 0.1 0.1 1"/>
    </material>
</xacro:macro>
```
Then changing the places they get used from `<material name="plastic"/>` to `<xacro:plastic_material />`
That way you don't end up putting very generic names like "aluminum" and "plastic" in the global namespace.