### PR TITLE
Add conditional param use_mesh

### DIFF
--- a/realsense2_description/launch/view_d415_model.launch
+++ b/realsense2_description/launch/view_d415_model.launch
@@ -1,5 +1,5 @@
 <launch>
-    <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find realsense2_description)/urdf/test_d415_camera.urdf.xacro' use_nominal_extrinsics:=true add_plug:=true" />
+    <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find realsense2_description)/urdf/test_d415_camera.urdf.xacro' use_nominal_extrinsics:=true add_plug:=true use_mesh:=true" />
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 
     <arg name="gui" default="True" />

--- a/realsense2_description/launch/view_d435_model.launch
+++ b/realsense2_description/launch/view_d435_model.launch
@@ -1,5 +1,5 @@
 <launch>
-    <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find realsense2_description)/urdf/test_d435_camera.urdf.xacro' use_nominal_extrinsics:=true add_plug:=true" />
+    <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find realsense2_description)/urdf/test_d435_camera.urdf.xacro' use_nominal_extrinsics:=true add_plug:=true use_mesh:=true" />
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 
     <arg name="gui" default="True" />

--- a/realsense2_description/launch/view_l515_model.launch
+++ b/realsense2_description/launch/view_l515_model.launch
@@ -1,5 +1,5 @@
 <launch>
-    <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find realsense2_description)/urdf/test_l515_camera.urdf.xacro' use_nominal_extrinsics:=true add_plug:=true" />
+    <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find realsense2_description)/urdf/test_l515_camera.urdf.xacro' use_nominal_extrinsics:=true add_plug:=true use_mesh:=true" />
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 
     <arg name="gui" default="True" />

--- a/realsense2_description/urdf/_d415.urdf.xacro
+++ b/realsense2_description/urdf/_d415.urdf.xacro
@@ -12,7 +12,7 @@ aluminum peripherial evaluation case.
   <xacro:include filename="$(find realsense2_description)/urdf/_materials.urdf.xacro" />
   <xacro:include filename="$(find realsense2_description)/urdf/_usb_plug.urdf.xacro" />
 
-  <xacro:macro name="sensor_d415" params="parent *origin  name:=camera  use_nominal_extrinsics:=false add_plug:=false">
+  <xacro:macro name="sensor_d415" params="parent *origin  name:=camera  use_nominal_extrinsics:=false add_plug:=false use_mesh:=true">
     <xacro:property name="M_PI" value="3.1415926535897931" />
 
     <!-- The following values are approximate, and the camera node
@@ -52,12 +52,18 @@ aluminum peripherial evaluation case.
 
     <link name="${name}_link">
       <visual>
-      <origin xyz="${d415_cam_mount_from_center_offset} ${-d415_cam_depth_py} 0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
-        <geometry>
-          <!-- <box size="${d415_cam_width} ${d415_cam_height} ${d415_cam_depth}"/> -->
-	         <mesh filename="package://realsense2_description/meshes/d415.stl" />
-        </geometry>
-        <material name="aluminum"/>
+        <xacro:if value="${use_mesh}">
+          <origin xyz="${d415_cam_mount_from_center_offset} ${-d415_cam_depth_py} 0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
+          <geometry>
+            <mesh filename="package://realsense2_description/meshes/d415.stl" />
+          </geometry>
+        </xacro:if>
+        <xacro:unless value="${use_mesh}">
+          <origin xyz="0 ${-d415_cam_depth_py} 0" rpy="0 0 0"/>
+          <geometry>
+            <box size="${d415_cam_depth} ${d415_cam_width} ${d415_cam_height}"/>
+          </geometry>
+        </xacro:unless>     
       </visual>
       <collision>
         <origin xyz="0 ${-d415_cam_depth_py} 0" rpy="0 0 0"/>

--- a/realsense2_description/urdf/_d435.urdf.xacro
+++ b/realsense2_description/urdf/_d435.urdf.xacro
@@ -13,7 +13,7 @@ aluminum peripherial evaluation case.
   <xacro:include filename="$(find realsense2_description)/urdf/_materials.urdf.xacro" />
   <xacro:include filename="$(find realsense2_description)/urdf/_usb_plug.urdf.xacro" />
 
-  <xacro:macro name="sensor_d435" params="parent *origin name:=camera use_nominal_extrinsics:=false add_plug:=false">
+  <xacro:macro name="sensor_d435" params="parent *origin name:=camera use_nominal_extrinsics:=false add_plug:=false use_mesh:=true">
     <xacro:property name="M_PI" value="3.1415926535897931" />
 
     <!-- The following values are approximate, and the camera node
@@ -58,12 +58,20 @@ aluminum peripherial evaluation case.
 
     <link name="${name}_link">
       <visual>
-        <!-- the mesh origin is at front plate in between the two infrared camera axes -->
-        <origin xyz="${d435_zero_depth_to_glass + d435_glass_to_front} ${-d435_cam_depth_py} 0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
-        <geometry>
-          <!-- <box size="${d435_cam_width} ${d435_cam_height} ${d435_cam_depth}"/> -->
-	        <mesh filename="package://realsense2_description/meshes/d435.dae" />
-        </geometry>
+        <xacro:if value="${use_mesh}">
+          <!-- the mesh origin is at front plate in between the two infrared camera axes -->
+          <origin xyz="${d435_zero_depth_to_glass + d435_glass_to_front} ${-d435_cam_depth_py} 0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
+          <geometry>
+            <mesh filename="package://realsense2_description/meshes/d435.dae" />
+          </geometry>
+        </xacro:if>
+        <xacro:unless value="${use_mesh}">
+          <origin xyz="0 ${-d435_cam_depth_py} 0" rpy="0 0 0"/>
+          <geometry>
+            <box size="${d435_cam_depth} ${d435_cam_width} ${d435_cam_height}"/>
+          </geometry>
+          <material name="aluminum"/>
+        </xacro:unless>     
       </visual>
       <collision>
         <origin xyz="0 ${-d435_cam_depth_py} 0" rpy="0 0 0"/>

--- a/realsense2_description/urdf/_l515.urdf.xacro
+++ b/realsense2_description/urdf/_l515.urdf.xacro
@@ -13,7 +13,7 @@ aluminum peripherial evaluation case.
   <xacro:include filename="$(find realsense2_description)/urdf/_materials.urdf.xacro" />
   <xacro:include filename="$(find realsense2_description)/urdf/_usb_plug.urdf.xacro" /> <!-- this specific plug does not apply to L515 -->
 
-  <xacro:macro name="sensor_l515" params="parent *origin name:=camera use_nominal_extrinsics:=false add_plug:=false">
+  <xacro:macro name="sensor_l515" params="parent *origin name:=camera use_nominal_extrinsics:=false add_plug:=false use_mesh:=true">
     <xacro:property name="M_PI" value="3.1415926535897931" />
 
     <!-- The following values are approximate, and the camera node
@@ -61,10 +61,19 @@ aluminum peripherial evaluation case.
     <link name="${name}_link">
       <visual>
         <!-- the mesh origin is in the middle of the front plate -->
-        <origin xyz="${l515_zero_depth_to_glass} 0 ${-l515_cam_center_to_depth_pz}" rpy="${M_PI/2} 0 ${M_PI/2}"/>
-        <geometry>
-	        <mesh filename="package://realsense2_description/meshes/l515.dae" />
-        </geometry>
+        <xacro:if value="${use_mesh}">
+          <origin xyz="${l515_zero_depth_to_glass} 0 ${-l515_cam_center_to_depth_pz}" rpy="${M_PI/2} 0 ${M_PI/2}"/>
+          <geometry>
+              <mesh filename="package://realsense2_description/meshes/l515.dae" />
+          </geometry>
+        </xacro:if>
+        <xacro:unless value="${use_mesh}">
+          <origin xyz="${-l515_cam_depth_px+l515_cam_mount_from_glass_offset-l515_cam_depth/2} 0 ${-l515_cam_center_to_depth_pz}" rpy="${M_PI/2} 0 ${M_PI/2}"/>
+          <geometry>
+            <cylinder radius="${l515_cam_width/2.0}" length="${l515_cam_depth}"/>
+          </geometry>
+          <material name="aluminum"/>
+        </xacro:unless>
       </visual>
       <collision>
         <origin xyz="${-l515_cam_depth_px+l515_cam_mount_from_glass_offset-l515_cam_depth/2} 0 ${-l515_cam_center_to_depth_pz}" rpy="${M_PI/2} 0 ${M_PI/2}"/>

--- a/realsense2_description/urdf/test_d415_camera.urdf.xacro
+++ b/realsense2_description/urdf/test_d415_camera.urdf.xacro
@@ -2,10 +2,11 @@
 <robot name="realsense2_camera" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:arg name="use_nominal_extrinsics" default="false" />
   <xacro:arg name="add_plug" default="false" />
+  <xacro:arg name="use_mesh" default="true" />
   <xacro:include filename="$(find realsense2_description)/urdf/_d415.urdf.xacro" />
 
   <link name="base_link" />
-  <xacro:sensor_d415 parent="base_link" use_nominal_extrinsics="$(arg use_nominal_extrinsics)" add_plug="$(arg add_plug)">
+  <xacro:sensor_d415 parent="base_link" use_nominal_extrinsics="$(arg use_nominal_extrinsics)" add_plug="$(arg add_plug)" use_mesh="$(arg use_mesh)">
     <origin xyz="0 0 0" rpy="0 0 0"/>
   </xacro:sensor_d415>
 </robot>

--- a/realsense2_description/urdf/test_d435_camera.urdf.xacro
+++ b/realsense2_description/urdf/test_d435_camera.urdf.xacro
@@ -2,10 +2,11 @@
 <robot name="realsense2_camera" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:arg name="use_nominal_extrinsics" default="false"/>
   <xacro:arg name="add_plug" default="false" />
+  <xacro:arg name="use_mesh" default="true" />
   <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro" />
   
   <link name="base_link" />
-  <xacro:sensor_d435 parent="base_link" use_nominal_extrinsics="$(arg use_nominal_extrinsics)" add_plug="$(arg add_plug)">
+  <xacro:sensor_d435 parent="base_link" use_nominal_extrinsics="$(arg use_nominal_extrinsics)" add_plug="$(arg add_plug)" use_mesh="$(arg use_mesh)">
     <origin xyz="0 0 0" rpy="0 0 0"/>
   </xacro:sensor_d435>
 </robot>

--- a/realsense2_description/urdf/test_l515_camera.urdf.xacro
+++ b/realsense2_description/urdf/test_l515_camera.urdf.xacro
@@ -2,10 +2,11 @@
 <robot name="realsense2_camera" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:arg name="use_nominal_extrinsics" default="false"/>
   <xacro:arg name="add_plug" default="false" />
+  <xacro:arg name="use_mesh" default="true" />
   <xacro:include filename="$(find realsense2_description)/urdf/_l515.urdf.xacro" />
   
   <link name="base_link" />
-  <xacro:sensor_l515 parent="base_link" use_nominal_extrinsics="$(arg use_nominal_extrinsics)" add_plug="$(arg add_plug)">
+  <xacro:sensor_l515 parent="base_link" use_nominal_extrinsics="$(arg use_nominal_extrinsics)" add_plug="$(arg add_plug)" use_mesh="$(arg use_mesh)">
     <origin xyz="0 0 0" rpy="0 0 0"/>
   </xacro:sensor_l515>
 </robot>


### PR DESCRIPTION
This pull request adds the option to use the param use_mesh to load the 3D files in URDF or not.

So, now we're able to turn on/off the mesh easily:
```
  <xacro:sensor_d435 
          parent="base_link"
          use_nominal_extrinsics="$(arg use_nominal_extrinsics)" 
          add_plug="$(arg add_plug)" 
          use_mesh="$(arg use_mesh)">

    <origin xyz="0 0 0" rpy="0 0 0"/>
  </xacro:sensor_d435>
```
I have been facing performance issues with the meshes then I added this option.