### PR TITLE
Add support for rgb_camera.power_line_frequency

### DIFF
--- a/realsense2_camera/launch/rs_launch.py
+++ b/realsense2_camera/launch/rs_launch.py
@@ -59,6 +59,7 @@ configurable_parameters = [{'name': 'camera_name',                  'default': '
                            {'name': 'depth_module.gain.2',         'default': '16', 'description': 'Initial value for hdr_merge filter'},
                            {'name': 'wait_for_device_timeout',      'default': '-1.', 'description': 'Timeout for waiting for device to connect (Seconds)'},
                            {'name': 'reconnect_timeout',            'default': '6.', 'description': 'Timeout(seconds) between consequtive reconnection attempts'},
+                           {'name': 'rgb_camera.power_line_frequency', 'default': '1', 'description': 'Disabled - 0; 50 Hz - 1; 60 Hz - 2'},
                           ]
 
 def declare_configurable_parameters(parameters):


### PR DESCRIPTION
When running with LibRealSense v2.54.0 (built from source) a warning is issued, because the value of rgb_camera.power_line_frequency defaults to "{rgb_camera.power_line_frequency}". which is not in the range [0,2].

Adding this line allows for the rgb_camera.power_line_frequency to be set as a parameter.

I cannot say whether or not this breaks compability with different versions of LibRealSense, but it works for me. (v2.54.0)