### PR TITLE
No tf broadcaster if publish_tf is set to false

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -275,7 +275,7 @@ namespace realsense2_camera
         std::map<rs2_stream, std::string> _stream_name;
         bool _publish_tf;
         double _tf_publish_rate;
-        tf2_ros::StaticTransformBroadcaster _static_tf_broadcaster;
+        std::shared_ptr<tf2_ros::StaticTransformBroadcaster> _static_tf_broadcaster;
         tf2_ros::TransformBroadcaster _dynamic_tf_broadcaster;
         std::vector<geometry_msgs::msg::TransformStamped> _static_tf_msgs;
         std::shared_ptr<std::thread> _tf_t, _update_functions_t;

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -107,11 +107,15 @@ BaseRealSenseNode::BaseRealSenseNode(rclcpp::Node& node,
     _logger(rclcpp::get_logger("RealSenseCameraNode")),
     _dev(dev),
     _json_file_path(""),
-    _static_tf_broadcaster(node),
     _dynamic_tf_broadcaster(node),
     _is_initialized_time_base(false),
     _parameters(parameters)
 {
+    setNgetNodeParameter(_publish_tf, "publish_tf", PUBLISH_TF);
+    if (_publish_tf) {
+      _static_tf_broadcaster = std::make_shared<tf2_ros::StaticTransformBroadcaster>(node);
+    }
+
     // Types for depth stream
     _format[RS2_STREAM_DEPTH] = RS2_FORMAT_Z16;    
     _image_format[RS2_STREAM_DEPTH] = CV_16UC1;    // CVBridge type
@@ -858,7 +862,6 @@ void BaseRealSenseNode::getParameters()
     setNgetNodeParameter(_filters_str, "filters", DEFAULT_FILTERS);
     _pointcloud |= (_filters_str.find("pointcloud") != std::string::npos);
 
-    setNgetNodeParameter(_publish_tf, "publish_tf", PUBLISH_TF);
     setNgetNodeParameter(_tf_publish_rate, "tf_publish_rate", TF_PUBLISH_RATE);
     setNgetNodeParameter(_sync_frames, "enable_sync", SYNC_FRAMES);
     if (_pointcloud || _align_depth || _filters_str.size() > 0)
@@ -2245,7 +2248,7 @@ void BaseRealSenseNode::publishStaticTransforms()
                 publishDynamicTransforms();
             });
         else
-            _static_tf_broadcaster.sendTransform(_static_tf_msgs);
+            _static_tf_broadcaster->sendTransform(_static_tf_msgs);
     }
 
     // Publish Extrinsics Topics:


### PR DESCRIPTION
Because of the tf static publisher, it is not possible to start the realsense node with `use_intra_process_comms` set to `true`. 
It is due to the fact that IPC requires ALL publishers of the node to have their QoS durability set to `volatile`, and the tf static publisher durability is `transient_local`. See here for know issue: https://answers.ros.org/question/364022/ros2-intra-process-communication-and-qos/
Hence this PR mitigates this issue by not initializing the `_static_tf_broadcaster` when it is not needed, i.e when `publish_tf` is set to `false`.