### PR TITLE
Load d435.dae properly both for Rviz and Gazebo Ignition

### DIFF
--- a/realsense2_description/urdf/_d435.urdf.xacro
+++ b/realsense2_description/urdf/_d435.urdf.xacro
@@ -75,7 +75,7 @@ aluminum peripherial evaluation case.
           <!-- the mesh origin is at front plate in between the two infrared camera axes -->
           <origin xyz="${d435_zero_depth_to_glass + d435_glass_to_front} ${-d435_cam_depth_py} 0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
           <geometry>
-            <mesh filename="package://realsense2_description/meshes/d435.dae" />
+            <mesh filename="file://$(find realsense2_description)/meshes/d435.dae" />
           </geometry>
         </xacro:if>
         <xacro:unless value="${use_mesh}">


### PR DESCRIPTION
Current approach leads to error while loading .dae in gazebo

[ign gazebo-7] [Err] [SystemPaths.cc:378] Unable to find file with URI [model://realsense2_description/meshes/d435.dae] [ign gazebo-7] [Err] [SystemPaths.cc:473] Could not resolve file [model://realsense2_description/meshes/d435.dae] [ign gazebo-7] [Err] [MeshManager.cc:173] Unable to find file[model://realsense2_description/meshes/d435.dae] [ign gazebo-7] [Err] [MeshDescriptor.cc:56] Mesh manager can't find mesh named [model://realsense2_description/meshes/d435.dae] [ign gazebo-7] [Err] [Ogre2MeshFactory.cc:562] Cannot load null mesh [model://realsense2_description/meshes/d435.dae