### PR TITLE
Fix ros2 parameter descriptions and range values

### DIFF
--- a/realsense2_camera/include/sensor_params.h
+++ b/realsense2_camera/include/sensor_params.h
@@ -23,6 +23,10 @@ namespace realsense2_camera
             rclcpp::Logger _logger;
 
         private:
+            double float_to_double(float val, rs2::option_range option_range);
+            template<class T>
+            rcl_interfaces::msg::ParameterDescriptor get_parameter_descriptor(const std::string& option_name, rs2::option_range option_range,
+                T option_value, const std::string& option_description, const std::string& description_addition);
             template<class T>
             void set_parameter(rs2::options sensor, rs2_option option, const std::string& module_name, const std::string& description_addition="");
 

--- a/realsense2_camera/src/sensor_params.cpp
+++ b/realsense2_camera/src/sensor_params.cpp
@@ -107,8 +107,8 @@ void SensorParams::set_parameter(rs2::options sensor, rs2_option option, const s
         rcl_interfaces::msg::IntegerRange range;
         range.from_value = int(op_range.min);
         range.to_value = int(op_range.max);
-	range.step = int(op_range.step);
-	desc << " default value: " << int(op_range.def);
+        range.step = int(op_range.step);
+        desc << " default value: " << int(op_range.def);
         crnt_descriptor.integer_range.push_back(range);
         if (std::is_same<T, bool>::value)
             ROS_DEBUG_STREAM("Declare: BOOL::" << option_name << " = " << option_value << "[" << op_range.min << ", " << op_range.max << "]");
@@ -121,7 +121,7 @@ void SensorParams::set_parameter(rs2::options sensor, rs2_option option, const s
         range.from_value = double(op_range.min);
         range.to_value = double(op_range.max);
         range.step = double(op_range.step);
-	desc << " default value: " << double(op_range.def);
+        desc << " default value: " << double(op_range.def);
         crnt_descriptor.floating_point_range.push_back(range);
         ROS_DEBUG_STREAM("Declare: DOUBLE::" << option_name << " = " << option_value);
     }

--- a/realsense2_camera/src/sensor_params.cpp
+++ b/realsense2_camera/src/sensor_params.cpp
@@ -86,11 +86,6 @@ SensorParams::~SensorParams()
 
 double SensorParams::float_to_double(float val, rs2::option_range option_range)
 {
-    if(val == 0)
-    {
-        return 0.0;
-    }
-
     // casting from float to double, while trying to increase precision
     // in order to be comply with the FloatingPointRange configurations
     // and to succeed the rclcpp NodeParameters::declare_parameter call
@@ -133,7 +128,7 @@ rcl_interfaces::msg::ParameterDescriptor SensorParams::get_parameter_descriptor(
         // add the default value of this option to the description stream
         description_stream << "Default value: " << static_cast<double>(option_range.def);        
 
-        ROS_INFO_STREAM("Declare: DOUBLE::" << option_name << "=" << option_value << "  [" << option_range.min << ", " << option_range.max << "]");
+        ROS_DEBUG_STREAM("Declare: DOUBLE::" << option_name << "=" << option_value << "  [" << option_range.min << ", " << option_range.max << "]");
     }
     else // T is bool or int
     {

--- a/realsense2_camera/src/sensor_params.cpp
+++ b/realsense2_camera/src/sensor_params.cpp
@@ -84,24 +84,105 @@ SensorParams::~SensorParams()
     clearParameters();
 }
 
+double SensorParams::float_to_double(float val, rs2::option_range option_range)
+{
+    if(val == 0)
+    {
+        return 0.0;
+    }
+
+    // casting from float to double, while trying to increase precision
+    // in order to be comply with the FloatingPointRange configurations
+    // and to succeed the rclcpp NodeParameters::declare_parameter call
+    // for more info, see https://github.com/ros2/rclcpp/blob/rolling/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+    // rcl_interfaces::msg::SetParametersResult and __are_doubles_equal methods
+    float range = option_range.max - option_range.min;
+    int steps = range / option_range.step;
+    double step = static_cast<double>(range) / steps;
+    double rounded_div = std::round((val - option_range.min) / step);
+    return option_range.min + rounded_div * step;
+}
+
+//for more info, see https://docs.ros2.org/galactic/api/rcl_interfaces/msg/ParameterDescriptor.html
+template<class T>
+rcl_interfaces::msg::ParameterDescriptor SensorParams::get_parameter_descriptor(const std::string& option_name,
+    rs2::option_range option_range, T option_value, const std::string& option_description, const std::string& description_addition)
+{
+    rcl_interfaces::msg::ParameterDescriptor parameter_descriptor;
+
+    // set descriptor name to be the option name in order to get more detailed warnings/errors from rclcpp
+    parameter_descriptor.name = option_name;
+
+    // create description stream, and start filling it.
+    std::stringstream description_stream;
+    description_stream << option_description << std::endl << description_addition;
+    if(description_addition.length() > 0)
+         description_stream << std::endl;
+
+    if (std::is_same<T, double>::value)
+    {
+        parameter_descriptor.type = rclcpp::PARAMETER_DOUBLE;
+
+        // set option range values (floats)
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = float_to_double(option_range.min, option_range);
+        range.to_value = float_to_double(option_range.max, option_range);
+        range.step = float_to_double(option_range.step, option_range);
+        parameter_descriptor.floating_point_range.push_back(range);
+
+        // add the default value of this option to the description stream
+        description_stream << "Default value: " << static_cast<double>(option_range.def);        
+
+        ROS_INFO_STREAM("Declare: DOUBLE::" << option_name << "=" << option_value << "  [" << option_range.min << ", " << option_range.max << "]");
+    }
+    else // T is bool or int
+    {
+        // set option range values (integers) (suitable for boolean ranges also: [0,1])
+        rcl_interfaces::msg::IntegerRange range;
+        range.from_value = static_cast<int64_t>(option_range.min);
+        range.to_value = static_cast<int64_t>(option_range.max);
+        range.step = static_cast<uint64_t>(option_range.step);
+        parameter_descriptor.integer_range.push_back(range);
+
+        if (std::is_same<T, bool>::value) 
+        {
+            parameter_descriptor.type = rclcpp::PARAMETER_BOOL;
+
+            // add the default value of this option to the description stream
+            description_stream << "Default value: " << (option_range.def == 0 ? "False" : "True");
+
+            ROS_DEBUG_STREAM("Declare: BOOL::" << option_name << "=" << (option_range.def == 0 ? "False" : "True") << "  [" << option_range.min << ", " << option_range.max << "]");
+        }
+        else
+        {
+            parameter_descriptor.type = rclcpp::PARAMETER_INTEGER;
+
+            // add the default value of this option to the description stream
+            description_stream << "Default value: " << static_cast<int64_t>(option_range.def);
+
+            ROS_DEBUG_STREAM("Declare: INT::" << option_name << "=" << option_value << "  [" << option_range.min << ", " << option_range.max << "]");
+        }
+    }
+    parameter_descriptor.description = description_stream.str();
+    return parameter_descriptor;
+}
+
 template<class T>
 void SensorParams::set_parameter(rs2::options sensor, rs2_option option, const std::string& module_name, const std::string& description_addition)
 {
+    // set the option name, for example: depth_module.exposure
     const std::string option_name(module_name + "." + create_graph_resource_name(rs2_option_to_string(option)));
+
+    // get option current value, and option range values from the sensor
     T option_value;
-    rs2::option_range op_range;
+    rs2::option_range option_range;
     try
     {
-        op_range = sensor.get_option_range(option);
+        option_range = sensor.get_option_range(option);
         float current_val = sensor.get_option(option);
-        if(std::is_same<T, double>::value && current_val > 0)
+        if(std::is_same<T, double>::value)
         {
-            // casting from float to double, while trying to increase precision
-            // in order to be comply with the FloatingPointRange configurations
-            // and to succeed the rclcpp NodeParameters::declare_parameter call
-            float range = op_range.max - op_range.min;
-            int temp_val = range / current_val;
-            option_value = static_cast<double>(range) / temp_val;
+            option_value = float_to_double(current_val, option_range);
         }
         else
         {
@@ -114,52 +195,9 @@ void SensorParams::set_parameter(rs2::options sensor, rs2_option option, const s
         return;
     }
 
-    rcl_interfaces::msg::ParameterDescriptor crnt_descriptor;
-
-    // set descriptor name to be the option name in order to get more detailed warnings/errors
-    crnt_descriptor.name = option_name;
-
-    std::stringstream desc;
-    desc << sensor.get_option_description(option) << std::endl << description_addition;
-    if (std::is_same<T, int>::value || std::is_same<T, bool>::value)
-    {
-        rcl_interfaces::msg::IntegerRange range;
-        range.from_value = static_cast<int64_t>(op_range.min);
-        range.to_value = static_cast<int64_t>(op_range.max);
-        range.step = static_cast<uint64_t>(op_range.step);
-        desc << " default value: " << static_cast<int64_t>(op_range.def);
-        crnt_descriptor.integer_range.push_back(range);
-        if (std::is_same<T, bool>::value) 
-        {
-            crnt_descriptor.type = rclcpp::PARAMETER_BOOL;
-            ROS_DEBUG_STREAM("Declare: BOOL::" << option_name << " = " << option_value << "[" << op_range.min << ", " << op_range.max << "]");
-        }
-        else
-        {
-            crnt_descriptor.type = rclcpp::PARAMETER_INTEGER;
-            ROS_DEBUG_STREAM("Declare: INT::" << option_name << " = " << option_value << "[" << op_range.min << ", " << op_range.max << "]");
-        }
-    }
-    else
-    {
-        rcl_interfaces::msg::FloatingPointRange range;
-        range.from_value = static_cast<double>(op_range.min);
-        range.to_value = static_cast<double>(op_range.max);
-
-        // casting from float to double, while trying to increase precision
-        // in order to be comply with the FloatingPointRange configurations
-        // and to succeed the rclcpp NodeParameters::declare_parameter call
-        float r = op_range.max - op_range.min;
-        int steps = r / op_range.step;
-        range.step = static_cast<double>(r) / steps;
-
-        desc << " default value: " << static_cast<double>(op_range.def);        
-        crnt_descriptor.floating_point_range.push_back(range);
-        crnt_descriptor.type = rclcpp::PARAMETER_DOUBLE;
-        ROS_DEBUG_STREAM("Declare: DOUBLE::" << option_name << " = " << option_value);
-    }
-
-    crnt_descriptor.description = desc.str();
+    // get parameter descriptor for this option
+    rcl_interfaces::msg::ParameterDescriptor parameter_descriptor = 
+        get_parameter_descriptor(option_name, option_range, option_value, sensor.get_option_description(option), description_addition);
     
     T new_val;
     try
@@ -167,12 +205,12 @@ void SensorParams::set_parameter(rs2::options sensor, rs2_option option, const s
         new_val = (_parameters->setParam<T>(option_name, option_value, [option, sensor](const rclcpp::Parameter& parameter)
                     {
                         param_set_option<T>(sensor, option, parameter);
-                    }, crnt_descriptor));
+                    }, parameter_descriptor));
         _parameters_names.push_back(option_name);
     }
     catch(const rclcpp::exceptions::InvalidParameterValueException& e)
     {
-        ROS_WARN_STREAM("Failed to set parameter:" << option_name << " = " << option_value << "[" << op_range.min << ", " << op_range.max << "]\n" << e.what());
+        ROS_WARN_STREAM("Failed to set parameter:" << option_name << " = " << option_value << "[" << option_range.min << ", " << option_range.max << "]\n" << e.what());
         return;
     }
     
@@ -184,7 +222,7 @@ void SensorParams::set_parameter(rs2::options sensor, rs2_option option, const s
         }
         catch(std::exception& e)
         {
-            ROS_WARN_STREAM("Failed to set value to sensor: " << option_name << " = " << option_value << "[" << op_range.min << ", " << op_range.max << "]\n" << e.what());            
+            ROS_WARN_STREAM("Failed to set value to sensor: " << option_name << " = " << option_value << "[" << option_range.min << ", " << option_range.max << "]\n" << e.what());            
         }
     }
 }

--- a/realsense2_camera/src/sensor_params.cpp
+++ b/realsense2_camera/src/sensor_params.cpp
@@ -100,31 +100,43 @@ void SensorParams::set_parameter(rs2::options sensor, rs2_option option, const s
     }
     rs2::option_range op_range = sensor.get_option_range(option);
     rcl_interfaces::msg::ParameterDescriptor crnt_descriptor;
+
+    // set descriptor name to be the option name in order to get more detailed warnings/errors
+    crnt_descriptor.name = option_name;
+
     std::stringstream desc;
     desc << sensor.get_option_description(option) << std::endl << description_addition;
     if (std::is_same<T, int>::value || std::is_same<T, bool>::value)
     {
         rcl_interfaces::msg::IntegerRange range;
-        range.from_value = int(op_range.min);
-        range.to_value = int(op_range.max);
-        range.step = int(op_range.step);
-        desc << " default value: " << int(op_range.def);
+        range.from_value = static_cast<int64_t>(op_range.min);
+        range.to_value = static_cast<int64_t>(op_range.max);
+        range.step = static_cast<uint64_t>(op_range.step);
+        desc << " default value: " << static_cast<int64_t>(op_range.def);
         crnt_descriptor.integer_range.push_back(range);
-        if (std::is_same<T, bool>::value)
+        if (std::is_same<T, bool>::value) 
+        {
+            crnt_descriptor.type = rclcpp::PARAMETER_BOOL;
             ROS_DEBUG_STREAM("Declare: BOOL::" << option_name << " = " << option_value << "[" << op_range.min << ", " << op_range.max << "]");
+        }
         else
+        {
+            crnt_descriptor.type = rclcpp::PARAMETER_INTEGER;
             ROS_DEBUG_STREAM("Declare: INT::" << option_name << " = " << option_value << "[" << op_range.min << ", " << op_range.max << "]");
+        }
     }
     else
     {
         rcl_interfaces::msg::FloatingPointRange range;
-        range.from_value = double(op_range.min);
-        range.to_value = double(op_range.max);
-        range.step = double(op_range.step);
-        desc << " default value: " << double(op_range.def);
+        range.from_value = static_cast<double>(op_range.min);
+        range.to_value = static_cast<double>(op_range.max);
+        range.step = static_cast<double>(op_range.step);
+        desc << " default value: " << static_cast<double>(op_range.def);        
         crnt_descriptor.floating_point_range.push_back(range);
+        crnt_descriptor.type = rclcpp::PARAMETER_DOUBLE;
         ROS_DEBUG_STREAM("Declare: DOUBLE::" << option_name << " = " << option_value);
     }
+
     crnt_descriptor.description = desc.str();
     
     T new_val;

--- a/realsense2_camera/src/sensor_params.cpp
+++ b/realsense2_camera/src/sensor_params.cpp
@@ -102,12 +102,13 @@ void SensorParams::set_parameter(rs2::options sensor, rs2_option option, const s
     rcl_interfaces::msg::ParameterDescriptor crnt_descriptor;
     std::stringstream desc;
     desc << sensor.get_option_description(option) << std::endl << description_addition;
-    crnt_descriptor.description = desc.str();
     if (std::is_same<T, int>::value || std::is_same<T, bool>::value)
     {
         rcl_interfaces::msg::IntegerRange range;
         range.from_value = int(op_range.min);
         range.to_value = int(op_range.max);
+	range.step = int(op_range.step);
+	desc << " default value: " << int(op_range.def);
         crnt_descriptor.integer_range.push_back(range);
         if (std::is_same<T, bool>::value)
             ROS_DEBUG_STREAM("Declare: BOOL::" << option_name << " = " << option_value << "[" << op_range.min << ", " << op_range.max << "]");
@@ -119,10 +120,13 @@ void SensorParams::set_parameter(rs2::options sensor, rs2_option option, const s
         rcl_interfaces::msg::FloatingPointRange range;
         range.from_value = double(op_range.min);
         range.to_value = double(op_range.max);
+        range.step = double(op_range.step);
+	desc << " default value: " << double(op_range.def);
         crnt_descriptor.floating_point_range.push_back(range);
         ROS_DEBUG_STREAM("Declare: DOUBLE::" << option_name << " = " << option_value);
     }
-
+    crnt_descriptor.description = desc.str();
+    
     T new_val;
     try
     {


### PR DESCRIPTION
Tracked by [DSO-18759]
- Added the correct step value to the Integer Range step value.
- Added default value to the parameter description section.
- Added parameter type
- Did some manipulation on floats before converting them to double, in order to get more precise values Thanks to @maloel suggestion
- Now, all warnings due to parameters wrong ranges or values are solved.
- Split long functions into short ones
