### PR TITLE
Remove wrong dependency

### DIFF
--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -93,11 +93,9 @@ find_package(rclcpp_components REQUIRED)
 find_package(realsense2_camera_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
-find_package(diagnostic_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2 REQUIRED)
-find_package(diagnostic_updater REQUIRED)
 
 find_package(realsense2 2.42.0)
 if(NOT realsense2_FOUND)
@@ -127,10 +125,8 @@ set(dependencies
   realsense2_camera_msgs
   std_msgs
   sensor_msgs
-  diagnostic_msgs
   nav_msgs
   tf2
-  diagnostic_updater
   realsense2
   tf2_ros
 )
@@ -183,7 +179,6 @@ if(BUILD_TESTING)
     OpenCV
     rclcpp
     sensor_msgs
-    diagnostic_msgs
     nav_msgs
     tf2
     tf2_ros)

--- a/realsense2_camera/include/realsense2_camera/base_realsense_node.h
+++ b/realsense2_camera/include/realsense2_camera/base_realsense_node.h
@@ -10,9 +10,6 @@
 #include "realsense2_camera/constants.h"
 #include <cv_bridge/cv_bridge.h>
 
-#include <diagnostic_updater/diagnostic_updater.hpp>
-#include <diagnostic_updater/update_functions.hpp>
-#include <diagnostic_updater/publisher.hpp>
 // #include <nav_msgs/Odometry.h>
 #include <image_transport/image_transport.hpp>
 #include "realsense2_camera_msgs/msg/imu_info.hpp"

--- a/realsense2_camera/package.xml
+++ b/realsense2_camera/package.xml
@@ -27,7 +27,6 @@
   <depend>nav_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
-  <depend>diagnostic_updater</depend>
 
   <exec_depend>launch_ros</exec_depend>
   <test_depend>ament_cmake_gtest</test_depend>


### PR DESCRIPTION
Hi.

This is this is my first Pull Request. So please understand if I did something wrong.

I tested the foxy branch of realsense-ros . I tried to build source code and there is a build error related dependency.
diagnostic_updater is not exist in foxy. So, it will not need anymore in foxy branch.
Please consider to fix this.