### PR TITLE
Update ros2 branch direction from ros1 landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ These are packages for using Intel RealSense cameras (D400 series SR300 camera a
 
 This version supports Kinetic, Melodic and Noetic distributions.
 
-For running in ROS2 environment please switch to the [ros2 branch](https://github.com/IntelRealSense/realsense-ros/tree/ros2). </br>
+For running in ROS2 environment please switch to the [ros2 branch](https://github.com/IntelRealSense/realsense-ros/tree/ros2-beta). </br>
 
 LibRealSense2 supported version: v2.50.0 (see [realsense2_camera release notes](https://github.com/IntelRealSense/realsense-ros/releases))
 


### PR DESCRIPTION
Since the default branch is development (ROS1) we want to direct ROS2 users into the new ros2-beta page and not the former ros2 page.