### PR TITLE
fix timestamp domain issues.

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -198,7 +198,8 @@ namespace realsense2_camera
         void enable_devices();
         void setupFilters();
         void setupStreams();
-        void setBaseTime(double frame_time, rs2_timestamp_domain time_domain);
+        bool setBaseTime(double frame_time, rs2_timestamp_domain time_domain);
+        double frameSystemTimeSec(rs2::frame frame);
         cv::Mat& fix_depth_scale(const cv::Mat& from_image, cv::Mat& to_image);
         void clip_depth(rs2::depth_frame depth_frame, float clipping_dist);
         void updateStreamCalibData(const rs2::video_stream_profile& video_profile);


### PR DESCRIPTION
Add offset to ros_time only if the device uses hardware-clock. Otherwise use device time - either system_time or global_time.
This prevents situations when the base time was taken with one timestamp domain and then applied to frames with different timestamp domain.
This aims to fix #1370 and #1665