### PR TITLE
 Fix pointCloud2 structure in ordered_pc 

### DIFF
--- a/realsense2_camera/include/realsense2_camera/base_realsense_node.h
+++ b/realsense2_camera/include/realsense2_camera/base_realsense_node.h
@@ -251,6 +251,7 @@ namespace realsense2_camera
         float _depth_scale_meters;
         float _clipping_distance;
         bool _allow_no_texture_points;
+        bool _ordered_pc;
 
         double _linear_accel_cov;
         double _angular_velocity_cov;

--- a/realsense2_camera/include/realsense2_camera/constants.h
+++ b/realsense2_camera/include/realsense2_camera/constants.h
@@ -27,6 +27,8 @@
 #define ROS_WARN_COND(cond, ...) RCLCPP_WARN_EXPRESSION(_logger, cond, __VA_ARGS__)
 #define ROS_WARN_STREAM_COND(cond, msg) RCLCPP_WARN_STREAM_EXPRESSION(_logger, cond, msg)
 
+#define ROS_INFO_STREAM_ONCE(msg) RCLCPP_INFO_STREAM_ONCE(_logger, msg)
+
 namespace realsense2_camera
 {
     const uint16_t SR300_PID        = 0x0aa5; // SR300
@@ -54,10 +56,11 @@ namespace realsense2_camera
     const uint16_t RS_L515_PID      = 0x0B64; // 
     
 
-    const bool ALIGN_DEPTH    = false;
-    const bool POINTCLOUD     = false;
+    const bool ALIGN_DEPTH             = false;
+    const bool POINTCLOUD              = false;
     const bool ALLOW_NO_TEXTURE_POINTS = false;
-    const bool SYNC_FRAMES    = false;
+    const bool SYNC_FRAMES             = false;
+    const bool ORDERED_POINTCLOUD      = false;
 
     const bool PUBLISH_TF        = true;
     const double TF_PUBLISH_RATE = 0; // Static transform

--- a/realsense2_camera/launch/rs_launch.py
+++ b/realsense2_camera/launch/rs_launch.py
@@ -65,6 +65,7 @@ configurable_parameters = [{'name': 'camera_name',                  'default': '
                            {'name': 'linear_accel_cov',             'default': '0.01', 'description': ''},                           
                            {'name': 'initial_reset',                'default': 'false', 'description': ''},                           
                            {'name': 'allow_no_texture_points',      'default': 'false', 'description': ''},                           
+                           {'name': 'ordered_pc',                   'default': 'false', 'description': ''},                           
                            {'name': 'calib_odom_file',              'default': '', 'description': ''},                           
                            {'name': 'topic_odom_in',                'default': '', 'description': 'topic for T265 wheel odometry'},
                           ]

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -752,6 +752,7 @@ void BaseRealSenseNode::getParameters()
     }
 
     setNgetNodeParameter(_allow_no_texture_points, "allow_no_texture_points", ALLOW_NO_TEXTURE_POINTS);
+    setNgetNodeParameter(_ordered_pc, "ordered_pc", ORDERED_POINTCLOUD);
     setNgetNodeParameter(_clipping_distance, "clip_distance", -1.0f);
 
     setNgetNodeParameter(_linear_accel_cov, "linear_accel_cov", 0.01);
@@ -2181,6 +2182,7 @@ void reverse_memcpy(unsigned char* dst, const unsigned char* src, size_t n)
 
 void BaseRealSenseNode::publishPointCloud(rs2::points pc, const rclcpp::Time& t, const rs2::frameset& frameset)
 {
+    ROS_INFO_STREAM_ONCE("publishing " << (_ordered_pc ? "" : "un") << "ordered pointcloud.");
     std::vector<NamedFilter>::iterator pc_filter = find_if(_filters.begin(), _filters.end(), [] (NamedFilter s) { return s._name == "pointcloud"; } );
     rs2_stream texture_source_id = static_cast<rs2_stream>(pc_filter->_filter->get_option(rs2_option::RS2_OPTION_STREAM_FILTER));
     bool use_texture = texture_source_id != RS2_STREAM_ANY;
@@ -2210,30 +2212,14 @@ void BaseRealSenseNode::publishPointCloud(rs2::points pc, const rclcpp::Time& t,
     const rs2::vertex* vertex = pc.get_vertices();
     const rs2::texture_coordinate* color_point = pc.get_texture_coordinates();
 
-    _valid_pc_indices.clear();
-    for (size_t point_idx=0; point_idx < pc.size(); point_idx++, vertex++, color_point++)
-    {
-        if (static_cast<float>(vertex->z) > 0)
-        {
-            float i = static_cast<float>(color_point->u);
-            float j = static_cast<float>(color_point->v);
-            if (_allow_no_texture_points || (i >= 0.f && i <= 1.f && j >= 0.f && j <= 1.f))
-            {
-                _valid_pc_indices.push_back(point_idx);
-            }
-        }
-    }
-
-    _msg_pointcloud.header.stamp = t;
-    _msg_pointcloud.header.frame_id = _optical_frame_id[DEPTH];
-    _msg_pointcloud.width = _valid_pc_indices.size();
-    _msg_pointcloud.height = 1;
-    _msg_pointcloud.is_dense = true;
+    rs2_intrinsics depth_intrin = pc.get_profile().as<rs2::video_stream_profile>().get_intrinsics();
 
     sensor_msgs::PointCloud2Modifier modifier(_msg_pointcloud);
     modifier.setPointCloud2FieldsByString(1, "xyz");    
+    modifier.resize(pc.size());
 
     vertex = pc.get_vertices();
+    size_t valid_count(0);
     if (use_texture)
     {
         rs2::video_frame texture_frame = (*texture_frame_itr).as<rs2::video_frame>();
@@ -2264,32 +2250,31 @@ void BaseRealSenseNode::publishPointCloud(rs2::points pc, const rclcpp::Time& t,
         color_point = pc.get_texture_coordinates();
 
         float color_pixel[2];
-        unsigned int prev_idx(0);
-        for (auto idx=_valid_pc_indices.begin(); idx != _valid_pc_indices.end(); idx++)
+        for (size_t point_idx=0; point_idx < pc.size(); point_idx++, vertex++, color_point++)
         {
-            unsigned int idx_jump(*idx-prev_idx);
-            prev_idx = *idx;
-            vertex+=idx_jump;
-            color_point+=idx_jump;
-
-            *iter_x = vertex->x;
-            *iter_y = vertex->y;
-            *iter_z = vertex->z;
-
             float i(color_point->u);
             float j(color_point->v);
-            if (i >= 0.f && i <= 1.f && j >= 0.f && j <= 1.f)
+            bool valid_color_pixel(i >= 0.f && i <=1.f && j >= 0.f && j <=1.f);
+            bool valid_pixel(vertex->z > 0 && (valid_color_pixel || _allow_no_texture_points));
+            if (valid_pixel || _ordered_pc)
             {
-                color_pixel[0] = i * texture_width;
-                color_pixel[1] = j * texture_height;
-                int pixx = static_cast<int>(color_pixel[0]);
-                int pixy = static_cast<int>(color_pixel[1]);
-                int offset = (pixy * texture_width + pixx) * num_colors;
-                reverse_memcpy(&(*iter_color), color_data+offset, num_colors);  // PointCloud2 order of rgb is bgr.
-            }
+                *iter_x = vertex->x;
+                *iter_y = vertex->y;
+                *iter_z = vertex->z;
 
-            ++iter_x; ++iter_y; ++iter_z;
-            ++iter_color;
+                if (valid_color_pixel)
+                {
+                    color_pixel[0] = i * texture_width;
+                    color_pixel[1] = j * texture_height;
+                    int pixx = static_cast<int>(color_pixel[0]);
+                    int pixy = static_cast<int>(color_pixel[1]);
+                    int offset = (pixy * texture_width + pixx) * num_colors;
+                    reverse_memcpy(&(*iter_color), color_data+offset, num_colors);  // PointCloud2 order of rgb is bgr.
+                }
+                ++iter_x; ++iter_y; ++iter_z;
+                ++iter_color;
+                ++valid_count;
+            }
         }
     }
     else
@@ -2302,19 +2287,35 @@ void BaseRealSenseNode::publishPointCloud(rs2::points pc, const rclcpp::Time& t,
         sensor_msgs::PointCloud2Iterator<float>iter_x(_msg_pointcloud, "x");
         sensor_msgs::PointCloud2Iterator<float>iter_y(_msg_pointcloud, "y");
         sensor_msgs::PointCloud2Iterator<float>iter_z(_msg_pointcloud, "z");
-        unsigned int prev_idx(0);
-        for (auto idx=_valid_pc_indices.begin(); idx != _valid_pc_indices.end(); idx++)
+
+        for (size_t point_idx=0; point_idx < pc.size(); point_idx++, vertex++)
         {
-            unsigned int idx_jump(*idx-prev_idx);
-            prev_idx = *idx;
-            vertex+=idx_jump;
-
-            *iter_x = vertex->x;
-            *iter_y = vertex->y;
-            *iter_z = vertex->z;
-
-            ++iter_x; ++iter_y; ++iter_z;
+            bool valid_pixel(vertex->z > 0);
+            if (valid_pixel || _ordered_pc)
+            {
+                *iter_x = vertex->x;
+                *iter_y = vertex->y;
+                *iter_z = vertex->z;
+    
+                ++iter_x; ++iter_y; ++iter_z;
+                ++valid_count;
+            }
         }
+    }
+    _msg_pointcloud.header.stamp = t;
+    _msg_pointcloud.header.frame_id = _optical_frame_id[DEPTH];
+    if (_ordered_pc)
+    {
+        _msg_pointcloud.width = depth_intrin.width;
+        _msg_pointcloud.height = depth_intrin.height;
+        _msg_pointcloud.is_dense = false;
+    }
+    else
+    {
+        _msg_pointcloud.width = valid_count;
+        _msg_pointcloud.height = 1;
+        _msg_pointcloud.is_dense = true;
+        modifier.resize(valid_count);
     }
     _pointcloud_publisher->publish(_msg_pointcloud);
 }

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -2240,8 +2240,18 @@ void BaseRealSenseNode::publishPointCloud(rs2::points pc, const rclcpp::Time& t,
                 throw std::runtime_error("Unhandled texture format passed in pointcloud " + std::to_string(texture_frame.get_profile().format()));
         }
         _msg_pointcloud.point_step = addPointField(_msg_pointcloud, format_str.c_str(), 1, sensor_msgs::msg::PointField::FLOAT32, _msg_pointcloud.point_step);
-        _msg_pointcloud.row_step = _msg_pointcloud.width * _msg_pointcloud.point_step;
-        _msg_pointcloud.data.resize(_msg_pointcloud.height * _msg_pointcloud.row_step);
+        
+        if (_ordered_pc)
+        {
+            _msg_pointcloud.row_step = depth_intrin.width * _msg_pointcloud.point_step;
+            _msg_pointcloud.data.resize( depth_intrin.height  * _msg_pointcloud.row_step);
+            
+        }
+        else {
+            _msg_pointcloud.row_step = _msg_pointcloud.width * _msg_pointcloud.point_step;
+            _msg_pointcloud.data.resize(_msg_pointcloud.height * _msg_pointcloud.row_step);
+        }
+    
 
         sensor_msgs::PointCloud2Iterator<float>iter_x(_msg_pointcloud, "x");
         sensor_msgs::PointCloud2Iterator<float>iter_y(_msg_pointcloud, "y");
@@ -2281,8 +2291,17 @@ void BaseRealSenseNode::publishPointCloud(rs2::points pc, const rclcpp::Time& t,
     {
         std::string format_str = "intensity";
         _msg_pointcloud.point_step = addPointField(_msg_pointcloud, format_str.c_str(), 1, sensor_msgs::msg::PointField::FLOAT32, _msg_pointcloud.point_step);
-        _msg_pointcloud.row_step = _msg_pointcloud.width * _msg_pointcloud.point_step;
-        _msg_pointcloud.data.resize(_msg_pointcloud.height * _msg_pointcloud.row_step);
+        
+        if (_ordered_pc)
+        {
+            _msg_pointcloud.row_step = depth_intrin.width * _msg_pointcloud.point_step;
+            _msg_pointcloud.data.resize( depth_intrin.height  * _msg_pointcloud.row_step);
+            
+        }
+        else {
+            _msg_pointcloud.row_step = _msg_pointcloud.width * _msg_pointcloud.point_step;
+            _msg_pointcloud.data.resize(_msg_pointcloud.height * _msg_pointcloud.row_step);
+        }
 
         sensor_msgs::PointCloud2Iterator<float>iter_x(_msg_pointcloud, "x");
         sensor_msgs::PointCloud2Iterator<float>iter_y(_msg_pointcloud, "y");


### PR DESCRIPTION
PR IntelRealSense#1627 modifies the point-cloud message width & height but does not update the row_step to match. pcl::fromPCLPointCloud2() uses row_step to advance through the image, and hence segfaults when fed a message generated with ordered_pc message.

This fixes the structure of the pointCloud2 msg created