### PR TITLE
rename camera_link frame_id

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - echo _python:$_python
   - echo _ros_dist:$_ros_dist
 
-  - sudo apt-key adv --keyserver keys.gnupg.net --recv-key C8B3A55A6F3EFCDE || sudo apt-key adv --keyserver hkp://keys.gnupg.net:80 --recv-key C8B3A55A6F3EFCDE
+  - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C8B3A55A6F3EFCDE || sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C8B3A55A6F3EFCDE
   - sudo add-apt-repository "deb https://librealsense.intel.com/Debian/apt-repo $(lsb_release -cs) main"
   - sudo apt-get update -qq
   - sudo apt-get install librealsense2-dkms --allow-unauthenticated -y

--- a/realsense2_camera/include/constants.h
+++ b/realsense2_camera/include/constants.h
@@ -97,7 +97,7 @@ namespace realsense2_camera
     const bool PUBLISH_ODOM_TF = true;
 
 
-    const std::string DEFAULT_BASE_FRAME_ID            = "camera_link";
+    const std::string DEFAULT_BASE_FRAME_ID            = "link";
     const std::string DEFAULT_ODOM_FRAME_ID            = "odom_frame";
     const std::string DEFAULT_IMU_OPTICAL_FRAME_ID     = "camera_imu_optical_frame";
 

--- a/realsense2_camera/src/parameters.cpp
+++ b/realsense2_camera/src/parameters.cpp
@@ -59,6 +59,7 @@ void BaseRealSenseNode::getParameters()
 
     param_name = std::string("base_frame_id");
     _base_frame_id = _parameters->setParam(param_name, rclcpp::ParameterValue(DEFAULT_BASE_FRAME_ID)).get<rclcpp::PARAMETER_STRING>();
+    _base_frame_id = (static_cast<std::ostringstream&&>(std::ostringstream() << _camera_name << "_" << _base_frame_id)).str();
     _parameters_names.push_back(param_name);
 }
 


### PR DESCRIPTION
When running rs_multi_camera_launch.py, both nodes publish a "camera_link" static frame, ignoring the names "camera1", "camera2"
This PR fixes the behavior of the "camera_link" frame_id to match the one shared by the rest of the frame_ids - to use the camera_name as a prefix.
In short: rename camera_link frame_id to <camera_name>_link