### PR TITLE
Publish static transforms when intra porocess communication is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,14 +288,6 @@ Further details on efficient intra-process communication can be found [here](htt
 ### Limitations
 
 * Node components are currently not supported on RCLPY
-* Transformations: `/static_tf` topic will be disabled
-  * To get the transformations published:
-    * Set `tf_publish_rate` to `1.0` in the launch file (or on the command-line, using `-p tf_publish_rate:=1.0`)
-    * Activate and read `/tf` and `/extrinsic/<stream>_to_<stream>` topics
-      * To echo the `/extrinsic/<stream>_to_<stream>` topic you will need to change the default CLI QoS to match the new QoS that the `intra-process` flow uses. E.g.:
-        ```bash
-        ros2 topic echo /extrinsics/depth_to_color --qos-durability=volatile --qos-reliability=reliable
-        ```
 * Compressed images using `image_transport` will be disabled as this isn't supported with intra-process communication
 
 ### Latency test tool and launch file


### PR DESCRIPTION
Hi @MartyG-RealSense ,

In the existing implementation of the ROS 2 driver, if users enable `intra_process_communication`, the driver will not publish static tf transforms due to this [condition](https://github.com/IntelRealSense/realsense-ros/blob/451147de3aaa9c5b05b1fb1f7a70f3f3f43c66f6/realsense2_camera/src/base_realsense_node.cpp#L94-L98)

However there is really no need to sacrifice static tf publishing at the expense on enabling `intra_process_communication` as `rclcpp` is smart enough to selectively disable the intra process publishing mechanism for publishers (or subscribers) by suitably overwriting the `PublisherOptions` for a given publisher.

This PR enables users to benefit from both `intra_process_comminication` **as well** as static tf transforms published by this driver. It short, it overcomes the `static_tf` limitation described in the README [here](https://github.com/IntelRealSense/realsense-ros/tree/ros2-beta#limitations) 😄 

It has been tested on `foxy` and `galactic` on `Ubuntu 20.04` with a `D455` camera.

Once you rebuild the package, and load the driver component into a component container with `use_intra_process_comms:=True`, you should still be able to `ros2 topic echo /tf_static --qos-reliability reliable --qos-durability transient_local` to see the static transforms.

Signed-off-by: Yadunund <yadunund@openrobotics.org>