### PR TITLE
Expose angular_velocity_cov arg

### DIFF
--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -103,6 +103,7 @@
   <arg name="filters"                  default=""/>
   <arg name="clip_distance"            default="-1"/>
   <arg name="linear_accel_cov"         default="0.01"/>
+  <arg name="angular_velocity_cov"     default="0.01"/>
   <arg name="initial_reset"            default="false"/>
   <arg name="reconnect_timeout"        default= "6.0"/>
   <arg name="wait_for_device_timeout"  default= "-1.0"/>
@@ -209,6 +210,7 @@
     <param name="filters"                  type="str"    value="$(arg filters)"/>
     <param name="clip_distance"            type="double" value="$(arg clip_distance)"/>
     <param name="linear_accel_cov"         type="double" value="$(arg linear_accel_cov)"/>
+    <param name="angular_velocity_cov"     type="double" value="$(arg angular_velocity_cov)"/>
     <param name="initial_reset"            type="bool"   value="$(arg initial_reset)"/>
     <param name="reconnect_timeout"        type="double" value="$(arg reconnect_timeout)"/>
     <param name="wait_for_device_timeout"  type="double" value="$(arg wait_for_device_timeout)"/>

--- a/realsense2_camera/launch/rs_camera.launch
+++ b/realsense2_camera/launch/rs_camera.launch
@@ -58,6 +58,7 @@
   <arg name="filters"                   default=""/>
   <arg name="clip_distance"             default="-2"/>
   <arg name="linear_accel_cov"          default="0.01"/>
+  <arg name="angular_velocity_cov"      default="0.01"/>
   <arg name="initial_reset"             default="false"/>
   <arg name="reconnect_timeout"         default="6.0"/>
   <arg name="wait_for_device_timeout"   default="-1.0"/>
@@ -130,6 +131,7 @@
       <arg name="filters"                  value="$(arg filters)"/>
       <arg name="clip_distance"            value="$(arg clip_distance)"/>
       <arg name="linear_accel_cov"         value="$(arg linear_accel_cov)"/>
+      <arg name="angular_velocity_cov"     value="$(arg angular_velocity_cov)"/>
       <arg name="initial_reset"            value="$(arg initial_reset)"/>
       <arg name="reconnect_timeout"        value="$(arg reconnect_timeout)"/>
       <arg name="wait_for_device_timeout"  value="$(arg wait_for_device_timeout)"/>


### PR DESCRIPTION
The README documents `angular_velocity_cov` as an argument for the `rs_camera.launch` file, but it's not available. This PR would make it available.