### PR TITLE
Minor change to move stream constants to constants.h.

### DIFF
--- a/realsense2_camera/include/realsense2_camera/constants.h
+++ b/realsense2_camera/include/realsense2_camera/constants.h
@@ -97,4 +97,24 @@ namespace realsense2_camera
 
     const float ROS_DEPTH_SCALE = 0.001;
     using stream_index_pair = std::pair<rs2_stream, int>;
+    
+    const stream_index_pair COLOR{RS2_STREAM_COLOR, 0};
+    const stream_index_pair DEPTH{RS2_STREAM_DEPTH, 0};
+    const stream_index_pair INFRA0{RS2_STREAM_INFRARED, 0};
+    const stream_index_pair INFRA1{RS2_STREAM_INFRARED, 1};
+    const stream_index_pair INFRA2{RS2_STREAM_INFRARED, 2};
+    const stream_index_pair FISHEYE{RS2_STREAM_FISHEYE, 0};
+    const stream_index_pair FISHEYE1{RS2_STREAM_FISHEYE, 1};
+    const stream_index_pair FISHEYE2{RS2_STREAM_FISHEYE, 2};
+    const stream_index_pair GYRO{RS2_STREAM_GYRO, 0};
+    const stream_index_pair ACCEL{RS2_STREAM_ACCEL, 0};
+    const stream_index_pair POSE{RS2_STREAM_POSE, 0};
+    const stream_index_pair CONFIDENCE{RS2_STREAM_CONFIDENCE, 0};    
+
+    const std::vector<stream_index_pair> IMAGE_STREAMS = {DEPTH, INFRA0, INFRA1, INFRA2,
+                                                          COLOR,
+                                                          FISHEYE,
+                                                          FISHEYE1, FISHEYE2, CONFIDENCE};
+
+    const std::vector<stream_index_pair> HID_STREAMS = {GYRO, ACCEL, POSE};
 }  // namespace realsense2_camera

--- a/realsense2_camera/include/realsense2_camera/realsense_node_factory.h
+++ b/realsense2_camera/include/realsense2_camera/realsense_node_factory.h
@@ -25,26 +25,6 @@
 
 namespace realsense2_camera
 {
-    const stream_index_pair COLOR{RS2_STREAM_COLOR, 0};
-    const stream_index_pair DEPTH{RS2_STREAM_DEPTH, 0};
-    const stream_index_pair INFRA0{RS2_STREAM_INFRARED, 0};
-    const stream_index_pair INFRA1{RS2_STREAM_INFRARED, 1};
-    const stream_index_pair INFRA2{RS2_STREAM_INFRARED, 2};
-    const stream_index_pair FISHEYE{RS2_STREAM_FISHEYE, 0};
-    const stream_index_pair FISHEYE1{RS2_STREAM_FISHEYE, 1};
-    const stream_index_pair FISHEYE2{RS2_STREAM_FISHEYE, 2};
-    const stream_index_pair GYRO{RS2_STREAM_GYRO, 0};
-    const stream_index_pair ACCEL{RS2_STREAM_ACCEL, 0};
-    const stream_index_pair POSE{RS2_STREAM_POSE, 0};
-    const stream_index_pair CONFIDENCE{RS2_STREAM_CONFIDENCE, 0};    
-
-    const std::vector<stream_index_pair> IMAGE_STREAMS = {DEPTH, INFRA0, INFRA1, INFRA2,
-                                                          COLOR,
-                                                          FISHEYE,
-                                                          FISHEYE1, FISHEYE2, CONFIDENCE};
-
-    const std::vector<stream_index_pair> HID_STREAMS = {GYRO, ACCEL, POSE};
-
     class InterfaceRealSenseNode
     {
     public:


### PR DESCRIPTION
Minor change to move stream constants to the `constants.h` file.

This makes it slightly easier to find the constants and also allows a downstream user to include the constants without needing to include `realsense_node_factory.h`
