### PR TITLE
Add comment for supporting rosdep for EOL distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This version supports ROS2 Dashing, Eloquent and Foxy.
   ### Step 4: Install dependencies:
    ```bash
   sudo apt-get install python3-rosdep -y
-  sudo rosdep init
+  sudo rosdep init # "sudo rosdep init --include-eol-distros" for Dashing
   rosdep update
   rosdep install -i --from-path src --rosdistro $ROS_DISTRO -y
   sudo apt purge ros-$ROS_DISTRO-librealsense2 -y


### PR DESCRIPTION
The installation steps provided for ROS2 are inaccurate and may cause errors on rosdep dependencies installation.

Since Dashing has reached EOL, in order to install dependencies for Dashing, the  `sudo rosdep init --include-eol-distros` is essential and may not be obvious for first-time users.