### PR TITLE
ROS2-beta - Fixing Galactic "deprecated-declarations" compilation warning

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -643,17 +643,17 @@ rclcpp::Time BaseRealSenseNode::frameSystemTimeSec(rs2::frame frame)
     if (frame.get_frame_timestamp_domain() == RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK)
     {
         double elapsed_camera_ns = (/*ms*/ frame.get_timestamp() - /*ms*/ _camera_time_base) * 1e6;
-	
-		/*
-		Fixing deprecated-declarations compilation warning.
-		Duration(rcl_duration_value_t) is deprecated in favor of 
-		static Duration::from_nanoseconds(rcl_duration_value_t)
-		starting from GALAXY.
-		*/	
+
+        /*
+        Fixing deprecated-declarations compilation warning.
+        Duration(rcl_duration_value_t) is deprecated in favor of 
+        static Duration::from_nanoseconds(rcl_duration_value_t)
+        starting from GALAXY.
+        */
 #if defined(FOXY) || defined(ELOQUENT) || defined(DASHING)
-		auto duration = rclcpp::Duration(elapsed_camera_ns);
+        auto duration = rclcpp::Duration(elapsed_camera_ns);
 #else
-		auto duration = rclcpp::Duration::from_nanoseconds(elapsed_camera_ns);
+        auto duration = rclcpp::Duration::from_nanoseconds(elapsed_camera_ns);
 #endif
 
         return rclcpp::Time(_ros_time_base + duration);

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -643,7 +643,20 @@ rclcpp::Time BaseRealSenseNode::frameSystemTimeSec(rs2::frame frame)
     if (frame.get_frame_timestamp_domain() == RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK)
     {
         double elapsed_camera_ns = (/*ms*/ frame.get_timestamp() - /*ms*/ _camera_time_base) * 1e6;
-        return rclcpp::Time(_ros_time_base + rclcpp::Duration(elapsed_camera_ns));
+	
+		/*
+		Fixing deprecated-declarations compilation warning.
+		Duration(rcl_duration_value_t) is deprecated in favor of 
+		static Duration::from_nanoseconds(rcl_duration_value_t)
+		starting from GALAXY.
+		*/	
+#if defined(FOXY) || defined(ELOQUENT) || defined(DASHING)
+		auto duration = rclcpp::Duration(elapsed_camera_ns);
+#else
+		auto duration = rclcpp::Duration::from_nanoseconds(elapsed_camera_ns);
+#endif
+
+        return rclcpp::Time(_ros_time_base + duration);
     }
     else
     {


### PR DESCRIPTION
Duration(rcl_duration_value_t) is deprecated in favor of static Duration::from_nanoseconds(rcl_duration_value_t) starting from v5.0.1

See: [5.1.0/rclcpp/include/rclcpp/duration.hpp](https://github.com/ros2-gbp/rclcpp-release/blob/upstream/5.1.0/rclcpp/include/rclcpp/duration.hpp)

This effects all versions from ROS2 Galactic and above, since older ROS2 distributions are using  rclcpp versions lower than 5.1.0

Tracked by [LRS-390]