### PR TITLE
ROS2-beta delete metadata publisher

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -989,6 +989,12 @@ void BaseRealSenseNode::publishFrame(rs2::frame f, const rclcpp::Time& t,
         image = fix_depth_scale(image, _depth_scaled_image[stream]);
     }
 
+    if (info_publishers.find(stream) == info_publishers.end() ||
+        image_publishers.find(stream) == image_publishers.end())
+        {
+            // Stream is already disabled.
+            return;
+        }
     auto& info_publisher = info_publishers.at(stream);
     auto& image_publisher = image_publishers.at(stream);
     if(0 != info_publisher->get_subscription_count() ||

--- a/realsense2_camera/src/dynamic_params.cpp
+++ b/realsense2_camera/src/dynamic_params.cpp
@@ -21,7 +21,7 @@ namespace realsense2_camera
                         {}
                         catch(const std::exception& e)
                         {
-                            std::cerr << e.what() << '\n';
+                            std::cerr << e.what() << ":" << parameter.get_name() << '\n';
                         }                            
                     }
                     rcl_interfaces::msg::SetParametersResult result;

--- a/realsense2_camera/src/rs_node_setup.cpp
+++ b/realsense2_camera/src/rs_node_setup.cpp
@@ -164,6 +164,7 @@ void BaseRealSenseNode::stopPublishers(const std::vector<stream_profile>& profil
             _imu_publishers.erase(sip);
             _imu_info_publisher.erase(sip);
         }
+        _metadata_publishers.erase(sip);
     }
 }
 


### PR DESCRIPTION
Delete the metadata publisher when the stream is closed.
fix bug: try to publish a frame acquired before the stream was closed.