### PR TITLE
Publish real frame rate of realsense camera node topics/publishers

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -639,6 +639,7 @@ void BaseRealSenseNode::frame_callback(rs2::frame frame)
     catch(const std::exception& ex)
     {
         ROS_ERROR_STREAM("An error has occurred during frame callback: " << ex.what());
+        throw(ex);
     }
     _synced_imu_publisher->Resume();
 } // frame_callback

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -518,128 +518,121 @@ void BaseRealSenseNode::pose_callback(rs2::frame frame)
 void BaseRealSenseNode::frame_callback(rs2::frame frame)
 {
     _synced_imu_publisher->Pause();
-    try{
-        double frame_time = frame.get_timestamp();
+    double frame_time = frame.get_timestamp();
 
-        // We compute a ROS timestamp which is based on an initial ROS time at point of first frame,
-        // and the incremental timestamp from the camera.
-        // In sync mode the timestamp is based on ROS time
-        bool placeholder_false(false);
-        if (_is_initialized_time_base.compare_exchange_strong(placeholder_false, true) )
+    // We compute a ROS timestamp which is based on an initial ROS time at point of first frame,
+    // and the incremental timestamp from the camera.
+    // In sync mode the timestamp is based on ROS time
+    bool placeholder_false(false);
+    if (_is_initialized_time_base.compare_exchange_strong(placeholder_false, true) )
+    {
+        _is_initialized_time_base = setBaseTime(frame_time, frame.get_frame_timestamp_domain());
+    }
+
+    rclcpp::Time t(frameSystemTimeSec(frame));
+    if (frame.is<rs2::frameset>())
+    {
+        ROS_DEBUG("Frameset arrived.");
+        auto frameset = frame.as<rs2::frameset>();
+        ROS_DEBUG("List of frameset before applying filters: size: %d", static_cast<int>(frameset.size()));
+        for (auto it = frameset.begin(); it != frameset.end(); ++it)
         {
-            _is_initialized_time_base = setBaseTime(frame_time, frame.get_frame_timestamp_domain());
+            auto f = (*it);
+            auto stream_type = f.get_profile().stream_type();
+            auto stream_index = f.get_profile().stream_index();
+            auto stream_format = f.get_profile().format();
+            auto stream_unique_id = f.get_profile().unique_id();
+
+            ROS_DEBUG("Frameset contain (%s, %d, %s %d) frame. frame_number: %llu ; frame_TS: %f ; ros_TS(NSec): %lu",
+                        rs2_stream_to_string(stream_type), stream_index, rs2_format_to_string(stream_format), stream_unique_id, frame.get_frame_number(), frame_time, t.nanoseconds());
+        }
+        // Clip depth_frame for max range:
+        rs2::depth_frame original_depth_frame = frameset.get_depth_frame();
+        if (original_depth_frame && _clipping_distance > 0)
+        {
+            clip_depth(original_depth_frame, _clipping_distance);
         }
 
-        rclcpp::Time t(frameSystemTimeSec(frame));
-        if (frame.is<rs2::frameset>())
+        ROS_DEBUG("num_filters: %d", static_cast<int>(_filters.size()));
+        for (auto filter_it : _filters)
         {
-            ROS_DEBUG("Frameset arrived.");
-            auto frameset = frame.as<rs2::frameset>();
-            ROS_DEBUG("List of frameset before applying filters: size: %d", static_cast<int>(frameset.size()));
-            for (auto it = frameset.begin(); it != frameset.end(); ++it)
-            {
-                auto f = (*it);
-                auto stream_type = f.get_profile().stream_type();
-                auto stream_index = f.get_profile().stream_index();
-                auto stream_format = f.get_profile().format();
-                auto stream_unique_id = f.get_profile().unique_id();
+            frameset = filter_it->Process(frameset);
+        }
 
-                ROS_DEBUG("Frameset contain (%s, %d, %s %d) frame. frame_number: %llu ; frame_TS: %f ; ros_TS(NSec): %lu",
-                            rs2_stream_to_string(stream_type), stream_index, rs2_format_to_string(stream_format), stream_unique_id, frame.get_frame_number(), frame_time, t.nanoseconds());
+        ROS_DEBUG("List of frameset after applying filters: size: %d", static_cast<int>(frameset.size()));
+        bool sent_depth_frame(false);
+        for (auto it = frameset.begin(); it != frameset.end(); ++it)
+        {
+            auto f = (*it);
+            auto stream_type = f.get_profile().stream_type();
+            auto stream_index = f.get_profile().stream_index();
+            auto stream_format = f.get_profile().format();
+            stream_index_pair sip{stream_type,stream_index};
+
+            ROS_DEBUG("Frameset contain (%s, %d, %s) frame. frame_number: %llu ; frame_TS: %f ; ros_TS(NSec): %lu", 
+                rs2_stream_to_string(stream_type), stream_index, rs2_format_to_string(stream_format), f.get_frame_number(), frame_time, t.nanoseconds());
+            if (f.is<rs2::video_frame>())
+                ROS_DEBUG_STREAM("frame: " << f.as<rs2::video_frame>().get_width() << " x " << f.as<rs2::video_frame>().get_height());
+
+            if (f.is<rs2::points>())
+            {
+                publishPointCloud(f.as<rs2::points>(), t, frameset);
+                continue;
             }
-            // Clip depth_frame for max range:
-            rs2::depth_frame original_depth_frame = frameset.get_depth_frame();
-            if (original_depth_frame && _clipping_distance > 0)
+            if (stream_type == RS2_STREAM_DEPTH)
             {
-                clip_depth(original_depth_frame, _clipping_distance);
-            }
-
-            ROS_DEBUG("num_filters: %d", static_cast<int>(_filters.size()));
-            for (auto filter_it : _filters)
-            {
-                frameset = filter_it->Process(frameset);
-            }
-
-            ROS_DEBUG("List of frameset after applying filters: size: %d", static_cast<int>(frameset.size()));
-            bool sent_depth_frame(false);
-            for (auto it = frameset.begin(); it != frameset.end(); ++it)
-            {
-                auto f = (*it);
-                auto stream_type = f.get_profile().stream_type();
-                auto stream_index = f.get_profile().stream_index();
-                auto stream_format = f.get_profile().format();
-                stream_index_pair sip{stream_type,stream_index};
-
-                ROS_DEBUG("Frameset contain (%s, %d, %s) frame. frame_number: %llu ; frame_TS: %f ; ros_TS(NSec): %lu",
-                            rs2_stream_to_string(stream_type), stream_index, rs2_format_to_string(stream_format), f.get_frame_number(), frame_time, t.nanoseconds());
-                if (f.is<rs2::video_frame>())
-                    ROS_DEBUG_STREAM("frame: " << f.as<rs2::video_frame>().get_width() << " x " << f.as<rs2::video_frame>().get_height());
-
-                if (f.is<rs2::points>())
+                if (sent_depth_frame) continue;
+                sent_depth_frame = true;
+                if (_align_depth_filter->is_enabled())
                 {
-                    publishPointCloud(f.as<rs2::points>(), t, frameset);
+                    publishFrame(f, t, COLOR,
+                            _depth_aligned_image,
+                            _depth_aligned_info_publisher,
+                            _depth_aligned_image_publishers,
+                            false);
                     continue;
                 }
-                if (stream_type == RS2_STREAM_DEPTH)
-                {
-                    if (sent_depth_frame) continue;
-                    sent_depth_frame = true;
-                    if (_align_depth_filter->is_enabled())
-                    {
-                        publishFrame(f, t, COLOR,
-                                    _depth_aligned_image,
-                                    _depth_aligned_info_publisher,
-                                    _depth_aligned_image_publishers,
-                                    false);
-                        continue;
-                    }
-                }
-                publishFrame(f, t, sip,
-                            _image,
-                            _info_publisher,
-                            _image_publishers);
             }
-            if (original_depth_frame && _align_depth_filter->is_enabled())
-            {
-                rs2::frame frame_to_send;
-                if (_colorizer_filter->is_enabled())
-                    frame_to_send = _colorizer_filter->Process(original_depth_frame);
-                else
-                    frame_to_send = original_depth_frame;
-                
-                publishFrame(frame_to_send, t,
-                                DEPTH,
-                                _image,
-                                _info_publisher,
-                                _image_publishers);
-            }
+            publishFrame(f, t, sip,
+                        _image,
+                        _info_publisher,
+                        _image_publishers);
         }
-        else if (frame.is<rs2::video_frame>())
+        if (original_depth_frame && _align_depth_filter->is_enabled())
         {
-            auto stream_type = frame.get_profile().stream_type();
-            auto stream_index = frame.get_profile().stream_index();
-            ROS_DEBUG("Single video frame arrived (%s, %d). frame_number: %llu ; frame_TS: %f ; ros_TS(NSec): %lu",
-                        rs2_stream_to_string(stream_type), stream_index, frame.get_frame_number(), frame_time, t.nanoseconds());
-            
-            stream_index_pair sip{stream_type,stream_index};
-            if (frame.is<rs2::depth_frame>())
-            {
-                if (_clipping_distance > 0)
-                {
-                    clip_depth(frame, _clipping_distance);
-                }
-            }
-            publishFrame(frame, t,
-                            sip,
-                            _image,
-                            _info_publisher,
-                            _image_publishers);
+            rs2::frame frame_to_send;
+            if (_colorizer_filter->is_enabled())
+                frame_to_send = _colorizer_filter->Process(original_depth_frame);
+            else
+                frame_to_send = original_depth_frame;
+                
+            publishFrame(frame_to_send, t,
+                        DEPTH,
+                        _image,
+                        _info_publisher,
+                        _image_publishers);
         }
     }
-    catch(const std::exception& ex)
+    else if (frame.is<rs2::video_frame>())
     {
-        ROS_ERROR_STREAM("An error has occurred during frame callback: " << ex.what());
-        throw(ex);
+        auto stream_type = frame.get_profile().stream_type();
+        auto stream_index = frame.get_profile().stream_index();
+        ROS_DEBUG("Single video frame arrived (%s, %d). frame_number: %llu ; frame_TS: %f ; ros_TS(NSec): %lu",
+                    rs2_stream_to_string(stream_type), stream_index, frame.get_frame_number(), frame_time, t.nanoseconds());
+            
+        stream_index_pair sip{stream_type,stream_index};
+        if (frame.is<rs2::depth_frame>())
+        {
+            if (_clipping_distance > 0)
+            {
+                clip_depth(frame, _clipping_distance);
+            }
+        }
+        publishFrame(frame, t,
+                    sip,
+                    _image,
+                    _info_publisher,
+                    _image_publishers);
     }
     _synced_imu_publisher->Resume();
 } // frame_callback

--- a/realsense2_camera/src/ros_sensor.cpp
+++ b/realsense2_camera/src/ros_sensor.cpp
@@ -49,10 +49,18 @@ RosSensor::RosSensor(rs2::sensor sensor,
             auto stream_type = frame.get_profile().stream_type();
             auto stream_index = frame.get_profile().stream_index();
             stream_index_pair sip{stream_type, stream_index};
-            if (_frequency_diagnostics.find(sip) != _frequency_diagnostics.end())
-                _frequency_diagnostics.at(sip).Tick();
-
-            _origin_frame_callback(frame);
+            try
+            {
+                _origin_frame_callback(frame);
+                if (_frequency_diagnostics.find(sip) != _frequency_diagnostics.end())
+                    _frequency_diagnostics.at(sip).Tick();
+            }
+            catch(const std::exception& ex)
+            {
+                // do nothing if exception catched
+                // don't tick the frequency diagnostics for this publisher
+            }
+           
         };
     setParameters();
 }

--- a/realsense2_camera/src/ros_sensor.cpp
+++ b/realsense2_camera/src/ros_sensor.cpp
@@ -57,10 +57,9 @@ RosSensor::RosSensor(rs2::sensor sensor,
             }
             catch(const std::exception& ex)
             {
-                // do nothing if exception catched
                 // don't tick the frequency diagnostics for this publisher
+                ROS_ERROR_STREAM("An error has occurred during frame callback: " << ex.what());
             }
-           
         };
     setParameters();
 }


### PR DESCRIPTION
- Catch backend exceptions and don't tick frequency diagnostics if so
- Tick the frequency diagnostics only if topic publishes the frame

All changes in base_realsense_node are removing the try/catch and moving them outside to the ros_sensor file

Tracked on [LRS-434] and [LRS-448]