### PR TITLE
Fix Metadata timestamps

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -227,7 +227,7 @@ namespace realsense2_camera
                           std::map<stream_index_pair, sensor_msgs::CameraInfo>& camera_info,
                           const std::map<rs2_stream, std::string>& encoding,
                           bool copy_data_from_frame = true);
-        void publishMetadata(rs2::frame f, const std::string& frame_id);
+        void publishMetadata(rs2::frame f, const ros::Time& header_time, const std::string& frame_id);
         bool getEnabledProfile(const stream_index_pair& stream_index, rs2::stream_profile& profile);
 
         void publishAlignedDepthToOthers(rs2::frameset frames, const ros::Time& t);

--- a/realsense2_camera/scripts/echo_metadada.py
+++ b/realsense2_camera/scripts/echo_metadada.py
@@ -8,6 +8,7 @@ import json
 def metadata_cb(msg):
     aa = json.loads(msg.json_data)
     os.system('clear')
+    print('header:', msg.header)
     print('\n'.join(['%10s:%-10s' % (key, str(value)) for key, value in aa.items()]))
 
 def main():


### PR DESCRIPTION
Aim to fix #2231, This PR sets metadata messages header time stamp to match images time stamp.
When synchronization is enabled, all the frames in a frameset get the same timestamp, the one that belongs to the first frame in the set. This is done to enable synchronization between them.
The header of the Metadata topics now gets the same timestamp. The individual frame's time is available in the data of the message.
