### PR TITLE
Fix #2649: Expose USB port in DeviceInfo service (ros2)

### DIFF
--- a/realsense2_camera/src/rs_node_setup.cpp
+++ b/realsense2_camera/src/rs_node_setup.cpp
@@ -390,4 +390,5 @@ void BaseRealSenseNode::getDeviceInfo(const realsense2_camera_msgs::srv::DeviceI
     }
 
     res->sensors = sensors_names.str().substr(0, sensors_names.str().size()-1);
+    res->physical_port = _dev.supports(RS2_CAMERA_INFO_PHYSICAL_PORT) ? _dev.get_info(RS2_CAMERA_INFO_PHYSICAL_PORT) : "";
 }

--- a/realsense2_camera_msgs/srv/DeviceInfo.srv
+++ b/realsense2_camera_msgs/srv/DeviceInfo.srv
@@ -5,3 +5,4 @@ string firmware_version
 string usb_type_descriptor
 string firmware_update_id
 string sensors
+string physical_port


### PR DESCRIPTION
Same as #2654 but for the ROS2 driver.