### PR TITLE
chore(realsense2_camera): make reconnect timeout a parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ The following parameters are available by the wrapper:
 
 - **rosbag_filename**: Will publish topics from rosbag file.
 - **initial_reset**: On occasions the device was not closed properly and due to firmware issues needs to reset. If set to true, the device will reset prior to usage.
+- **reconnect_timeout**: When the driver cannot connect to the device try to reconnect after this timeout (in seconds).
 - **align_depth**: If set to true, will publish additional topics for the "aligned depth to color" image.: ```/camera/aligned_depth_to_color/image_raw```, ```/camera/aligned_depth_to_color/camera_info```.</br>
 The pointcloud, if enabled, will be built based on the aligned_depth_to_color image.</br>
 - **filters**: any of the following options, separated by commas:</br>

--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -104,6 +104,7 @@
   <arg name="clip_distance"            default="-1"/>
   <arg name="linear_accel_cov"         default="0.01"/>
   <arg name="initial_reset"            default="false"/>
+  <arg name="reconnect_timeout"        default= "6"/>
   <arg name="unite_imu_method"         default="none"/> <!-- Options are: [none, copy, linear_interpolation] -->
   
 
@@ -208,6 +209,7 @@
     <param name="clip_distance"            type="double" value="$(arg clip_distance)"/>
     <param name="linear_accel_cov"         type="double" value="$(arg linear_accel_cov)"/>
     <param name="initial_reset"            type="bool"   value="$(arg initial_reset)"/>
+    <param name="reconnect_timeout"        type="int"    value="$(arg reconnect_timeout)"/>
     <param name="unite_imu_method"         type="str"    value="$(arg unite_imu_method)"/>
 
   </node>

--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -104,7 +104,7 @@
   <arg name="clip_distance"            default="-1"/>
   <arg name="linear_accel_cov"         default="0.01"/>
   <arg name="initial_reset"            default="false"/>
-  <arg name="reconnect_timeout"        default= "6"/>
+  <arg name="reconnect_timeout"        default= "6.0"/>
   <arg name="unite_imu_method"         default="none"/> <!-- Options are: [none, copy, linear_interpolation] -->
   
 
@@ -209,7 +209,7 @@
     <param name="clip_distance"            type="double" value="$(arg clip_distance)"/>
     <param name="linear_accel_cov"         type="double" value="$(arg linear_accel_cov)"/>
     <param name="initial_reset"            type="bool"   value="$(arg initial_reset)"/>
-    <param name="reconnect_timeout"        type="int"    value="$(arg reconnect_timeout)"/>
+    <param name="reconnect_timeout"        type="double"    value="$(arg reconnect_timeout)"/>
     <param name="unite_imu_method"         type="str"    value="$(arg unite_imu_method)"/>
 
   </node>

--- a/realsense2_camera/launch/rs_camera.launch
+++ b/realsense2_camera/launch/rs_camera.launch
@@ -59,7 +59,7 @@
   <arg name="clip_distance"             default="-2"/>
   <arg name="linear_accel_cov"          default="0.01"/>
   <arg name="initial_reset"             default="false"/>
-  <arg name="reconnect_timeout"         default="6"/>
+  <arg name="reconnect_timeout"         default="6.0"/>
   <arg name="unite_imu_method"          default=""/>
   <arg name="topic_odom_in"             default="odom_in"/>
   <arg name="calib_odom_file"           default=""/>

--- a/realsense2_camera/launch/rs_camera.launch
+++ b/realsense2_camera/launch/rs_camera.launch
@@ -59,6 +59,7 @@
   <arg name="clip_distance"             default="-2"/>
   <arg name="linear_accel_cov"          default="0.01"/>
   <arg name="initial_reset"             default="false"/>
+  <arg name="reconnect_timeout"         default="6"/>
   <arg name="unite_imu_method"          default=""/>
   <arg name="topic_odom_in"             default="odom_in"/>
   <arg name="calib_odom_file"           default=""/>
@@ -129,6 +130,7 @@
       <arg name="clip_distance"            value="$(arg clip_distance)"/>
       <arg name="linear_accel_cov"         value="$(arg linear_accel_cov)"/>
       <arg name="initial_reset"            value="$(arg initial_reset)"/>
+      <arg name="reconnect_timeout"        value="$(arg reconnect_timeout)"/>
       <arg name="unite_imu_method"         value="$(arg unite_imu_method)"/>
       <arg name="topic_odom_in"            value="$(arg topic_odom_in)"/>
       <arg name="calib_odom_file"          value="$(arg calib_odom_file)"/>

--- a/realsense2_camera/launch/rs_d400_and_t265.launch
+++ b/realsense2_camera/launch/rs_d400_and_t265.launch
@@ -8,7 +8,7 @@
   <arg name="tf_prefix_camera1"         default="$(arg camera1)"/>
   <arg name="tf_prefix_camera2"         default="$(arg camera2)"/>
   <arg name="initial_reset"             default="false"/>
-  <arg name="reconnect_timeout"         default="6"/>
+  <arg name="reconnect_timeout"         default="6.0"/>
   <arg name="enable_fisheye"            default="false"/>
   <arg name="color_width"               default="640"/>
   <arg name="color_height"              default="480"/>

--- a/realsense2_camera/launch/rs_d400_and_t265.launch
+++ b/realsense2_camera/launch/rs_d400_and_t265.launch
@@ -8,6 +8,7 @@
   <arg name="tf_prefix_camera1"         default="$(arg camera1)"/>
   <arg name="tf_prefix_camera2"         default="$(arg camera2)"/>
   <arg name="initial_reset"             default="false"/>
+  <arg name="reconnect_timeout"         default="6"/>
   <arg name="enable_fisheye"            default="false"/>
   <arg name="color_width"               default="640"/>
   <arg name="color_height"              default="480"/>
@@ -23,6 +24,7 @@
       <arg name="serial_no"             value="$(arg serial_no_camera1)"/>
       <arg name="tf_prefix"         		value="$(arg tf_prefix_camera1)"/>
       <arg name="initial_reset"         value="$(arg initial_reset)"/>
+      <arg name="reconnect_timeout"     value="$(arg reconnect_timeout)"/>
       <arg name="enable_fisheye1"       value="$(arg enable_fisheye)"/>
       <arg name="enable_fisheye2"       value="$(arg enable_fisheye)"/>
       <arg name="topic_odom_in"         value="$(arg topic_odom_in)"/>
@@ -37,6 +39,7 @@
       <arg name="serial_no"             value="$(arg serial_no_camera2)"/>
       <arg name="tf_prefix"		          value="$(arg tf_prefix_camera2)"/>
       <arg name="initial_reset"         value="$(arg initial_reset)"/>
+      <arg name="reconnect_timeout"     value="$(arg reconnect_timeout)"/>
       <arg name="align_depth"           value="true"/>
       <arg name="filters"               value="pointcloud"/>
       <arg name="color_width"           value="$(arg color_width)"/>

--- a/realsense2_camera/launch/rs_d435_camera_with_model.launch
+++ b/realsense2_camera/launch/rs_d435_camera_with_model.launch
@@ -43,6 +43,7 @@
   <arg name="clip_distance"             default="-2"/>
   <arg name="linear_accel_cov"          default="0.01"/>
   <arg name="initial_reset"             default="false"/>
+  <arg name="reconnect_timeout"         default="6"/>
   <arg name="unite_imu_method"          default=""/>
   <arg name="topic_odom_in"             default="odom_in"/>
   <arg name="calib_odom_file"           default=""/>
@@ -93,6 +94,7 @@
       <arg name="clip_distance"            value="$(arg clip_distance)"/>
       <arg name="linear_accel_cov"         value="$(arg linear_accel_cov)"/>
       <arg name="initial_reset"            value="$(arg initial_reset)"/>
+      <arg name="reconnect_timeout"        value="$(arg reconnect_timeout)"/>
       <arg name="unite_imu_method"         value="$(arg unite_imu_method)"/>
       <arg name="topic_odom_in"            value="$(arg topic_odom_in)"/>
       <arg name="calib_odom_file"          value="$(arg calib_odom_file)"/>

--- a/realsense2_camera/launch/rs_d435_camera_with_model.launch
+++ b/realsense2_camera/launch/rs_d435_camera_with_model.launch
@@ -43,7 +43,7 @@
   <arg name="clip_distance"             default="-2"/>
   <arg name="linear_accel_cov"          default="0.01"/>
   <arg name="initial_reset"             default="false"/>
-  <arg name="reconnect_timeout"         default="6"/>
+  <arg name="reconnect_timeout"         default="6.0"/>
   <arg name="unite_imu_method"          default=""/>
   <arg name="topic_odom_in"             default="odom_in"/>
   <arg name="calib_odom_file"           default=""/>

--- a/realsense2_camera/launch/rs_multiple_devices.launch
+++ b/realsense2_camera/launch/rs_multiple_devices.launch
@@ -9,12 +9,14 @@
   <arg name="tf_prefix_camera2"         default="$(arg camera2)"/>
   <arg name="tf_prefix_camera3"         default="$(arg camera3)"/>
   <arg name="initial_reset"             default="false"/>
+  <arg name="reconnect_timeout"         default="6"/>
 
   <group ns="$(arg camera1)">
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
       <arg name="serial_no"             value="$(arg serial_no_camera1)"/>
       <arg name="tf_prefix"         		value="$(arg tf_prefix_camera1)"/>
       <arg name="initial_reset"         value="$(arg initial_reset)"/>
+      <arg name="reconnect_timeout"     value="$(arg reconnect_timeout)"/>
     </include>
   </group>
 
@@ -23,6 +25,7 @@
       <arg name="serial_no"             value="$(arg serial_no_camera2)"/>
       <arg name="tf_prefix"		          value="$(arg tf_prefix_camera2)"/>
       <arg name="initial_reset"         value="$(arg initial_reset)"/>
+      <arg name="reconnect_timeout"     value="$(arg reconnect_timeout)"/>
     </include>
   </group>
 
@@ -31,6 +34,7 @@
       <arg name="serial_no"             value="$(arg serial_no_camera3)"/>
       <arg name="tf_prefix"		          value="$(arg tf_prefix_camera3)"/>
       <arg name="initial_reset"         value="$(arg initial_reset)"/>
+      <arg name="reconnect_timeout"     value="$(arg reconnect_timeout)"/>
     </include>
   </group>
 </launch>

--- a/realsense2_camera/launch/rs_multiple_devices.launch
+++ b/realsense2_camera/launch/rs_multiple_devices.launch
@@ -9,7 +9,7 @@
   <arg name="tf_prefix_camera2"         default="$(arg camera2)"/>
   <arg name="tf_prefix_camera3"         default="$(arg camera3)"/>
   <arg name="initial_reset"             default="false"/>
-  <arg name="reconnect_timeout"         default="6"/>
+  <arg name="reconnect_timeout"         default="6.0"/>
 
   <group ns="$(arg camera1)">
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">

--- a/realsense2_camera/launch/rs_t265.launch
+++ b/realsense2_camera/launch/rs_t265.launch
@@ -29,6 +29,7 @@ https://github.com/IntelRealSense/librealsense/blob/master/third-party/libtm/lib
 
   <arg name="linear_accel_cov"      default="0.01"/>
   <arg name="initial_reset"         default="false"/>
+  <arg name="reconnect_timeout"     default="6"/>
   <arg name="unite_imu_method"      default=""/>
 
   <arg name="publish_odom_tf"     default="true"/>
@@ -57,6 +58,7 @@ https://github.com/IntelRealSense/librealsense/blob/master/third-party/libtm/lib
 
       <arg name="linear_accel_cov"         value="$(arg linear_accel_cov)"/>
       <arg name="initial_reset"            value="$(arg initial_reset)"/>
+      <arg name="reconnect_timeout"        value="$(arg reconnect_timeout)"/>
       <arg name="unite_imu_method"         value="$(arg unite_imu_method)"/>
 
       <arg name="publish_odom_tf"          value="$(arg publish_odom_tf)"/>

--- a/realsense2_camera/launch/rs_t265.launch
+++ b/realsense2_camera/launch/rs_t265.launch
@@ -29,7 +29,7 @@ https://github.com/IntelRealSense/librealsense/blob/master/third-party/libtm/lib
 
   <arg name="linear_accel_cov"      default="0.01"/>
   <arg name="initial_reset"         default="false"/>
-  <arg name="reconnect_timeout"     default="6"/>
+  <arg name="reconnect_timeout"     default="6.0"/>
   <arg name="unite_imu_method"      default=""/>
 
   <arg name="publish_odom_tf"     default="true"/>

--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -290,9 +290,9 @@ void RealSenseNodeFactory::initialize(const ros::WallTimerEvent &ignored)
 			_is_alive = true;
 			_query_thread = std::thread([=]()
 						{
-              int reconnect_timeout;
-              privateNh.param("reconnect_timeout", reconnect_timeout, 6);
-              std::chrono::seconds timespan(reconnect_timeout);
+							int reconnect_timeout;
+							privateNh.param("reconnect_timeout", reconnect_timeout, 6);
+							std::chrono::seconds timespan(reconnect_timeout);
 							while (_is_alive && !_device)
 							{
 								getDevice(_ctx.query_devices());

--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -290,9 +290,9 @@ void RealSenseNodeFactory::initialize(const ros::WallTimerEvent &ignored)
 			_is_alive = true;
 			_query_thread = std::thread([=]()
 						{
-							int reconnect_timeout;
-							privateNh.param("reconnect_timeout", reconnect_timeout, 6);
-							std::chrono::seconds timespan(reconnect_timeout);
+              double reconnect_timeout;
+              privateNh.param("reconnect_timeout", reconnect_timeout, 6.0);
+              std::chrono::duration<double> timespan(reconnect_timeout);
 							while (_is_alive && !_device)
 							{
 								getDevice(_ctx.query_devices());

--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -290,9 +290,9 @@ void RealSenseNodeFactory::initialize(const ros::WallTimerEvent &ignored)
 			_is_alive = true;
 			_query_thread = std::thread([=]()
 						{
-              double reconnect_timeout;
-              privateNh.param("reconnect_timeout", reconnect_timeout, 6.0);
-              std::chrono::duration<double> timespan(reconnect_timeout);
+							double reconnect_timeout;
+							privateNh.param("reconnect_timeout", reconnect_timeout, 6.0);
+							std::chrono::duration<double> timespan(reconnect_timeout);
 							while (_is_alive && !_device)
 							{
 								getDevice(_ctx.query_devices());

--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -290,7 +290,9 @@ void RealSenseNodeFactory::initialize(const ros::WallTimerEvent &ignored)
 			_is_alive = true;
 			_query_thread = std::thread([=]()
 						{
-							std::chrono::milliseconds timespan(6000);
+              int reconnect_timeout;
+              privateNh.param("reconnect_timeout", reconnect_timeout, 6);
+              std::chrono::seconds timespan(reconnect_timeout);
 							while (_is_alive && !_device)
 							{
 								getDevice(_ctx.query_devices());


### PR DESCRIPTION
Currently the reconnect timeout when a device has not been found is hard coded to 6000 ms. This allows for a custom setting through a parameter. Also changed from ms to seconds since this is more convenient for a user. 