### PR TITLE
Move dynamic reconfigure setup function later in the init chain

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -243,12 +243,12 @@ void BaseRealSenseNode::publishTopics()
     setupDevice();
     setupFilters();
     registerHDRoptions();
-    registerDynamicReconfigCb(_node_handle);
     setupErrorCallback();
     enable_devices();
     setupPublishers();
     setupStreams();
     SetBaseStream();
+    registerDynamicReconfigCb(_node_handle);
     registerAutoExposureROIOptions(_node_handle);
     publishStaticTransforms();
     publishIntrinsics();


### PR DESCRIPTION
Before this change, I was not able to set dynamic reconfigure options using the ROS parameter server. For example, with my D435, running `rosparam set /camera/stereo_module/visual_preset 3` and then `roslaunch realsense2_camera rs_camera.launch` led to:
```
[ INFO] [1630540842.060283902]: Setting Dynamic reconfig parameters.
 02/09 00:00:47,271 WARNING [547782746512] (types.cpp:48) get_xu(id=2) failed! Last Error: Resource temporarily unavailable
terminate called after throwing an instance of 'rs2::invalid_value_error'
  what():  get_xu(id=2) failed! Last Error: Resource temporarily unavailable
```
The only solution was to unplug and replug the sensor, and launch again, this time without the ROS param set.

After this change, the driver works with no errors.

This has been tested with the following sensor:
```
Name                          : 	Intel RealSense D435
    Serial Number                 : 	819312073246
    Firmware Version              : 	05.11.01.100
```
in a Docker image running Ubuntu 16.04 (xenial) with ROS kinetic. The version of `realsense-ros` was 2.2.8, and the version of librealsense was `librealsense2.so.2.28`.