### PR TITLE
ROS2-beta: fixed align_depth parameter name in launch file

### DIFF
--- a/realsense2_camera/launch/rs_launch.py
+++ b/realsense2_camera/launch/rs_launch.py
@@ -52,7 +52,7 @@ configurable_parameters = [{'name': 'camera_name',                  'default': '
                            {'name': 'pointcloud.stream_filter',     'default': '2', 'description': 'texture stream for pointcloud'},
                            {'name': 'pointcloud.stream_index_filter','default': '0', 'description': 'texture stream index for pointcloud'},
                            {'name': 'enable_sync',                  'default': 'false', 'description': "''"},                           
-                           {'name': 'align_depth',                  'default': 'false', 'description': "''"},                           
+                           {'name': 'align_depth.enable',           'default': 'false', 'description': "''"},                           
                            {'name': 'clip_distance',                'default': '-2.', 'description': "''"},                           
                            {'name': 'linear_accel_cov',             'default': '0.01', 'description': "''"},                           
                            {'name': 'initial_reset',                'default': 'false', 'description': "''"},                           


### PR DESCRIPTION
rs_launch.py: fixed wrong parameter name, `align_depth` to `align_depth.enable`