### PR TITLE
Resolve symbol lookup issue by including opencv in cmakelist

### DIFF
--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -8,6 +8,9 @@ option(SET_USER_BREAK_AT_STARTUP "Set user wait point in startup (for debug)" OF
 add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
+# Find OpenCV dependency
+find_package(OpenCV REQUIRED)
+
 find_package(catkin REQUIRED COMPONENTS
     message_generation
     nav_msgs
@@ -88,6 +91,7 @@ include_directories(
     include
     ${realsense2_INCLUDE_DIR}
     ${catkin_INCLUDE_DIRS}
+    ${OpenCV_INCLUDE_DIRS}
     )
 
 # RealSense ROS Node
@@ -122,6 +126,7 @@ target_link_libraries(${PROJECT_NAME}
     ${realsense2_LIBRARY}
     ${catkin_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
+    ${OpenCV_LIBRARIES}
     )
 
 if(WIN32)


### PR DESCRIPTION
When launching `demo_t265.launch` in the `realsense2_camera` package, I was getting the following error on the Jetson Nano:
```
/opt/ros/noetic/lib/nodelet/nodelet: symbol lookup error: /home/jetson/catkin_ws/devel/lib//librealsense2_camera.so: undefined symbol: _ZN2cv3MatC1Ev
```

This causes the node to die:
```
[camera/realsense2_camera_manager-6] process has died [pid 11838, exit code 127, cmd /opt/ros/noetic/lib/nodelet/nodelet manager __name:=realsense2_camera_manager __log:=/home/jetson/.ros/log/6ba3e59e-c751-11ed-b31d-c168ba9af96b/camera-realsense2_camera_manager-6.log].
log file: /home/jetson/.ros/log/6ba3e59e-c751-11ed-b31d-c168ba9af96b/camera-realsense2_camera_manager-6*.log
[camera/realsense2_camera-7] process has finished cleanly
log file: /home/jetson/.ros/log/6ba3e59e-c751-11ed-b31d-c168ba9af96b/camera-realsense2_camera-7*.log
```

The fix suggested here: https://github.com/IntelRealSense/realsense-ros/issues/2326#issuecomment-1107658481 fixed it for me. This seems to have up come up in another issue as well (https://github.com/IntelRealSense/realsense-ros/issues/2467).