### PR TITLE
Fix ordered pointcloud2 format

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -2160,6 +2160,12 @@ void BaseRealSenseNode::publishPointCloud(rs2::points pc, const ros::Time& t, co
     sensor_msgs::PointCloud2Modifier modifier(_msg_pointcloud);
     modifier.setPointCloud2FieldsByString(1, "xyz");    
     modifier.resize(pc.size());
+    if (_ordered_pc)
+    {
+        _msg_pointcloud.width = depth_intrin.width;
+        _msg_pointcloud.height = depth_intrin.height;
+        _msg_pointcloud.is_dense = false;
+    }
 
     vertex = pc.get_vertices();
     size_t valid_count(0);
@@ -2247,13 +2253,7 @@ void BaseRealSenseNode::publishPointCloud(rs2::points pc, const ros::Time& t, co
     }
     _msg_pointcloud.header.stamp = t;
     _msg_pointcloud.header.frame_id = _optical_frame_id[DEPTH];
-    if (_ordered_pc)
-    {
-        _msg_pointcloud.width = depth_intrin.width;
-        _msg_pointcloud.height = depth_intrin.height;
-        _msg_pointcloud.is_dense = false;
-    }
-    else
+    if (!_ordered_pc)
     {
         _msg_pointcloud.width = valid_count;
         _msg_pointcloud.height = 1;


### PR DESCRIPTION
related to #1664
based on @joelbudu's  #1668, set _msg_pointcloud.width before resize.
I prefer this implementation as it's shorter and contains fewer if-else cases.
If you approve, I'll try to add a unit-test based on the [example](https://github.com/mferenduros/pointcloud2_crash) from @mferenduros before merging.
