### PR TITLE
ROS2 fix config override

### DIFF
--- a/realsense2_camera/config/d435i.yaml
+++ b/realsense2_camera/config/d435i.yaml
@@ -1,4 +1,4 @@
-camera1:
+camera:
     camera:
       ros__parameters:
         device_type: ''


### PR DESCRIPTION
In `rs_launch.py` we have:
```
                node_namespace=LaunchConfiguration("camera_name"),
                node_name=LaunchConfiguration("camera_name"),
```
or 
```
                namespace=LaunchConfiguration("camera_name"),
                name=LaunchConfiguration("camera_name"),
```

Hence `namespace` and `node name` are identical. This is not reflected in the configuration yaml file.