### PR TITLE
Fix #2649: Expose USB port in DeviceInfo service

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -2567,6 +2567,7 @@ bool BaseRealSenseNode::getDeviceInfo(realsense2_camera::DeviceInfo::Request&,
     res.firmware_version = _dev.supports(RS2_CAMERA_INFO_FIRMWARE_VERSION) ? _dev.get_info(RS2_CAMERA_INFO_FIRMWARE_VERSION) : "";
     res.usb_type_descriptor = _dev.supports(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR) ? _dev.get_info(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR) : "";
     res.firmware_update_id = _dev.supports(RS2_CAMERA_INFO_FIRMWARE_UPDATE_ID) ? _dev.get_info(RS2_CAMERA_INFO_FIRMWARE_UPDATE_ID) : "";
+    res.physical_port = _dev.supports(RS2_CAMERA_INFO_PHYSICAL_PORT) ? _dev.get_info(RS2_CAMERA_INFO_PHYSICAL_PORT) : "";
 
     std::stringstream sensors_names;
     for(auto&& sensor : _dev_sensors)

--- a/realsense2_camera/srv/DeviceInfo.srv
+++ b/realsense2_camera/srv/DeviceInfo.srv
@@ -5,3 +5,4 @@ string firmware_version
 string usb_type_descriptor
 string firmware_update_id
 string sensors
+string physical_port


### PR DESCRIPTION
Adds a `physical_port` field to the DeviceInfo service response, see #2649.