### PR TITLE
Update stale comment to reflect new branch name

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -13,7 +13,7 @@ name: pre-release
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the ros2-beta branch
+  # Triggers the workflow on push or pull request events but only for the ros2-development branch
   push:
     branches:
       - ros2-development


### PR DESCRIPTION
Seems like there's a stale comment referring to the old, `ros2-beta` branch name, when it should instead reference the new, `ros2-development` branch.