### PR TITLE
Relative naming of coordinate frames

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -199,6 +199,7 @@ namespace realsense2_camera
                 double          m_time_ns;
         };
 
+        std::string getNamespaceStr();
         void getParameters();
         void setupDevice();
         void setupErrorCallback();

--- a/realsense2_camera/launch/rs_multi_camera_launch.py
+++ b/realsense2_camera/launch/rs_multi_camera_launch.py
@@ -25,6 +25,7 @@
 """Launch realsense2_camera node."""
 import copy
 from launch import LaunchDescription
+import launch_ros.actions
 from launch.actions import IncludeLaunchDescription
 from launch.substitutions import LaunchConfiguration, ThisLaunchFileDir
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -63,5 +64,11 @@ def generate_launch_description():
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource([ThisLaunchFileDir(), '/rs_launch.py']),
             launch_arguments=set_configurable_parameters(params2).items(),
+        ),
+        # dummy static transformation from camera1 to camera2
+        launch_ros.actions.Node(
+            package = "tf2_ros",
+            executable = "static_transform_publisher",
+            arguments = ["0", "0", "0", "0", "0", "0", "camera1_link", "camera2_link"]
         ),
     ])

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -12,9 +12,11 @@ using namespace realsense2_camera;
 
 // stream_index_pair sip{stream_type, stream_index};
 #define STREAM_NAME(sip) (static_cast<std::ostringstream&&>(std::ostringstream() << _stream_name[sip.first] << ((sip.second>0) ? std::to_string(sip.second) : ""))).str()
-#define FRAME_ID(sip) (static_cast<std::ostringstream&&>(std::ostringstream() << "camera_" << STREAM_NAME(sip) << "_frame")).str()
-#define OPTICAL_FRAME_ID(sip) (static_cast<std::ostringstream&&>(std::ostringstream() << "camera_" << STREAM_NAME(sip) << "_optical_frame")).str()
-#define ALIGNED_DEPTH_TO_FRAME_ID(sip) (static_cast<std::ostringstream&&>(std::ostringstream() << "camera_aligned_depth_to_" << STREAM_NAME(sip) << "_frame")).str()
+#define FRAME_ID(sip) (static_cast<std::ostringstream&&>(std::ostringstream() << getNamespaceStr() << "_" << STREAM_NAME(sip) << "_frame")).str()
+#define OPTICAL_FRAME_ID(sip) (static_cast<std::ostringstream&&>(std::ostringstream() << getNamespaceStr() << "_" << STREAM_NAME(sip) << "_optical_frame")).str()
+#define ALIGNED_DEPTH_TO_FRAME_ID(sip) (static_cast<std::ostringstream&&>(std::ostringstream() << getNamespaceStr() << "_aligned_depth_to_" << STREAM_NAME(sip) << "_frame")).str()
+#define BASE_FRAME_ID() (static_cast<std::ostringstream&&>(std::ostringstream() << getNamespaceStr() << "_link")).str()
+#define ODOM_FRAME_ID() (static_cast<std::ostringstream&&>(std::ostringstream() << getNamespaceStr() << "_odom_frame")).str()
 
 
 std::vector<std::string> split(const std::string& s, char delimiter) // Thanks to Jonathan Boccara (https://www.fluentcpp.com/2017/04/21/how-to-split-a-string-in-c/)
@@ -173,6 +175,13 @@ size_t SyncedImuPublisher::getNumSubscribers()
 {
     if (!_publisher) return 0;
     return _publisher->get_subscription_count();
+}
+
+std::string BaseRealSenseNode::getNamespaceStr()
+{
+    auto ns = _node.get_namespace();
+    //ns.erase(std::remove(ns.begin(), ns.end(), '/'), ns.end());
+    return ns;
 }
 
 static const rmw_qos_profile_t rmw_qos_profile_latched =
@@ -956,8 +965,8 @@ void BaseRealSenseNode::getParameters()
         param_name = "enable_" + STREAM_NAME(stream);
         setNgetNodeParameter(_enable[stream], param_name, ENABLE_IMU);
     }
-    setNgetNodeParameter(_base_frame_id, "base_frame_id", DEFAULT_BASE_FRAME_ID);
-    setNgetNodeParameter(_odom_frame_id, "odom_frame_id", DEFAULT_ODOM_FRAME_ID);
+    setNgetNodeParameter(_base_frame_id, "base_frame_id", BASE_FRAME_ID());
+    setNgetNodeParameter(_odom_frame_id, "odom_frame_id", ODOM_FRAME_ID());
 
     std::vector<stream_index_pair> streams(IMAGE_STREAMS);
     streams.insert(streams.end(), HID_STREAMS.begin(), HID_STREAMS.end());


### PR DESCRIPTION
Please see [Issue #2001](https://github.com/IntelRealSense/realsense-ros/issues/2001) for more information.

Basically, this changes naming of frame ID's in base_realsense_node.cpp, so that instead of generic "camera" camera name is used. Additionally, rs_multi_camera launch file starts one more node which publishes transformation information from camera1 to camera2. As cameras no longer have the same coordinate frame names, this transformation is necessary to get streams from both cameras. In final applications, this transformation would contain real world transformation of position of one camera to the other, but in the examples, all the values are set to 0.

Naming coordinate frames this way would make it easier for users to connect multiple cameras and not have to worry about renaming all frame ID's in either launch or config file. Finally, applications which use multiple cameras need to have a set transformation, as this is used in processing information (images), so that position of each pointcloud is set correctly.