### PR TITLE
ROS2-Beta: Publish extrinsics topics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ After running the above command with D435i attached, the following list of topic
 - /camera/depth/camera_info
 - /camera/depth/color/points
 - /camera/depth/image_rect_raw
+- /camera/extrinsics/depth_to_color
 - /camera/imu
 - /diagnostics
 - /parameter_events
@@ -107,10 +108,13 @@ or in runtime using the following commands:
 ros2 param set /camera/camera enable_accel true
 ros2 param set /camera/camera enable_gyro true
 ```
-This will add the following topics:
+
+Enabling stream adds matching topics. For instance, enabling the gyro and accel streams adds the following topics:
 - /camera/accel/imu_info
 - /camera/accel/metadata
 - /camera/accel/sample
+- /camera/extrinsics/depth_to_accel
+- /camera/extrinsics/depth_to_gyro
 - /camera/gyro/imu_info
 - /camera/gyro/metadata
 - /camera/gyro/sample

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -144,6 +144,7 @@ namespace realsense2_camera
         std::shared_ptr<Parameters> _parameters;
         std::list<std::string> _parameters_names;
 
+        void publishExtrinsicsTopic(const stream_index_pair& sip, const rs2_extrinsics& ex);
         virtual void calcAndPublishStaticTransform(const rs2::stream_profile& profile, const rs2::stream_profile& base_profile);
         void getDeviceInfo(const realsense2_camera_msgs::srv::DeviceInfo::Request::SharedPtr req,
                                  realsense2_camera_msgs::srv::DeviceInfo::Response::SharedPtr res);
@@ -190,7 +191,7 @@ namespace realsense2_camera
         void startDynamicTf();
         void publishDynamicTransforms();
         void publishPointCloud(rs2::points f, const rclcpp::Time& t, const rs2::frameset& frameset);
-        Extrinsics rsExtrinsicsToMsg(const rs2_extrinsics& extrinsics, const std::string& frame_id) const;
+        Extrinsics rsExtrinsicsToMsg(const rs2_extrinsics& extrinsics) const;
 
         IMUInfo getImuInfo(const rs2::stream_profile& profile);
         void publishFrame(rs2::frame f, const rclcpp::Time& t,
@@ -257,6 +258,7 @@ namespace realsense2_camera
         std::map<stream_index_pair, rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr> _info_publisher;
         std::map<stream_index_pair, rclcpp::Publisher<realsense2_camera_msgs::msg::Metadata>::SharedPtr> _metadata_publishers;
         std::map<stream_index_pair, rclcpp::Publisher<IMUInfo>::SharedPtr> _imu_info_publisher;
+        std::map<stream_index_pair, rclcpp::Publisher<Extrinsics>::SharedPtr> _extrinsics_publishers;
         std::map<stream_index_pair, cv::Mat> _image;
         std::map<unsigned int, std::string> _encoding;
 

--- a/realsense2_camera/include/constants.h
+++ b/realsense2_camera/include/constants.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <string>
+#include <rclcpp/rclcpp.hpp>
 
 #define REALSENSE_ROS_MAJOR_VERSION    4
 #define REALSENSE_ROS_MINOR_VERSION    0
@@ -110,4 +111,17 @@ namespace realsense2_camera
     const std::string DEFAULT_TOPIC_ODOM_IN            = "";
 
     const float ROS_DEPTH_SCALE = 0.001;
+
+    static const rmw_qos_profile_t rmw_qos_profile_latched =
+    {
+        RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+        1,
+        RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+        RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,
+        RMW_QOS_DEADLINE_DEFAULT,
+        RMW_QOS_LIFESPAN_DEFAULT,
+        RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT,
+        RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT,
+        false
+    };
 }  // namespace realsense2_camera

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -775,6 +775,15 @@ void BaseRealSenseNode::publish_static_tf(const rclcpp::Time& t,
     _static_tf_msgs.push_back(msg);
 }
 
+void BaseRealSenseNode::publishExtrinsicsTopic(const stream_index_pair& sip, const rs2_extrinsics& ex){
+    // Publish extrinsics topic:
+    Extrinsics msg = rsExtrinsicsToMsg(ex);
+    if (_extrinsics_publishers.find(sip) != _extrinsics_publishers.end())
+    {
+        _extrinsics_publishers[sip]->publish(msg);
+    }
+}
+
 void BaseRealSenseNode::calcAndPublishStaticTransform(const rs2::stream_profile& profile, const rs2::stream_profile& base_profile)
 {
     // Transform base to stream
@@ -817,6 +826,7 @@ void BaseRealSenseNode::calcAndPublishStaticTransform(const rs2::stream_profile&
         publish_static_tf(transform_ts_, trans, Q, _base_frame_id, ALIGNED_DEPTH_TO_FRAME_ID(sip));
         publish_static_tf(transform_ts_, zero_trans, quaternion_optical, ALIGNED_DEPTH_TO_FRAME_ID(sip), OPTICAL_FRAME_ID(sip));
     }
+    publishExtrinsicsTopic(sip, ex);
 }
 
 void BaseRealSenseNode::SetBaseStream()
@@ -921,7 +931,7 @@ void BaseRealSenseNode::publishPointCloud(rs2::points pc, const rclcpp::Time& t,
 }
 
 
-Extrinsics BaseRealSenseNode::rsExtrinsicsToMsg(const rs2_extrinsics& extrinsics, const std::string& frame_id) const
+Extrinsics BaseRealSenseNode::rsExtrinsicsToMsg(const rs2_extrinsics& extrinsics) const
 {
     Extrinsics extrinsicsMsg;
     for (int i = 0; i < 9; ++i)
@@ -930,8 +940,6 @@ Extrinsics BaseRealSenseNode::rsExtrinsicsToMsg(const rs2_extrinsics& extrinsics
         if (i < 3)
             extrinsicsMsg.translation[i] = extrinsics.translation[i];
     }
-
-    extrinsicsMsg.header.frame_id = frame_id;
     return extrinsicsMsg;
 }
 

--- a/realsense2_camera/src/rs_node_setup.cpp
+++ b/realsense2_camera/src/rs_node_setup.cpp
@@ -172,6 +172,7 @@ void BaseRealSenseNode::stopPublishers(const std::vector<stream_profile>& profil
             _imu_info_publisher.erase(sip);
         }
         _metadata_publishers.erase(sip);
+        _extrinsics_publishers.erase(sip);
     }
 }
 
@@ -240,6 +241,14 @@ void BaseRealSenseNode::startPublishers(const std::vector<stream_profile>& profi
         rmw_qos_profile_t qos = sensor.getInfoQOS(sip);
         _metadata_publishers[sip] = _node.create_publisher<realsense2_camera_msgs::msg::Metadata>(topic_metadata, 
                                 rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos), qos));
+        
+        if (!((rs2::stream_profile)profile==(rs2::stream_profile)_base_profile))
+        {
+            qos = rmw_qos_profile_latched;
+            std::string topic_extrinsics("extrinsics/" + create_graph_resource_name(ros_stream_to_string(_base_profile.stream_type()) + "_to_" + stream_name));
+            _extrinsics_publishers[sip] = _node.create_publisher<realsense2_camera_msgs::msg::Extrinsics>(topic_extrinsics, 
+                                    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos), qos));
+        }
     }
 }
 

--- a/realsense2_camera_msgs/msg/Extrinsics.msg
+++ b/realsense2_camera_msgs/msg/Extrinsics.msg
@@ -1,3 +1,2 @@
-std_msgs/Header header
 float64[9] rotation
 float64[3] translation


### PR DESCRIPTION
extrinsics is published on topics `/camera/extrinsics/<base_profile>_to_<profile>`, for instance: `/camera/extrinsics/depth_to_infra2`
Also, add topic_hz.py - a more reliable test for messages publishing rate.