### PR TITLE
migration toggle_sensors feature to ros2

### DIFF
--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -92,6 +92,7 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(realsense2_camera_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
@@ -154,6 +155,7 @@ set(dependencies
   rclcpp_components
   realsense2_camera_msgs
   std_msgs
+  std_srvs
   sensor_msgs
   nav_msgs
   tf2

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -30,6 +30,7 @@
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
+#include <std_srvs/srv/set_bool.hpp>
 
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2_ros/transform_broadcaster.h>
@@ -159,9 +160,12 @@ namespace realsense2_camera
         bool _align_depth;
         std::vector<rs2_option> _monitor_options;
         rclcpp::Logger _logger;
+        rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr _toggle_sensors_srv;
 
         virtual void calcAndPublishStaticTransform(const stream_index_pair& stream, const rs2::stream_profile& base_profile);
-        void publishTopics();
+        virtual void toggleSensors(bool enabled);
+        bool toggle_sensor_callback(std_srvs::srv::SetBool::Request::SharedPtr req, std_srvs::srv::SetBool::Response::SharedPtr res);
+        virtual void publishTopics();
         rs2::stream_profile getAProfile(const stream_index_pair& stream);
         tf2::Quaternion rotationMatrixToQuaternion(const float rotation[9]) const;
         void publish_static_tf(const rclcpp::Time& t,

--- a/realsense2_camera/include/t265_realsense_node.h
+++ b/realsense2_camera/include/t265_realsense_node.h
@@ -10,7 +10,8 @@ namespace realsense2_camera
         public:
             T265RealsenseNode(rclcpp::Node& node,
                           rs2::device dev, std::shared_ptr<Parameters> parameters);
-            void publishTopics();
+            virtual void toggleSensors(bool enabled) override;
+            virtual void publishTopics() override;
 
         protected:
             void calcAndPublishStaticTransform(const stream_index_pair& stream, const rs2::stream_profile& base_profile) override;

--- a/realsense2_camera/package.xml
+++ b/realsense2_camera/package.xml
@@ -24,6 +24,7 @@
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
   <depend>nav_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>

--- a/realsense2_camera/src/t265_realsense_node.cpp
+++ b/realsense2_camera/src/t265_realsense_node.cpp
@@ -40,6 +40,11 @@ void T265RealsenseNode::initializeOdometryInput()
     _use_odom_in = true;
 }
 
+void T265RealsenseNode::toggleSensors(bool enabled)
+{
+  ROS_WARN_STREAM("toggleSensors method not implemented for T265");
+}
+
 void T265RealsenseNode::publishTopics()
 {
     BaseRealSenseNode::publishTopics();


### PR DESCRIPTION
Hello,

This pull request is addressing this issue: "Plans to migrate "/enable" service to ROS2?" #1813 
and consists in migrating this PR to ROS2: "add enable (SetBool) service for disabling/enabling sensor streams" #1313

The main differences from the above PR are:
- using a ROS2 service (`rclcpp::Service` instead of `ros::ServiceServer`)
- on the ros1 branch "development", the class [`BaseRealSenseNode` inherits from class `InterfaceRealSenseNode`](https://github.com/wyca-robotics/realsense-ros/blob/8af6b8d0382721e71fe8709bc28a0bf1221df9db/realsense2_camera/include/base_realsense_node.h#L118). But on "ros2" branch, [it doesn't](https://github.com/wyca-robotics/realsense-ros/blob/4f66b1ca8d13252e4e8ca6e30c47e46732ed6877/realsense2_camera/include/base_realsense_node.h#L119). So every changes from the original PR applied in the class `InterfaceRealSenseNode` have been directly moved to `BaseRealSenseNode`. I hope this is an acceptable design.

This PR has been tested on a D435, with Ubuntu 20.04 and ROS2 Rolling. 