### PR TITLE
ROS2 - Add filling correct Tx, Ty values in projection matrix of right camera.

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -204,7 +204,6 @@ namespace realsense2_camera
         cv::Mat& fix_depth_scale(const cv::Mat& from_image, cv::Mat& to_image);
         void clip_depth(rs2::depth_frame depth_frame, float clipping_dist);
         void updateStreamCalibData(const rs2::video_stream_profile& video_profile);
-        void updateExtrinsicsCalibData(const rs2::video_stream_profile& left_video_profile, const rs2::video_stream_profile& right_video_profile);
         void SetBaseStream();
         void publishStaticTransforms();
         void publishDynamicTransforms();
@@ -221,7 +220,6 @@ namespace realsense2_camera
                           const std::map<stream_index_pair, image_transport::Publisher>& image_publishers,
                           std::map<stream_index_pair, int>& seq,
                           std::map<stream_index_pair, sensor_msgs::msg::CameraInfo>& camera_info,
-                          const std::map<stream_index_pair, std::string>& optical_frame_id,
                           const std::map<rs2_stream, std::string>& encoding);
         bool getEnabledProfile(const stream_index_pair& stream_index, rs2::stream_profile& profile);
 


### PR DESCRIPTION
Migrating PR#901
Added filling correct Tx, Ty values in projection matrix of the right camera.
Generalize solution to all stereo sensors (fisheye)
Fixed frame_id of the right sensor to match left sensor in a stereo pair. Based on a suggestion by @pavloblindnology (https://github.com/IntelRealSense/realsense-ros/pull/1242#issuecomment-785778234)