### PR TITLE
remove galactic from pre release GHA script

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -31,12 +31,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ros_distro: [humble, galactic, foxy]
+        ros_distro: [humble, foxy]
         include:
         - ros_distro: 'humble'
           os: ubuntu-22.04
-        - ros_distro: 'galactic'
-          os: ubuntu-20.04
         - ros_distro: 'foxy'
           os: ubuntu-20.04
           


### PR DESCRIPTION
Remove galactic from pre-release.yaml

Since galactic is EOL, our pre release script using industrial_ci throws an error:
`Running test 'ros_prerelease'
galactic is EOL, pre-releases test are not supported anymore.
`

Tracked by [LRS-654]