### PR TITLE
Correct  IMU_FRAME and IMU_OPTICAL_FRAME definition from camera_name

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -59,8 +59,8 @@ using realsense2_camera_msgs::msg::Extrinsics;
 using realsense2_camera_msgs::msg::IMUInfo;
 
 #define FRAME_ID(sip) (static_cast<std::ostringstream&&>(std::ostringstream() << _camera_name << "_" << STREAM_NAME(sip) << "_frame")).str()
-#define IMU_FRAME_ID (static_cast<std::ostringstream&&>(std::ostringstream() << _camera_name << "_imu_frame")).str()
-#define IMU_OPTICAL_FRAME_ID (static_cast<std::ostringstream&&>(std::ostringstream() << _camera_name << "_imu_optical_frame")).str()
+#define IMU_FRAME_ID(sip) (static_cast<std::ostringstream&&>(std::ostringstream() << _camera_name << "_imu_frame")).str()
+#define IMU_OPTICAL_FRAME_ID(sip) (static_cast<std::ostringstream&&>(std::ostringstream() << _camera_name << "_imu_optical_frame")).str()
 #define OPTICAL_FRAME_ID(sip) (static_cast<std::ostringstream&&>(std::ostringstream() << _camera_name << "_" << STREAM_NAME(sip) << "_optical_frame")).str()
 #define ALIGNED_DEPTH_TO_FRAME_ID(sip) (static_cast<std::ostringstream&&>(std::ostringstream() << _camera_name << "_" << "aligned_depth_to_" << STREAM_NAME(sip) << "_frame")).str()
 

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -363,7 +363,7 @@ void BaseRealSenseNode::FillImuData_Copy(const CimuData imu_data, std::deque<sen
 
 void BaseRealSenseNode::ImuMessage_AddDefaultValues(sensor_msgs::msg::Imu& imu_msg)
 {
-    imu_msg.header.frame_id = IMU_OPTICAL_FRAME_ID;
+    imu_msg.header.frame_id = IMU_OPTICAL_FRAME_ID(sip);
     imu_msg.orientation.x = 0.0;
     imu_msg.orientation.y = 0.0;
     imu_msg.orientation.z = 0.0;
@@ -916,8 +916,8 @@ void BaseRealSenseNode::calcAndPublishStaticTransform(const rs2::stream_profile&
 
     if ((_imu_sync_method > imu_sync_method::NONE) && (profile.stream_type() == RS2_STREAM_GYRO))
     {
-        publish_static_tf(transform_ts_, zero_trans, zero_rot_quaternions, FRAME_ID(sip), IMU_FRAME_ID);
-        publish_static_tf(transform_ts_, zero_trans, quaternion_optical, IMU_FRAME_ID, IMU_OPTICAL_FRAME_ID);
+        publish_static_tf(transform_ts_, zero_trans, zero_rot_quaternions, FRAME_ID(sip), IMU_FRAME_ID(sip));
+        publish_static_tf(transform_ts_, zero_trans, quaternion_optical, IMU_FRAME_ID(sip), IMU_OPTICAL_FRAME_ID(sip));
     }
 
     publishExtrinsicsTopic(sip, ex);


### PR DESCRIPTION
Related to the issue  #2617.

Now the imu topic header is based on camera_name:
```
header:
  stamp:
    sec: 1676470898
    nanosec: 797342208
  frame_id: front_camera_imu_optical_frame
orientation:
  x: 0.0
  y: 0.0
  z: 0.0
```
And the tf tree is complete:
![Screenshot from 2023-02-15 09-22-43](https://user-images.githubusercontent.com/42455962/219053875-e47550cd-c57a-412e-8f03-6ff874d6871e.png)
