### PR TITLE
Fix clang compile errors

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -365,7 +365,7 @@ void BaseRealSenseNode::imu_callback(rs2::frame frame)
     }
 
     ROS_DEBUG("Frame arrived: stream: %s ; index: %d ; Timestamp Domain: %s",
-                ros_stream_to_string(frame.get_profile().stream_type()),
+                ros_stream_to_string(frame.get_profile().stream_type()).c_str(),
                 frame.get_profile().stream_index(),
                 rs2_timestamp_domain_to_string(frame.get_frame_timestamp_domain()));
 
@@ -392,7 +392,7 @@ void BaseRealSenseNode::imu_callback(rs2::frame frame)
         }
         imu_msg.header.stamp = t;
         _imu_publishers[stream_index]->publish(imu_msg);
-        ROS_DEBUG("Publish %s stream", ros_stream_to_string(frame.get_profile().stream_type()));
+        ROS_DEBUG("Publish %s stream", ros_stream_to_string(frame.get_profile().stream_type()).c_str());
     }
     publishMetadata(frame, t, OPTICAL_FRAME_ID(stream_index));
 }


### PR DESCRIPTION
When building the `ros2-beta` branch with clang 14, some compile errors occur:
```
/home/user/repos/rmua-2022/realsense-ros/realsense2_camera/src/base_realsense_node.cpp:368:17: error: cannot pass non-trivial object of type 'std::string' (aka 'basic_string<char>') to variadic function; expected type from format string was 'char *' [-Wnon-pod-varargs]
                ros_stream_to_string(frame.get_profile().stream_type()),
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/user/repos/rmua-2022/realsense-ros/realsense2_camera/include/constants.h:18:46: note: expanded from macro 'ROS_DEBUG'
#define ROS_DEBUG(...) RCLCPP_DEBUG(_logger, __VA_ARGS__)
                                             ^~~~~~~~~~~
/opt/ros/rolling/include/rclcpp/logging.hpp:102:7: note: expanded from macro 'RCLCPP_DEBUG'
      __VA_ARGS__); \
      ^~~~~~~~~~~
/opt/ros/rolling/include/rcutils/logging_macros.h:256:5: note: expanded from macro 'RCUTILS_LOG_DEBUG_NAMED'
    __VA_ARGS__)
    ^~~~~~~~~~~
/opt/ros/rolling/include/rcutils/logging_macros.h:72:64: note: expanded from macro 'RCUTILS_LOG_COND_NAMED'
      rcutils_log(&__rcutils_logging_location, severity, name, __VA_ARGS__); \
                                                               ^~~~~~~~~~~
/home/user/repos/rmua-2022/realsense-ros/realsense2_camera/src/base_realsense_node.cpp:368:17: note: did you mean to call the c_str() method?
/home/user/repos/rmua-2022/realsense-ros/realsense2_camera/src/base_realsense_node.cpp:395:40: error: cannot pass non-trivial object of type 'std::string' (aka 'basic_string<char>') to variadic function; expected type from format string was 'char *' [-Wnon-pod-varargs]
        ROS_DEBUG("Publish %s stream", ros_stream_to_string(frame.get_profile().stream_type()));
                           ~~          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/user/repos/rmua-2022/realsense-ros/realsense2_camera/include/constants.h:18:46: note: expanded from macro 'ROS_DEBUG'
#define ROS_DEBUG(...) RCLCPP_DEBUG(_logger, __VA_ARGS__)
                                             ^~~~~~~~~~~
/opt/ros/rolling/include/rclcpp/logging.hpp:102:7: note: expanded from macro 'RCLCPP_DEBUG'
      __VA_ARGS__); \
      ^~~~~~~~~~~
/opt/ros/rolling/include/rcutils/logging_macros.h:256:5: note: expanded from macro 'RCUTILS_LOG_DEBUG_NAMED'
    __VA_ARGS__)
    ^~~~~~~~~~~
/opt/ros/rolling/include/rcutils/logging_macros.h:72:64: note: expanded from macro 'RCUTILS_LOG_COND_NAMED'
      rcutils_log(&__rcutils_logging_location, severity, name, __VA_ARGS__); \
                                                               ^~~~~~~~~~~
/home/user/repos/rmua-2022/realsense-ros/realsense2_camera/src/base_realsense_node.cpp:395:40: note: did you mean to call the c_str() method?
```
This PR fixes these errors.