### PR TITLE
ROS1- Fix occasional missing diagnostic messages

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -2472,9 +2472,11 @@ void BaseRealSenseNode::publish_temperature()
 
 void BaseRealSenseNode::publish_frequency_update()
 {
+    std::chrono::milliseconds timespan(1);
     for (auto &image_publisher : _image_publishers)
     {
         image_publisher.second.second->update();
+        std::this_thread::sleep_for(timespan);
     }
 }
 


### PR DESCRIPTION
The issue is caused by ROS traffic issues.
Solution is based on @g-gemignani at https://github.com/ros/diagnostics/issues/195#issuecomment-830818432