### PR TITLE
Adding namespace to user defined services

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,8 @@ Setting *unite_imu_method* creates a new topic, *imu*, that replaces the default
 - **calib_odom_file**: For the T265 to include odometry input, it must be given a [configuration file](https://github.com/IntelRealSense/librealsense/blob/master/unit-tests/resources/calibration_odometry.json). Explanations can be found [here](https://github.com/IntelRealSense/librealsense/pull/3462). The calibration is done in ROS coordinates system.
 - **publish_tf**: boolean, publish or not TF at all. Defaults to True.
 - **tf_publish_rate**: double, positive values mean dynamic transform publication with specified rate, all other values mean static transform publication. Defaults to 0 
-- **diagnostics_period**: double, positive values set the period between diagnostics updates on the `/diagnostics` topic. 0 or negative values mean no diagnostics topic is published. Defaults to 0.
+-- **diagnostics_period**: double, positive values set the period between diagnostics updates on the `/diagnostics` topic. 0 or negative values mean no diagnostics topic is published. Defaults to 0.</br>
+The `/diagnostics` topic includes information regarding the device temperatures and actual frequency of the enabled streams.
 - **publish_odom_tf**: If True (default) publish TF from odom_frame to pose_frame.
 - **infra_rgb**: When set to True (default: False), it configures the infrared camera to stream in RGB (color) mode, thus enabling the use of a RGB image in the same frame as the depth image, potentially avoiding frame transformation related errors. When this feature is required, you are additionally required to also enable `enable_infra:=true` for the infrared stream to be enabled.
   - **NOTE** The configuration required for `enable_infra` is independent of `enable_depth`

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -304,6 +304,7 @@ namespace realsense2_camera
         const rmw_qos_profile_t qos_string_to_qos(std::string str);
         rs2_stream rs2_string_to_stream(std::string str);
         void startDiagnosticsUpdater();
+        void frequencyDiagnosticsTick(const rs2::frame& frame);
         void clean();
 
         rs2::device _dev;

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -389,12 +389,6 @@ bool BaseRealSenseNode::toggleSensors(bool enabled, std::string& msg)
             {
                 _depth_scale_meters = sensor.as<rs2::depth_sensor>().get_depth_scale();
             }
-            for (auto& profile : profiles[module_name])
-            {
-                stream_index_pair sip(profile.stream_type(), profile.stream_index());
-                if (_diagnostics_updater)
-                    _frequency_diagnostics.emplace(sip, FrequencyDiagnostics(STREAM_NAME(sip), profile.fps(), _diagnostics_updater));
-            }
         }
         catch(const rs2::wrong_api_call_sequence_error& e)
         {
@@ -2140,6 +2134,12 @@ void BaseRealSenseNode::setupStreams()
             if (sensor.is<rs2::depth_sensor>())
             {
                 _depth_scale_meters = sensor.as<rs2::depth_sensor>().get_depth_scale();
+            }
+            for (auto& profile : profiles[module_name])
+            {
+                stream_index_pair sip(profile.stream_type(), profile.stream_index());
+                if (_diagnostics_updater)
+                    _frequency_diagnostics.emplace(sip, FrequencyDiagnostics(STREAM_NAME(sip), profile.fps(), _diagnostics_updater));
             }
         }
     }

--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -18,7 +18,7 @@ using namespace realsense2_camera;
 constexpr auto realsense_ros_camera_version = REALSENSE_ROS_EMBEDDED_VERSION_STR;
 
 RealSenseNodeFactory::RealSenseNodeFactory(const rclcpp::NodeOptions & node_options) :
-	Node("camera", "/", node_options),
+	Node("camera", "/camera", node_options),
 	_logger(this->get_logger())
 {
   init();


### PR DESCRIPTION
Before this change, if ros2 is launched by a ros2 run command (without using the launch file), the services device_info and enable are shown in the services list without the namespace ("camera/").
With this change, this does not happen.