### PR TITLE
foxy-Avoid aligning confidence image

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -1038,7 +1038,7 @@ void BaseRealSenseNode::publishAlignedDepthToOthers(rs2::frameset frames, const 
         auto frame = (*it);
         auto stream_type = frame.get_profile().stream_type();
 
-        if (RS2_STREAM_DEPTH == stream_type)
+        if (RS2_STREAM_DEPTH == stream_type || RS2_STREAM_CONFIDENCE == stream_type)
             continue;
 
         auto stream_index = frame.get_profile().stream_index();


### PR DESCRIPTION
Should not align confidence image to depth as they are already aligned.
fix Issue 1669