### PR TITLE
ROS2-beta: fix galactic issue with undeclaring parameters

### DIFF
--- a/realsense2_camera/include/dynamic_params.h
+++ b/realsense2_camera/include/dynamic_params.h
@@ -11,21 +11,25 @@ namespace realsense2_camera
         public:
             Parameters(rclcpp::Node& node);
             ~Parameters();
-            rclcpp::ParameterValue setParam(std::string param_name, const rclcpp::ParameterValue& initial_value, 
-                                            std::function<void(const rclcpp::Parameter&)> func = std::function<void(const rclcpp::Parameter&)>(),
-                                            rcl_interfaces::msg::ParameterDescriptor descriptor=rcl_interfaces::msg::ParameterDescriptor());
-
-            rclcpp::ParameterValue readAndDeleteParam(std::string param_name, const rclcpp::ParameterValue& initial_value);
             template <class T>
-            void setParamT(std::string param_name, const rclcpp::ParameterValue& initial_value, 
-                           T& param,
+            T setParam(std::string param_name, const T& initial_value, 
+                                    std::function<void(const rclcpp::Parameter&)> func = std::function<void(const rclcpp::Parameter&)>(), 
+                                    rcl_interfaces::msg::ParameterDescriptor descriptor=rcl_interfaces::msg::ParameterDescriptor());
+
+            template <class T>
+            T readAndDeleteParam(std::string param_name, const T& initial_value);
+
+            template <class T>
+            void setParamT(std::string param_name, T& param,
                            std::function<void(const rclcpp::Parameter&)> func = std::function<void(const rclcpp::Parameter&)>(),
                            rcl_interfaces::msg::ParameterDescriptor descriptor=rcl_interfaces::msg::ParameterDescriptor());
             template <class T>
             void setParamValue(T& param, const T& value); // function updates the parameter value both locally and in the parameters server
+
             void setRosParamValue(const std::string param_name, void const* const value); // function updates the parameters server
             void removeParam(std::string param_name);
             void pushUpdateFunctions(std::vector<std::function<void()> > funcs);
+
             template <class T>
             void queueSetRosValue(const std::string& param_name, const T value);
             

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -76,8 +76,10 @@ BaseRealSenseNode::BaseRealSenseNode(rclcpp::Node& node,
     // _rs_diagnostic_updater(diagnostic_updater, serial_no),
     _dev(dev),
     _json_file_path(""),
+    _tf_publish_rate(TF_PUBLISH_RATE),
     _static_tf_broadcaster(node),
     _is_initialized_time_base(false),
+    _sync_frames(SYNC_FRAMES),
     _is_profile_changed(false)
 {
     _image_format[1] = CV_8UC1;    // CVBridge type

--- a/realsense2_camera/src/dynamic_params.cpp
+++ b/realsense2_camera/src/dynamic_params.cpp
@@ -101,7 +101,7 @@ namespace realsense2_camera
         {
             ROS_DEBUG_STREAM("setParam::Setting parameter: " << param_name);
 #if defined(GALACTIC) || defined(ROLLING)
-            descriptor.dynamic_typing=true;
+            descriptor.dynamic_typing=true; // Without this, undeclare_parameter() throws in Galactic onward.
 #endif
             if (!_node.get_parameter(param_name, result_value))
             {
@@ -143,7 +143,9 @@ namespace realsense2_camera
         return result_value;
     }
 
-
+    // setParamT: Used to automatically update param based on its parallel ros parameter.
+    // Notice: param must remain alive as long as the callback is active - 
+    //      if param is destroyed the behavior of the callback is undefined.
     template <class T>
     void Parameters::setParamT(std::string param_name, T& param, 
                               std::function<void(const rclcpp::Parameter&)> func,
@@ -189,6 +191,7 @@ namespace realsense2_camera
         }                            
     }
 
+    // setRosParamValue - Used to set ROS parameter back to a valid value if an invalid value was set by user.
     void Parameters::setRosParamValue(const std::string param_name, void const* const value)
     {
         // setRosParamValue sets a value to a parameter in the parameters server.
@@ -225,6 +228,7 @@ namespace realsense2_camera
         }
     }
 
+    // queueSetRosValue - Set parameter in queue to be pushed to ROS parameter by monitor_update_functions
     template <class T>
     void Parameters::queueSetRosValue(const std::string& param_name, const T value)
     {

--- a/realsense2_camera/src/dynamic_params.cpp
+++ b/realsense2_camera/src/dynamic_params.cpp
@@ -99,8 +99,8 @@ namespace realsense2_camera
         T result_value(initial_value);
         try
         {
-            ROS_INFO_STREAM("setParam::Setting parameter: " << param_name);
-#ifdef GALACTIC            
+            ROS_DEBUG_STREAM("setParam::Setting parameter: " << param_name);
+#if defined(GALACTIC) || defined(ROLLING)
             descriptor.dynamic_typing=true;
 #endif
             if (!_node.get_parameter(param_name, result_value))

--- a/realsense2_camera/src/dynamic_params.cpp
+++ b/realsense2_camera/src/dynamic_params.cpp
@@ -82,38 +82,30 @@ namespace realsense2_camera
         // remove_on_set_parameters_callback(_params_backend);
     }
 
-
-    rclcpp::ParameterValue Parameters::readAndDeleteParam(std::string param_name, const rclcpp::ParameterValue& initial_value)
+    template <class T>
+    T Parameters::readAndDeleteParam(std::string param_name, const T& initial_value)
     {
         // Function is meant for reading parameters needed in initialization but should not be declared by the app.
-        rclcpp::ParameterValue result_value(initial_value);
-        if (!_node.has_parameter(param_name))
-        {
-            result_value = _node.declare_parameter(param_name, rclcpp::ParameterValue(initial_value));
-            _node.undeclare_parameter(param_name);
-        }
-        else
-        {
-            result_value = _node.get_parameter(param_name).get_parameter_value();
-        }
+        T result_value = setParam(param_name, initial_value);
+        removeParam(param_name);
         return result_value;
     }
 
-    rclcpp::ParameterValue Parameters::setParam(std::string param_name, const rclcpp::ParameterValue& initial_value, 
+    template <class T>
+    T Parameters::setParam(std::string param_name, const T& initial_value, 
                               std::function<void(const rclcpp::Parameter&)> func, 
                               rcl_interfaces::msg::ParameterDescriptor descriptor)
     {
-        rclcpp::ParameterValue result_value(initial_value);
+        T result_value(initial_value);
         try
         {
-            ROS_DEBUG_STREAM("setParam::Setting parameter: " << param_name);
-            if (!_node.has_parameter(param_name))
+            ROS_INFO_STREAM("setParam::Setting parameter: " << param_name);
+#ifdef GALACTIC            
+            descriptor.dynamic_typing=true;
+#endif
+            if (!_node.get_parameter(param_name, result_value))
             {
                 result_value = _node.declare_parameter(param_name, initial_value, descriptor);
-            }
-            else
-            {
-                result_value = _node.get_parameter(param_name).get_parameter_value();
             }
         }
         catch(const std::exception& e)
@@ -128,7 +120,7 @@ namespace realsense2_camera
                 range << val.from_value << ", " << val.to_value;
             }
             ROS_WARN_STREAM("Could not set param: " << param_name << " with " << 
-                             rclcpp::Parameter(param_name, initial_value).value_to_string() << 
+                             initial_value << 
                             " Range: [" << range.str() << "]" <<
                              ": " << e.what());
             return initial_value;
@@ -153,24 +145,17 @@ namespace realsense2_camera
 
 
     template <class T>
-    void Parameters::setParamT(std::string param_name, const rclcpp::ParameterValue& initial_value, 
-                              T& param, 
+    void Parameters::setParamT(std::string param_name, T& param, 
                               std::function<void(const rclcpp::Parameter&)> func,
                               rcl_interfaces::msg::ParameterDescriptor descriptor)
+
     {
-        // NOTICE: callback function is set AFTER the parameter is declared!!!
-        if (!_node.has_parameter(param_name))
-            param = _node.declare_parameter(param_name, initial_value, descriptor).get<T>();
-        else
-        {
-            param = _node.get_parameter(param_name).get_parameter_value().get<T>();
-        }        
-        _param_functions[param_name] = [&param, func](const rclcpp::Parameter& parameter)
-            {
-                param = parameter.get_value<T>();
-                if (func) func(parameter);
-            };
-        _param_names[&param] = param_name;
+    param = setParam<T>(param_name, param, 
+                          [&param, func](const rclcpp::Parameter& parameter)
+                                        {
+                                            param = parameter.get_value<T>();
+                                            if (func) func(parameter);
+                                        }, descriptor);
     }
 
     template <class T>
@@ -258,9 +243,14 @@ namespace realsense2_camera
         _param_functions.erase(param_name);
     }
 
-    template void Parameters::setParamT<bool>(std::string param_name, const rclcpp::ParameterValue& initial_value, bool& param, std::function<void(const rclcpp::Parameter&)> func, rcl_interfaces::msg::ParameterDescriptor descriptor);
-    template void Parameters::setParamT<int>(std::string param_name, const rclcpp::ParameterValue& initial_value, int& param, std::function<void(const rclcpp::Parameter&)> func, rcl_interfaces::msg::ParameterDescriptor descriptor);
-    template void Parameters::setParamT<double>(std::string param_name, const rclcpp::ParameterValue& initial_value, double& param, std::function<void(const rclcpp::Parameter&)> func, rcl_interfaces::msg::ParameterDescriptor descriptor);
+    template void Parameters::setParamT<bool>(std::string param_name, bool& param, std::function<void(const rclcpp::Parameter&)> func, rcl_interfaces::msg::ParameterDescriptor descriptor);
+    template void Parameters::setParamT<int>(std::string param_name, int& param, std::function<void(const rclcpp::Parameter&)> func, rcl_interfaces::msg::ParameterDescriptor descriptor);
+    template void Parameters::setParamT<double>(std::string param_name, double& param, std::function<void(const rclcpp::Parameter&)> func, rcl_interfaces::msg::ParameterDescriptor descriptor);
+
+    template bool Parameters::setParam<bool>(std::string param_name, const bool& initial_value, std::function<void(const rclcpp::Parameter&)> func, rcl_interfaces::msg::ParameterDescriptor descriptor);
+    template int Parameters::setParam<int>(std::string param_name, const int& initial_value, std::function<void(const rclcpp::Parameter&)> func, rcl_interfaces::msg::ParameterDescriptor descriptor);
+    template double Parameters::setParam<double>(std::string param_name, const double& initial_value, std::function<void(const rclcpp::Parameter&)> func, rcl_interfaces::msg::ParameterDescriptor descriptor);
+    template std::string Parameters::setParam<std::string>(std::string param_name, const std::string& initial_value, std::function<void(const rclcpp::Parameter&)> func, rcl_interfaces::msg::ParameterDescriptor descriptor);
 
     template void Parameters::setParamValue<int>(int& param, const int& value);
     template void Parameters::setParamValue<bool>(bool& param, const bool& value);
@@ -268,4 +258,6 @@ namespace realsense2_camera
 
     template void Parameters::queueSetRosValue<std::string>(const std::string& param_name, const std::string value);
     template void Parameters::queueSetRosValue<int>(const std::string& param_name, const int value);
+
+    template int Parameters::readAndDeleteParam<int>(std::string param_name, const int& initial_value);
 }

--- a/realsense2_camera/src/named_filter.cpp
+++ b/realsense2_camera/src/named_filter.cpp
@@ -84,7 +84,6 @@ void PointcloudFilter::setParameters()
                     _params.getParameters()->queueSetRosValue(parameter.get_name(), _pointcloud_qos);
                 }
             }, crnt_descriptor);
-    ROS_WARN_STREAM("1._pointcloud_qos:" << _pointcloud_qos);
     _parameters_names.push_back(param_name);
     NamedFilter::setParameters([this](const rclcpp::Parameter& )
         {
@@ -97,11 +96,9 @@ void PointcloudFilter::setPublisher()
     std::lock_guard<std::mutex> lock_guard(_mutex_publisher);
     if ((_is_enabled) && (!_pointcloud_publisher))
     {
-        ROS_WARN_STREAM("_node.create_publisher");
         _pointcloud_publisher = _node.create_publisher<sensor_msgs::msg::PointCloud2>("depth/color/points", 
                                 rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_string_to_qos(_pointcloud_qos)),
                                             qos_string_to_qos(_pointcloud_qos)));
-        ROS_WARN_STREAM("_node.create_publisher - Done");
     }
     else if ((!_is_enabled) && (_pointcloud_publisher))
     {

--- a/realsense2_camera/src/named_filter.cpp
+++ b/realsense2_camera/src/named_filter.cpp
@@ -20,7 +20,7 @@ void NamedFilter::setParameters(std::function<void(const rclcpp::Parameter&)> en
     _params.registerDynamicOptions(*(_filter.get()), module_name_str.str());
     module_name_str << ".enable";
 
-    _params.getParameters()->setParamT(module_name_str.str(), rclcpp::ParameterValue(_is_enabled), _is_enabled, enable_param_func);
+    _params.getParameters()->setParamT(module_name_str.str(), _is_enabled, enable_param_func);
     _parameters_names.push_back(module_name_str.str());
 }
 
@@ -49,31 +49,28 @@ rs2::frameset NamedFilter::Process(rs2::frameset frameset)
 
 PointcloudFilter::PointcloudFilter(std::shared_ptr<rs2::filter> filter, rclcpp::Node& node, std::shared_ptr<Parameters> parameters, rclcpp::Logger logger, bool is_enabled):
     NamedFilter(filter, parameters, logger, is_enabled, false),
-    _node(node)
+    _node(node),
+    _allow_no_texture_points(ALLOW_NO_TEXTURE_POINTS),
+    _ordered_pc(ORDERED_PC)
     {
         setParameters();
     }
 
 void PointcloudFilter::setParameters()
 {
-    NamedFilter::setParameters([this](const rclcpp::Parameter& )
-        {
-            setPublisher();
-        });
-
     std::string module_name = create_graph_resource_name(rs2_to_ros(_filter->get_info(RS2_CAMERA_INFO_NAME)));
     std::string param_name(module_name + "." + "allow_no_texture_points");
-    _params.getParameters()->setParamT(param_name, rclcpp::ParameterValue(ALLOW_NO_TEXTURE_POINTS), _allow_no_texture_points);
+    _params.getParameters()->setParamT(param_name, _allow_no_texture_points);
     _parameters_names.push_back(param_name);
 
     param_name = module_name + "." + std::string("ordered_pc");
-    _params.getParameters()->setParamT(param_name, rclcpp::ParameterValue(ORDERED_PC), _ordered_pc);
+    _params.getParameters()->setParamT(param_name, _ordered_pc);
     _parameters_names.push_back(param_name);
 
     param_name = module_name + "." + std::string("pointcloud_qos");
     rcl_interfaces::msg::ParameterDescriptor crnt_descriptor;
     crnt_descriptor.description = "Available options are:\n" + list_available_qos_strings();
-    _pointcloud_qos = _params.getParameters()->setParam(param_name, rclcpp::ParameterValue(DEFAULT_QOS), [this](const rclcpp::Parameter& parameter)
+    _pointcloud_qos = _params.getParameters()->setParam<std::string>(param_name, DEFAULT_QOS, [this](const rclcpp::Parameter& parameter)
             {
                 try
                 {
@@ -86,9 +83,13 @@ void PointcloudFilter::setParameters()
                     ROS_ERROR_STREAM("Given value, " << parameter.get_value<std::string>() << " is unknown. Set ROS param back to: " << _pointcloud_qos);
                     _params.getParameters()->queueSetRosValue(parameter.get_name(), _pointcloud_qos);
                 }
-            }, crnt_descriptor).get<rclcpp::PARAMETER_STRING>();
+            }, crnt_descriptor);
+    ROS_WARN_STREAM("1._pointcloud_qos:" << _pointcloud_qos);
     _parameters_names.push_back(param_name);
-    setPublisher();
+    NamedFilter::setParameters([this](const rclcpp::Parameter& )
+        {
+            setPublisher();
+        });
 }
 
 void PointcloudFilter::setPublisher() 
@@ -96,9 +97,11 @@ void PointcloudFilter::setPublisher()
     std::lock_guard<std::mutex> lock_guard(_mutex_publisher);
     if ((_is_enabled) && (!_pointcloud_publisher))
     {
+        ROS_WARN_STREAM("_node.create_publisher");
         _pointcloud_publisher = _node.create_publisher<sensor_msgs::msg::PointCloud2>("depth/color/points", 
                                 rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_string_to_qos(_pointcloud_qos)),
                                             qos_string_to_qos(_pointcloud_qos)));
+        ROS_WARN_STREAM("_node.create_publisher - Done");
     }
     else if ((!_is_enabled) && (_pointcloud_publisher))
     {

--- a/realsense2_camera/src/parameters.cpp
+++ b/realsense2_camera/src/parameters.cpp
@@ -10,15 +10,15 @@ void BaseRealSenseNode::getParameters()
 
     std::string param_name;
     param_name = std::string("camera_name");
-    _camera_name = _parameters->setParam(param_name, rclcpp::ParameterValue("camera")).get<rclcpp::PARAMETER_STRING>();
+    _camera_name = _parameters->setParam<std::string>(param_name, "camera");
     _parameters_names.push_back(param_name);
 
     param_name = std::string("publish_tf");
-    _publish_tf = _parameters->setParam(param_name, rclcpp::ParameterValue(PUBLISH_TF)).get<rclcpp::PARAMETER_BOOL>();
+    _publish_tf = _parameters->setParam<bool>(param_name, PUBLISH_TF);
     _parameters_names.push_back(param_name);
 
     param_name = std::string("tf_publish_rate");
-    _parameters->setParamT(param_name, rclcpp::ParameterValue(TF_PUBLISH_RATE), _tf_publish_rate, [this](const rclcpp::Parameter& )
+    _parameters->setParamT(param_name, _tf_publish_rate, [this](const rclcpp::Parameter& )
             {
                 startDynamicTf();
             });
@@ -26,39 +26,39 @@ void BaseRealSenseNode::getParameters()
     startDynamicTf();
 
     param_name = std::string("diagnostics_period");
-    _diagnostics_period = _parameters->setParam(param_name, rclcpp::ParameterValue(DIAGNOSTICS_PERIOD)).get<rclcpp::PARAMETER_DOUBLE>();
+    _diagnostics_period = _parameters->setParam<double>(param_name, DIAGNOSTICS_PERIOD);
     _parameters_names.push_back(param_name);
 
     param_name = std::string("enable_sync");
-    _parameters->setParamT(param_name, rclcpp::ParameterValue(SYNC_FRAMES), _sync_frames);
+    _parameters->setParamT(param_name, _sync_frames);
     _parameters_names.push_back(param_name);
 
     param_name = std::string("json_file_path");
-    _json_file_path = _parameters->setParam(param_name, rclcpp::ParameterValue("")).get<rclcpp::PARAMETER_STRING>();
+    _json_file_path = _parameters->setParam<std::string>(param_name, "");
     _parameters_names.push_back(param_name);
 
     param_name = std::string("clip_distance");
-    _clipping_distance = _parameters->setParam(param_name, rclcpp::ParameterValue(-1.0)).get<rclcpp::PARAMETER_DOUBLE>();
+    _clipping_distance = _parameters->setParam<double>(param_name, -1.0);
     _parameters_names.push_back(param_name);
 
     param_name = std::string("linear_accel_cov");
-    _linear_accel_cov = _parameters->setParam(param_name, rclcpp::ParameterValue(0.01)).get<rclcpp::PARAMETER_DOUBLE>();
+    _linear_accel_cov = _parameters->setParam<double>(param_name, 0.01);
     _parameters_names.push_back(param_name);
 
     param_name = std::string("angular_velocity_cov");
-    _angular_velocity_cov = _parameters->setParam(param_name, rclcpp::ParameterValue(0.01)).get<rclcpp::PARAMETER_DOUBLE>();
+    _angular_velocity_cov = _parameters->setParam<double>(param_name, 0.01);
     _parameters_names.push_back(param_name);
    
     param_name = std::string("hold_back_imu_for_frames");
-    _hold_back_imu_for_frames = _parameters->setParam(param_name, rclcpp::ParameterValue(HOLD_BACK_IMU_FOR_FRAMES)).get<rclcpp::PARAMETER_BOOL>();
+    _hold_back_imu_for_frames = _parameters->setParam<bool>(param_name, HOLD_BACK_IMU_FOR_FRAMES);
     _parameters_names.push_back(param_name);
 
     param_name = std::string("publish_odom_tf");
-    _publish_odom_tf = _parameters->setParam(param_name, rclcpp::ParameterValue(PUBLISH_ODOM_TF)).get<rclcpp::PARAMETER_BOOL>();
+    _publish_odom_tf = _parameters->setParam<bool>(param_name, PUBLISH_ODOM_TF);
     _parameters_names.push_back(param_name);
 
     param_name = std::string("base_frame_id");
-    _base_frame_id = _parameters->setParam(param_name, rclcpp::ParameterValue(DEFAULT_BASE_FRAME_ID)).get<rclcpp::PARAMETER_STRING>();
+    _base_frame_id = _parameters->setParam<std::string>(param_name, DEFAULT_BASE_FRAME_ID);
     _base_frame_id = (static_cast<std::ostringstream&&>(std::ostringstream() << _camera_name << "_" << _base_frame_id)).str();
     _parameters_names.push_back(param_name);
 }
@@ -107,7 +107,7 @@ void BaseRealSenseNode::setDynamicParams()
     std::stringstream desc;
     desc << "Available options are:" << std::endl << enum_str_values.str();
     crnt_descriptor.description = desc.str();
-    _parameters->setParam(param_name, rclcpp::ParameterValue(int(imu_sync_method::NONE)), 
+    _parameters->setParam<int>(param_name, int(imu_sync_method::NONE), 
                             [this](const rclcpp::Parameter& parameter)
                             {
                                 _imu_sync_method = imu_sync_method(parameter.get_value<int>());

--- a/realsense2_camera/src/profile_manager.cpp
+++ b/realsense2_camera/src/profile_manager.cpp
@@ -42,7 +42,7 @@ void ProfilesManager::registerSensorQOSParam(std::string template_name,
         std::shared_ptr<std::string> param = params[sip];
         rcl_interfaces::msg::ParameterDescriptor crnt_descriptor;
         crnt_descriptor.description = "Available options are:\n" + list_available_qos_strings();
-        rclcpp::ParameterValue aa = _params.getParameters()->setParam(param_name, rclcpp::ParameterValue(value), [this, param](const rclcpp::Parameter& parameter)
+        _params.getParameters()->setParam<std::string>(param_name, value, [this, param](const rclcpp::Parameter& parameter)
                 {
                     try
                     {
@@ -76,7 +76,7 @@ void ProfilesManager::registerSensorUpdateParam(std::string template_name,
         if (params.find(sip) == params.end())
             params[sip] = std::make_shared<T>(value);
         std::shared_ptr<T> param = params[sip];
-        rclcpp::ParameterValue aa = _params.getParameters()->setParam(param_name, rclcpp::ParameterValue(*(params[sip])), [param, update_sensor_func](const rclcpp::Parameter& parameter)
+        _params.getParameters()->setParam<T>(param_name, *(params[sip]), [param, update_sensor_func](const rclcpp::Parameter& parameter)
                 {
                     *param = parameter.get_value<T>();
                     update_sensor_func();
@@ -264,7 +264,7 @@ void VideoProfilesManager::registerVideoSensorParams()
     crnt_descriptor.description = "Available options are:\n" + get_profiles_descriptions();
     std::stringstream crnt_profile_str;
     crnt_profile_str << _width << "x" << _height << "x" << _fps;
-    rclcpp::ParameterValue aa = _params.getParameters()->setParam(param_name, rclcpp::ParameterValue(crnt_profile_str.str()), [this](const rclcpp::Parameter& parameter)
+    _params.getParameters()->setParam<std::string>(param_name, crnt_profile_str.str(), [this](const rclcpp::Parameter& parameter)
             {
                 std::regex self_regex("\\s*([0-9]+)\\s*[xX,]\\s*([0-9]+)\\s*[xX,]\\s*([0-9]+)\\s*", std::regex_constants::ECMAScript);
                 std::smatch match;
@@ -388,7 +388,7 @@ void MotionProfilesManager::registerFPSParams()
         crnt_descriptor.description = "Available options are:\n" + description;
         std::shared_ptr<int> param(_fps[sip]);
         std::vector<int> available_values(sips_fps_values[sip]);
-        rclcpp::ParameterValue aa = _params.getParameters()->setParam(param_name, rclcpp::ParameterValue(*(fps.second)), [this, sip](const rclcpp::Parameter& parameter)
+        _params.getParameters()->setParam<int>(param_name, *(fps.second), [this, sip](const rclcpp::Parameter& parameter)
             {
                 int next_fps(parameter.get_value<int>());
                 bool found(false);

--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -265,7 +265,7 @@ void RealSenseNodeFactory::init()
 		_usb_port_id = declare_parameter("usb_port_id", rclcpp::ParameterValue("")).get<rclcpp::PARAMETER_STRING>();
 		_device_type = declare_parameter("device_type", rclcpp::ParameterValue("")).get<rclcpp::PARAMETER_STRING>();
     	_wait_for_device_timeout = declare_parameter("wait_for_device_timeout", rclcpp::ParameterValue(-1.0)).get<rclcpp::PARAMETER_DOUBLE>();
-    	_reconnect_timeout = declare_parameter("reconnect_timeout", rclcpp::ParameterValue(6.0)).get<rclcpp::PARAMETER_DOUBLE>();
+    	_reconnect_timeout = declare_parameter("reconnect_timeout", 6.0);
 
 		// A ROS2 hack: until a better way is found to avoid auto convertion of strings containing only digits to integers:
 		if (_serial_no.front() == '_') _serial_no = _serial_no.substr(1);	// remove '_' prefix

--- a/realsense2_camera/src/ros_sensor.cpp
+++ b/realsense2_camera/src/ros_sensor.cpp
@@ -79,7 +79,7 @@ void RosSensor::UpdateSequenceIdCallback()
             std::stringstream param_name_str;
             param_name_str << module_name << "." << create_graph_resource_name(rs2_option_to_string(option)) << "." << seq_id;
             int option_value = get_option(option);
-            int user_set_option_value = _params.getParameters()->readAndDeleteParam(param_name_str.str(), rclcpp::ParameterValue(option_value)).get<rclcpp::PARAMETER_INTEGER>();
+            int user_set_option_value = _params.getParameters()->readAndDeleteParam(param_name_str.str(), option_value);
             if (option_value != user_set_option_value)
             {
                 ROS_INFO_STREAM("Set " << rs2_option_to_string(option) << "." << seq_id << " to " << user_set_option_value);
@@ -94,7 +94,7 @@ void RosSensor::UpdateSequenceIdCallback()
     try
     {
         int option_value = static_cast<int>(get_option(RS2_OPTION_SEQUENCE_ID));
-        _params.getParameters()->setParam(option_name, rclcpp::ParameterValue(option_value), 
+        _params.getParameters()->setParam<int>(option_name, option_value, 
             [this](const rclcpp::Parameter& parameter)
             {
                 set_option(RS2_OPTION_SEQUENCE_ID, parameter.get_value<int>());
@@ -356,19 +356,19 @@ void RosSensor::registerAutoExposureROIOptions()
 
         ROS_DEBUG_STREAM("Publish roi for " << module_name);
         std::string param_name(module_name + ".left");
-        _params.getParameters()->setParamT(param_name, rclcpp::ParameterValue(0),     _auto_exposure_roi.min_x, [this](const rclcpp::Parameter&){set_sensor_auto_exposure_roi();});
+        _params.getParameters()->setParamT(param_name, _auto_exposure_roi.min_x, [this](const rclcpp::Parameter&){set_sensor_auto_exposure_roi();});
         _parameters_names.push_back(param_name);
 
         param_name = std::string(module_name + ".right");
-        _params.getParameters()->setParamT(module_name + ".right", rclcpp::ParameterValue(max_x), _auto_exposure_roi.max_x, [this](const rclcpp::Parameter&){set_sensor_auto_exposure_roi();});
+        _params.getParameters()->setParamT(module_name + ".right", _auto_exposure_roi.max_x, [this](const rclcpp::Parameter&){set_sensor_auto_exposure_roi();});
         _parameters_names.push_back(param_name);
 
         param_name = std::string(module_name + ".top");
-        _params.getParameters()->setParamT(module_name + ".top", rclcpp::ParameterValue(0),     _auto_exposure_roi.min_y, [this](const rclcpp::Parameter&){set_sensor_auto_exposure_roi();});
+        _params.getParameters()->setParamT(module_name + ".top", _auto_exposure_roi.min_y, [this](const rclcpp::Parameter&){set_sensor_auto_exposure_roi();});
         _parameters_names.push_back(param_name);
 
         param_name = std::string(module_name + ".bottom");
-        _params.getParameters()->setParamT(module_name + ".bottom", rclcpp::ParameterValue(max_y), _auto_exposure_roi.max_y, [this](const rclcpp::Parameter&){set_sensor_auto_exposure_roi();});
+        _params.getParameters()->setParamT(module_name + ".bottom", _auto_exposure_roi.max_y, [this](const rclcpp::Parameter&){set_sensor_auto_exposure_roi();});
         _parameters_names.push_back(param_name);
     }
 }

--- a/realsense2_camera/src/sensor_params.cpp
+++ b/realsense2_camera/src/sensor_params.cpp
@@ -123,11 +123,10 @@ void SensorParams::set_parameter(rs2::options sensor, rs2_option option, const s
     T new_val;
     try
     {
-        rclcpp::ParameterValue pValue = (_parameters->setParam(option_name, rclcpp::ParameterValue(option_value), [option, sensor](const rclcpp::Parameter& parameter)
+        new_val = (_parameters->setParam<T>(option_name, option_value, [option, sensor](const rclcpp::Parameter& parameter)
                     {
                         param_set_option<T>(sensor, option, parameter);
                     }, crnt_descriptor));
-        new_val = pValue.get<T>();
         _parameters_names.push_back(option_name);
     }
     catch(const rclcpp::exceptions::InvalidParameterValueException& e)

--- a/realsense2_camera/src/t265_realsense_node.cpp
+++ b/realsense2_camera/src/t265_realsense_node.cpp
@@ -18,7 +18,7 @@ void T265RealsenseNode::initializeOdometryInput()
 {
     std::string calib_odom_file;
     std::string param_name("calib_odom_file");
-    calib_odom_file = _parameters->setParam(param_name, rclcpp::ParameterValue("")).get<rclcpp::PARAMETER_STRING>();
+    calib_odom_file = _parameters->setParam<std::string>(param_name, "");
     if (calib_odom_file.empty())
     {
         ROS_INFO("No calib_odom_file. No input odometry accepted.");
@@ -54,7 +54,7 @@ void T265RealsenseNode::setupSubscribers()
 {
     if (!_use_odom_in) return;
 
-    std::string topic_odom_in = _parameters->setParam("topic_odom_in", rclcpp::ParameterValue(DEFAULT_TOPIC_ODOM_IN)).get<rclcpp::PARAMETER_STRING>();
+    std::string topic_odom_in = _parameters->setParam<std::string>("topic_odom_in", DEFAULT_TOPIC_ODOM_IN);
     ROS_INFO_STREAM("Subscribing to in_odom topic: " << topic_odom_in);
 
     _odom_subscriber = _node.create_subscription<nav_msgs::msg::Odometry>(topic_odom_in, 1, [this](const nav_msgs::msg::Odometry::SharedPtr msg){odom_in_callback(msg);});


### PR DESCRIPTION
Aim to fix #2245 
Fix dynamic_params syntax.
Fix issue with Galactic parameters set by default to static which prevents them from being undeclared.

This PR needs some more testing before merging. Will appreciate users' reviews.