### PR TITLE
Update PID for D405 to allow minimal compatibility 

### DIFF
--- a/realsense2_camera/include/realsense2_camera/constants.h
+++ b/realsense2_camera/include/realsense2_camera/constants.h
@@ -34,7 +34,7 @@ namespace realsense2_camera
     const uint16_t RS435i_RGB_PID   = 0x0B3A; // AWGC_MM
     const uint16_t RS465_PID        = 0x0b4d; // D465
     const uint16_t RS416_RGB_PID    = 0x0B52; // F416 RGB
-    const uint16_t RS405_PID        = 0x0b0c; // DS5U
+    const uint16_t RS405_PID        = 0x0B5B; // DS5U
     const uint16_t RS455_PID        = 0x0B5C; // D455
     const uint16_t RS_T265_PID      = 0x0b37; // 
     const uint16_t RS_L515_PID_PRE_PRQ = 0x0B3D; // 


### PR DESCRIPTION
Allows D405 to be used with ROS 1 wrapper. Does not seem to work with reconfigure but I'll see if its possible to patch 

Link to Issue:  #2290 

![Screenshot from 2022-03-23 19-33-15](https://user-images.githubusercontent.com/66944854/159781217-f8bce6a0-9b5d-4a09-ba7d-46b0d2f6371a.png)

