### PR TITLE
ROS2-beta - Fix Eloquent compilation error due using rmw_qos_profile_unknown 

### DIFF
--- a/realsense2_camera/src/ros_utils.cpp
+++ b/realsense2_camera/src/ros_utils.cpp
@@ -79,7 +79,7 @@ static const rmw_qos_profile_t rmw_qos_profile_latched =
 
 const rmw_qos_profile_t qos_string_to_qos(std::string str)
 {
-#ifndef DASHING
+#if !defined(DASHING) && !defined(ELOQUENT)
     if (str == "UNKNOWN")
         return rmw_qos_profile_unknown;
 #endif


### PR DESCRIPTION
The **rmw_qos_profile_unknown** was added to **qos_profile.h rmw v0.9.0** for ROS2 Foxy and above distributions.
For older distributions (Dashing/Eloquent), we should use **rmw_qos_profile_system_default**

Tracked by [LRS-388]
