### PR TITLE
Replace deprecated parameter node_name with name

### DIFF
--- a/realsense2_description/launch/view_model.launch.py
+++ b/realsense2_description/launch/view_model.launch.py
@@ -11,33 +11,34 @@ import sys
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 from launch_utils import to_urdf
 
+
 def generate_launch_description():
     available_urdf_files = [f for f in os.listdir(os.path.join(get_package_share_directory('realsense2_description'), 'urdf')) if f.startswith('test_')]
-    params = dict([aa for aa in [aa.split(':=') for aa in sys.argv] if len(aa)==2])
+    params = dict([aa for aa in [aa.split(':=') for aa in sys.argv] if len(aa) == 2])
     if ('model' not in params or params['model'] not in available_urdf_files):
-        print ('USAGE:')
-        print ('ros2 launch realsense2_description view_model.launch.py model:=<model>')
-        print ('Available argumants for <model> are as follows:')
-        print ('\n'.join(available_urdf_files))
+        print('USAGE:')
+        print('ros2 launch realsense2_description view_model.launch.py model:=<model>')
+        print('Available argumants for <model> are as follows:')
+        print('\n'.join(available_urdf_files))
         return launch.LaunchDescription()
 
     rviz_config_dir = os.path.join(get_package_share_directory('realsense2_description'), 'rviz', 'urdf.rviz')
     xacro_path = os.path.join(get_package_share_directory('realsense2_description'), 'urdf', params['model'])
-    urdf = to_urdf(xacro_path, {'use_nominal_extrinsics' : 'true', 'add_plug' : 'true'})
+    urdf = to_urdf(xacro_path, {'use_nominal_extrinsics': 'true', 'add_plug': 'true'})
     rviz_node = Node(
         package='rviz2',
         executable='rviz2',
-        node_name='rviz2',
-        output = 'screen',
+        name='rviz2',
+        output='screen',
         arguments=['-d', rviz_config_dir],
         parameters=[{'use_sim_time': False}]
         )
     model_node = Node(
-        node_name='model_node',
+        name='model_node',
         package='robot_state_publisher',
         executable='robot_state_publisher',
         namespace='',
         output='screen',
-        arguments = [urdf]
+        arguments=[urdf]
         )
     return launch.LaunchDescription([rviz_node, model_node])


### PR DESCRIPTION
The `node_name` parameter of launch_ros.actions.Node was deprecated in Foxy and removed in Galactic, and needs to be replaced with the `name` parameter to avoid errors.

This change will cause errors for versions before Foxy, but those versions already have errors due to their use of the `node_executable` parameter instead of the modern `executable`.

PS: I couldn't stop myself from making some style changes to assuage my linter.