### PR TITLE
Ros2 fix frameids

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,7 @@ install:
   - cd ~/ros2_ws
   - sudo rosdep init
   - rosdep update
-  - rosdep install -i --from-path src --rosdistro $_ros_dist -y
-  - sudo apt purge ros-$_ros_dist-librealsense2 -y
+  - rosdep install -i --from-path src --rosdistro $_ros_dist --skip-keys=librealsense2 -y
   - colcon build
 
   - . install/local_setup.bash

--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ This version supports ROS2 Dashing, Eloquent and Foxy.
   sudo apt-get install python3-rosdep -y
   sudo rosdep init # "sudo rosdep init --include-eol-distros" for Dashing
   rosdep update
-  rosdep install -i --from-path src --rosdistro $ROS_DISTRO -y
-  sudo apt purge ros-$ROS_DISTRO-librealsense2 -y
+  rosdep install -i --from-path src --rosdistro $_ros_dist --skip-keys=librealsense2 -y
   ```
 
   ### Step 5: Build:

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -179,7 +179,8 @@ size_t SyncedImuPublisher::getNumSubscribers()
 
 std::string BaseRealSenseNode::getNamespaceStr()
 {
-    auto ns = _node.get_namespace();
+    std::string ns(_node.get_namespace());
+    ns.erase (std::remove(ns.begin(), ns.end(), '/'), ns.end());
     return ns;
 }
 


### PR DESCRIPTION
Following #2128, the frame ids were added with a '/' header.
This PR fixes that.
