### PR TITLE
fix CUDA suffix for pointcloud and align_depth topics

### DIFF
--- a/realsense2_camera/src/ros_utils.cpp
+++ b/realsense2_camera/src/ros_utils.cpp
@@ -37,9 +37,9 @@ std::string rs2_to_ros(std::string rs2_name)
         {"Stereo Module", "Depth Module"},
         {"L500 Depth Sensor", "Depth Module"} ,
         {"Pointcloud (SSE3)", "Pointcloud"},
-		{"Pointcloud (CUDA)", "Pointcloud"},
+	{"Pointcloud (CUDA)", "Pointcloud"},
         {"Align (SSE3)", "Align Depth"},
-		{"Align (CUDA)", "Align Depth"},
+	{"Align (CUDA)", "Align Depth"},
         {"Depth to Disparity", "disparity filter"},
         {"Depth Visualization", "colorizer"}
     };

--- a/realsense2_camera/src/ros_utils.cpp
+++ b/realsense2_camera/src/ros_utils.cpp
@@ -37,7 +37,9 @@ std::string rs2_to_ros(std::string rs2_name)
         {"Stereo Module", "Depth Module"},
         {"L500 Depth Sensor", "Depth Module"} ,
         {"Pointcloud (SSE3)", "Pointcloud"},
+		{"Pointcloud (CUDA)", "Pointcloud"},
         {"Align (SSE3)", "Align Depth"},
+		{"Align (CUDA)", "Align Depth"},
         {"Depth to Disparity", "disparity filter"},
         {"Depth Visualization", "colorizer"}
     };


### PR DESCRIPTION
Fixing CUDA suffix added to point cloud and align depth on Nvidia Jetson Xavier Jetpack 4.6 (Ubuntu 18.04 based) - ROS2 Dashing
Tracked by [LRS-398]
