### PR TITLE
Warn instead of error for undefined sensor callbacks

### DIFF
--- a/realsense2_camera/src/rs_node_setup.cpp
+++ b/realsense2_camera/src/rs_node_setup.cpp
@@ -161,8 +161,8 @@ void BaseRealSenseNode::setAvailableSensors()
         }
         else
         {
-            ROS_ERROR_STREAM("Module Name \"" << module_name << "\" does not define a callback.");
-            throw("Error: Module not supported");
+            ROS_WARN_STREAM("Module Name \"" << module_name << "\" does not define a callback.");
+            continue;
         }
         _available_ros_sensors.push_back(std::move(rosSensor));
     }


### PR DESCRIPTION
Tracked by [LRS-727]

- Warn instead of error when sensor doesn't define a callback method.