### PR TITLE
ROS1-Fix pointcloud message size when no texture is added.

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -2255,7 +2255,6 @@ void BaseRealSenseNode::publishPointCloud(rs2::points pc, const ros::Time& t, co
     else
     {
         std::string format_str = "intensity";
-        _msg_pointcloud.point_step = addPointField(_msg_pointcloud, format_str.c_str(), 1, sensor_msgs::PointField::FLOAT32, _msg_pointcloud.point_step);
         _msg_pointcloud.row_step = _msg_pointcloud.width * _msg_pointcloud.point_step;
         _msg_pointcloud.data.resize(_msg_pointcloud.height * _msg_pointcloud.row_step);
 


### PR DESCRIPTION
A texture field was added, but not filled when pointcloud was built without texture.