### PR TITLE
Foxy confidence image

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ After running the above command with D435i attached, the following list of topic
 - /rosout
 - /tf_static
 
+>Using an L515 device the list differs a little by adding a 4-bit confidence grade (published as a mono8 image):
+>- /camera/confidence/camera_info
+>- /camera/confidence/image_rect_raw
+>
+>It also replaces the 2 infrared topic sets with the single available one:
+>- /camera/infra/camera_info
+>- /camera/infra/image_raw
+
 The "/camera" prefix is the namesapce specified in the given launch file.
 When using D435 or D415, the gyro and accel topics wont be available. Likewise, other topics will be available when using T265 (see below).
 

--- a/realsense2_camera/include/realsense2_camera/base_realsense_node.h
+++ b/realsense2_camera/include/realsense2_camera/base_realsense_node.h
@@ -58,12 +58,13 @@ namespace realsense2_camera
     const stream_index_pair GYRO{RS2_STREAM_GYRO, 0};
     const stream_index_pair ACCEL{RS2_STREAM_ACCEL, 0};
     const stream_index_pair POSE{RS2_STREAM_POSE, 0};
+    const stream_index_pair CONFIDENCE{RS2_STREAM_CONFIDENCE, 0};
     
 
     const std::vector<stream_index_pair> IMAGE_STREAMS = {DEPTH, INFRA0, INFRA1, INFRA2,
                                                           COLOR,
                                                           FISHEYE,
-                                                          FISHEYE1, FISHEYE2};
+                                                          FISHEYE1, FISHEYE2, CONFIDENCE};
 
     const std::vector<stream_index_pair> HID_STREAMS = {GYRO, ACCEL, POSE};
 

--- a/realsense2_camera/scripts/show_center_depth.py
+++ b/realsense2_camera/scripts/show_center_depth.py
@@ -1,0 +1,105 @@
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import Image as msg_Image
+from sensor_msgs.msg import CameraInfo
+from cv_bridge import CvBridge, CvBridgeError
+import sys
+import os
+import numpy as np
+import pyrealsense2 as rs2
+if (not hasattr(rs2, 'intrinsics')):
+    import pyrealsense2.pyrealsense2 as rs2
+
+class ImageListener(Node):
+    def __init__(self, depth_image_topic, depth_info_topic):
+        node_name = os.path.basename(sys.argv[0]).split('.')[0]
+        super().__init__(node_name)
+        self.bridge = CvBridge()
+        self.sub = self.create_subscription(msg_Image, depth_image_topic, self.imageDepthCallback, 1)
+        self.sub_info = self.create_subscription(CameraInfo, depth_info_topic, self.imageDepthInfoCallback, 1)
+        confidence_topic = depth_image_topic.replace('depth', 'confidence')
+        self.sub_conf = self.create_subscription(msg_Image, confidence_topic, self.confidenceCallback, 1)
+        self.intrinsics = None
+        self.pix = None
+        self.pix_grade = None
+
+    def imageDepthCallback(self, data):
+        try:
+            cv_image = self.bridge.imgmsg_to_cv2(data, data.encoding)
+            # pick one pixel among all the pixels with the closest range:
+            indices = np.array(np.where(cv_image == cv_image[cv_image > 0].min()))[:,0]
+            pix = (indices[1], indices[0])
+            self.pix = pix
+            line = '\rDepth at pixel(%3d, %3d): %7.1f(mm).' % (pix[0], pix[1], cv_image[pix[1], pix[0]])
+
+            if self.intrinsics:
+                depth = cv_image[pix[1], pix[0]]
+                result = rs2.rs2_deproject_pixel_to_point(self.intrinsics, [pix[0], pix[1]], depth)
+                line += '  Coordinate: %8.2f %8.2f %8.2f.' % (result[0], result[1], result[2])
+            if (not self.pix_grade is None):
+                line += ' Grade: %2d' % self.pix_grade
+            line += '\r'
+            sys.stdout.write(line)
+            sys.stdout.flush()
+
+        except CvBridgeError as e:
+            print(e)
+            return
+        except ValueError as e:
+            return
+
+    def confidenceCallback(self, data):
+        try:
+            cv_image = self.bridge.imgmsg_to_cv2(data, data.encoding)
+            grades = np.bitwise_and(cv_image >> 4, 0x0f)
+            if (self.pix):
+                self.pix_grade = grades[self.pix[1], self.pix[0]]
+        except CvBridgeError as e:
+            print(e)
+            return
+
+
+
+    def imageDepthInfoCallback(self, cameraInfo):
+        try:
+            if self.intrinsics:
+                return
+            self.intrinsics = rs2.intrinsics()
+            self.intrinsics.width = cameraInfo.width
+            self.intrinsics.height = cameraInfo.height
+            self.intrinsics.ppx = cameraInfo.k[2]
+            self.intrinsics.ppy = cameraInfo.k[5]
+            self.intrinsics.fx = cameraInfo.k[0]
+            self.intrinsics.fy = cameraInfo.k[4]
+            if cameraInfo.distortion_model == 'plumb_bob':
+                self.intrinsics.model = rs2.distortion.brown_conrady
+            elif cameraInfo.distortion_model == 'equidistant':
+                self.intrinsics.model = rs2.distortion.kannala_brandt4
+            self.intrinsics.coeffs = [i for i in cameraInfo.d]
+        except CvBridgeError as e:
+            print(e)
+            return
+
+def main():
+    depth_image_topic = '/camera/depth/image_rect_raw'
+    depth_info_topic = '/camera/depth/camera_info'
+
+    print ()
+    print ('show_center_depth.py')
+    print ('--------------------')
+    print ('App to demontrate the usage of the /camera/depth topics.')
+    print ()
+    print ('Application subscribes to %s and %s topics.' % (depth_image_topic, depth_info_topic))
+    print ('Application then calculates and print the range to the closest object.')
+    print ('If intrinsics data is available, it also prints the 3D location of the object')
+    print ('If a confedence map is also available in the topic %s, it also prints the confidence grade.' % depth_image_topic.replace('depth', 'confidence'))
+    print ()
+    
+    listener = ImageListener(depth_image_topic, depth_info_topic)
+    rclpy.spin(listener)
+    listener.destroy_node()
+    rclpy.shutdown()    
+
+if __name__ == '__main__':
+    rclpy.init(args=sys.argv)
+    main()

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -106,6 +106,13 @@ BaseRealSenseNode::BaseRealSenseNode(rclcpp::Node& node,
     _stream_name[RS2_STREAM_DEPTH] = "depth";
     _depth_aligned_encoding[RS2_STREAM_DEPTH] = sensor_msgs::image_encodings::TYPE_16UC1;
 
+    // Types for confidence stream
+    _image_format[RS2_STREAM_CONFIDENCE] = CV_8UC1;    // CVBridge type
+    _encoding[RS2_STREAM_CONFIDENCE] = sensor_msgs::image_encodings::MONO8; // ROS message type
+    _unit_step_size[RS2_STREAM_CONFIDENCE] = sizeof(uint8_t); // sensor_msgs::ImagePtr row step size
+    _stream_name[RS2_STREAM_CONFIDENCE] = "confidence";
+    _depth_aligned_encoding[RS2_STREAM_CONFIDENCE] = sensor_msgs::image_encodings::TYPE_16UC1;
+
     // Infrared stream
     _format[RS2_STREAM_INFRARED] = RS2_FORMAT_Y8;
 
@@ -768,7 +775,7 @@ void BaseRealSenseNode::getParameters()
 
     for (auto& stream : IMAGE_STREAMS)
     {
-        if (stream == DEPTH) continue;
+        if (stream == DEPTH || stream == CONFIDENCE) continue;
         if (stream.second > 1) continue;
         std::string param_name(static_cast<std::ostringstream&&>(std::ostringstream() << "aligned_depth_to_" << STREAM_NAME(stream) << "_frame_id").str());
         setNgetNodeParameter(_depth_aligned_frame_id[stream], param_name, ALIGNED_DEPTH_TO_FRAME_ID(stream));
@@ -946,7 +953,7 @@ void BaseRealSenseNode::setupPublishers()
         {
             std::stringstream image_raw, camera_info;
             bool rectified_image = false;
-            if (stream == DEPTH || stream == INFRA1 || stream == INFRA2)
+            if (stream == DEPTH || stream == CONFIDENCE || stream == INFRA1 || stream == INFRA2)
                 rectified_image = true;
 
             std::string stream_name(STREAM_NAME(stream));
@@ -956,7 +963,7 @@ void BaseRealSenseNode::setupPublishers()
             _image_publishers[stream] = {image_transport::create_publisher(&_node, image_raw.str(), qos_string_to_qos(_qos[stream]))};
             _info_publisher[stream] = _node.create_publisher<sensor_msgs::msg::CameraInfo>(camera_info.str(), 1);
 
-            if (_align_depth && (stream != DEPTH) && stream.second < 2)
+            if (_align_depth && (stream != DEPTH) && (stream != CONFIDENCE) && stream.second < 2)
             {
                 std::stringstream aligned_image_raw, aligned_camera_info;
                 aligned_image_raw << "aligned_depth_to_" << stream_name << "/image_raw";


### PR DESCRIPTION
Add support for L515 confidence image.
Published as a mono8 ROS image, containing a 4-bit confidence grade for each pixel.