### PR TITLE
ROS2-fix multiple cameras initial_reset issue

### DIFF
--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -74,9 +74,9 @@ void RealSenseNodeFactory::getDevice(rs2::device_list list)
 		else
 		{
 			bool found = false;
+			rs2::device dev;
 			for (size_t count = 0; count < list.size(); count++)
 			{
-				rs2::device dev;
 				try
 				{
 					dev = list[count];


### PR DESCRIPTION
Based on @nomumu's suggestion at https://github.com/IntelRealSense/realsense-ros/issues/2188#issue-1071501021
This workaround solves the issue of resetting multiple devices at the same time.
The underlying issue may be lying inside librealsense2 but until a more thorough investigation can take place I think it's best to have this work-around merged.
This fix aims to solve issues #2188, 