### PR TITLE
enable intra-process communication for point clouds

### DIFF
--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -161,6 +161,17 @@ else()
   message(FATAL_ERROR "Unsupported ROS Distribution: " "$ENV{ROS_DISTRO}")
 endif()
 
+# The header 'cv_bridge/cv_bridge.hpp' was added in version 3.3.0. For older
+# cv_bridge versions, we have to use the header 'cv_bridge/cv_bridge.h'.
+if(${cv_bridge_VERSION} VERSION_GREATER_EQUAL "3.3.0")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCV_BRDIGE_HAS_HPP")
+endif()
+
+# 'OnSetParametersCallbackType' is only defined for rclcpp 17 and onward.
+if(${rclcpp_VERSION} VERSION_GREATER_EQUAL "17.0")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DRCLCPP_HAS_OnSetParametersCallbackType")
+endif()
+
 set(INCLUDES
     include/constants.h
     include/realsense_node_factory.h

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -8,7 +8,7 @@
 #include "constants.h"
 
 // cv_bridge.h last supported version is humble
-#if defined(ROLLING)
+#if defined(CV_BRDIGE_HAS_HPP)
 #include <cv_bridge/cv_bridge.hpp>
 #else
 #include <cv_bridge/cv_bridge.h>

--- a/realsense2_camera/include/named_filter.h
+++ b/realsense2_camera/include/named_filter.h
@@ -54,7 +54,6 @@ namespace realsense2_camera
             bool _allow_no_texture_points;
             bool _ordered_pc;
             std::mutex _mutex_publisher;
-            sensor_msgs::msg::PointCloud2 _msg_pointcloud;
             rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr _pointcloud_publisher;
             std::string _pointcloud_qos;
     };

--- a/realsense2_camera/include/ros_param_backend.h
+++ b/realsense2_camera/include/ros_param_backend.h
@@ -13,7 +13,7 @@ namespace realsense2_camera
             ParametersBackend(rclcpp::Node& node) : 
                 _node(node),
                 _logger(node.get_logger())
-                {};
+                {}
             ~ParametersBackend();
 
 

--- a/realsense2_camera/include/ros_param_backend.h
+++ b/realsense2_camera/include/ros_param_backend.h
@@ -17,7 +17,7 @@ namespace realsense2_camera
             ~ParametersBackend();
 
 
-            #if defined( ROLLING ) 
+            #if defined( RCLCPP_HAS_OnSetParametersCallbackType )
                 using ros2_param_callback_type = rclcpp::node_interfaces::NodeParametersInterface::OnSetParametersCallbackType;
             #else
                 using ros2_param_callback_type = rclcpp::node_interfaces::NodeParametersInterface::OnParametersSetCallbackType;

--- a/realsense2_camera/src/named_filter.cpp
+++ b/realsense2_camera/src/named_filter.cpp
@@ -240,7 +240,6 @@ void PointcloudFilter::Publish(rs2::points pc, const rclcpp::Time& t, const rs2:
     }
     else
     {
-        std::string format_str = "intensity";
         msg_pointcloud->row_step = msg_pointcloud->width * msg_pointcloud->point_step;
         msg_pointcloud->data.resize(msg_pointcloud->height * msg_pointcloud->row_step);
 

--- a/realsense2_camera/src/named_filter.cpp
+++ b/realsense2_camera/src/named_filter.cpp
@@ -167,14 +167,16 @@ void PointcloudFilter::Publish(rs2::points pc, const rclcpp::Time& t, const rs2:
 
     rs2_intrinsics depth_intrin = pc.get_profile().as<rs2::video_stream_profile>().get_intrinsics();
 
-    sensor_msgs::PointCloud2Modifier modifier(_msg_pointcloud);
+    sensor_msgs::msg::PointCloud2::UniquePtr msg_pointcloud = std::make_unique<sensor_msgs::msg::PointCloud2>();
+
+    sensor_msgs::PointCloud2Modifier modifier(*msg_pointcloud);
     modifier.setPointCloud2FieldsByString(1, "xyz");    
     modifier.resize(pc.size());
     if (_ordered_pc)
     {
-        _msg_pointcloud.width = depth_intrin.width;
-        _msg_pointcloud.height = depth_intrin.height;
-        _msg_pointcloud.is_dense = false;
+        msg_pointcloud->width = depth_intrin.width;
+        msg_pointcloud->height = depth_intrin.height;
+        msg_pointcloud->is_dense = false;
     }
 
     vertex = pc.get_vertices();
@@ -198,14 +200,14 @@ void PointcloudFilter::Publish(rs2::points pc, const rclcpp::Time& t, const rs2:
             default:
                 throw std::runtime_error("Unhandled texture format passed in pointcloud " + std::to_string(texture_frame.get_profile().format()));
         }
-        _msg_pointcloud.point_step = addPointField(_msg_pointcloud, format_str.c_str(), 1, sensor_msgs::msg::PointField::FLOAT32, _msg_pointcloud.point_step);
-        _msg_pointcloud.row_step = _msg_pointcloud.width * _msg_pointcloud.point_step;
-        _msg_pointcloud.data.resize(_msg_pointcloud.height * _msg_pointcloud.row_step);
+        msg_pointcloud->point_step = addPointField(*msg_pointcloud, format_str.c_str(), 1, sensor_msgs::msg::PointField::FLOAT32, msg_pointcloud->point_step);
+        msg_pointcloud->row_step = msg_pointcloud->width * msg_pointcloud->point_step;
+        msg_pointcloud->data.resize(msg_pointcloud->height * msg_pointcloud->row_step);
 
-        sensor_msgs::PointCloud2Iterator<float>iter_x(_msg_pointcloud, "x");
-        sensor_msgs::PointCloud2Iterator<float>iter_y(_msg_pointcloud, "y");
-        sensor_msgs::PointCloud2Iterator<float>iter_z(_msg_pointcloud, "z");
-        sensor_msgs::PointCloud2Iterator<uint8_t>iter_color(_msg_pointcloud, format_str);
+        sensor_msgs::PointCloud2Iterator<float>iter_x(*msg_pointcloud, "x");
+        sensor_msgs::PointCloud2Iterator<float>iter_y(*msg_pointcloud, "y");
+        sensor_msgs::PointCloud2Iterator<float>iter_z(*msg_pointcloud, "z");
+        sensor_msgs::PointCloud2Iterator<uint8_t>iter_color(*msg_pointcloud, format_str);
         color_point = pc.get_texture_coordinates();
 
         float color_pixel[2];
@@ -239,12 +241,12 @@ void PointcloudFilter::Publish(rs2::points pc, const rclcpp::Time& t, const rs2:
     else
     {
         std::string format_str = "intensity";
-        _msg_pointcloud.row_step = _msg_pointcloud.width * _msg_pointcloud.point_step;
-        _msg_pointcloud.data.resize(_msg_pointcloud.height * _msg_pointcloud.row_step);
+        msg_pointcloud->row_step = msg_pointcloud->width * msg_pointcloud->point_step;
+        msg_pointcloud->data.resize(msg_pointcloud->height * msg_pointcloud->row_step);
 
-        sensor_msgs::PointCloud2Iterator<float>iter_x(_msg_pointcloud, "x");
-        sensor_msgs::PointCloud2Iterator<float>iter_y(_msg_pointcloud, "y");
-        sensor_msgs::PointCloud2Iterator<float>iter_z(_msg_pointcloud, "z");
+        sensor_msgs::PointCloud2Iterator<float>iter_x(*msg_pointcloud, "x");
+        sensor_msgs::PointCloud2Iterator<float>iter_y(*msg_pointcloud, "y");
+        sensor_msgs::PointCloud2Iterator<float>iter_z(*msg_pointcloud, "z");
 
         for (size_t point_idx=0; point_idx < pc.size(); point_idx++, vertex++)
         {
@@ -260,19 +262,19 @@ void PointcloudFilter::Publish(rs2::points pc, const rclcpp::Time& t, const rs2:
             }
         }
     }
-    _msg_pointcloud.header.stamp = t;
-    _msg_pointcloud.header.frame_id = frame_id;
+    msg_pointcloud->header.stamp = t;
+    msg_pointcloud->header.frame_id = frame_id;
     if (!_ordered_pc)
     {
-        _msg_pointcloud.width = valid_count;
-        _msg_pointcloud.height = 1;
-        _msg_pointcloud.is_dense = true;
+        msg_pointcloud->width = valid_count;
+        msg_pointcloud->height = 1;
+        msg_pointcloud->is_dense = true;
         modifier.resize(valid_count);
     }
     {
         std::lock_guard<std::mutex> lock_guard(_mutex_publisher);
         if (_pointcloud_publisher)
-            _pointcloud_publisher->publish(_msg_pointcloud);
+            _pointcloud_publisher->publish(std::move(msg_pointcloud));
     }
 }
 


### PR DESCRIPTION
The node currently publishes point cloud messages directly and does not use a unique shared pointer, which prevents using efficient zero-copy intra-process communication as it requires copying the data between nodes in the same process.

This PR fixes this by publishing the point cloud via a unique shared pointer. I verified by the address of the `data` vector that the camera node and a point cloud subscriber indeed share that message without copying data.

The PR also contains some cleanup commits and one commit to guard different method signatures behind a version check to enable compilation on Ubuntu 20.04 with ROS2 rolling. Note that those checks should be done by library version and not ROS2 distribution names, as the same ROS2 distribution (e.g. `rolling` in this case) can have different versions of a library on different Ubuntu versions.