### PR TITLE
[ros2] add wait_for_device_timeout

### DIFF
--- a/realsense2_camera/include/realsense_node_factory.h
+++ b/realsense2_camera/include/realsense_node_factory.h
@@ -51,6 +51,7 @@ namespace realsense2_camera
         std::string _serial_no;
         std::string _usb_port_id;
         std::string _device_type;
+        double _wait_for_device_timeout;
         bool _initial_reset;
         std::thread _query_thread;
         bool _is_alive;


### PR DESCRIPTION
This PR adds a param `wait_for_device_timeout` for avoiding to wait indefinitely for a device to show up (which can cause some issues in the long run on the usb devices because of the infinite calls to `ctx.query_devices()`)
When the timeout expires, the node closes.
Set to `-1` by default (keep original behavior of waiting indefinitly)