### PR TITLE
fix imu topic frame_id with came_name ns

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -59,8 +59,8 @@ using realsense2_camera_msgs::msg::Extrinsics;
 using realsense2_camera_msgs::msg::IMUInfo;
 
 #define FRAME_ID(sip) (static_cast<std::ostringstream&&>(std::ostringstream() << _camera_name << "_" << STREAM_NAME(sip) << "_frame")).str()
-#define IMU_FRAME_ID (static_cast<std::ostringstream&&>(std::ostringstream() << _camera_name << "_imu_frame")).str()
-#define IMU_OPTICAL_FRAME_ID (static_cast<std::ostringstream&&>(std::ostringstream() << _camera_name << "_imu_optical_frame")).str()
+#define IMU_FRAME_ID (static_cast<std::ostringstream&&>(std::ostringstream() << _camera_name <<  "_" << "imu_frame")).str()
+#define IMU_OPTICAL_FRAME_ID (static_cast<std::ostringstream&&>(std::ostringstream() << _camera_name << "_" << "imu_optical_frame")).str()
 #define OPTICAL_FRAME_ID(sip) (static_cast<std::ostringstream&&>(std::ostringstream() << _camera_name << "_" << STREAM_NAME(sip) << "_optical_frame")).str()
 #define ALIGNED_DEPTH_TO_FRAME_ID(sip) (static_cast<std::ostringstream&&>(std::ostringstream() << _camera_name << "_" << "aligned_depth_to_" << STREAM_NAME(sip) << "_frame")).str()
 

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -286,13 +286,13 @@ sensor_msgs::msg::Imu BaseRealSenseNode::CreateUnitedMessage(const CimuData acce
     rclcpp::Time t(gyro_data.m_time_ns);  //rclcpp::Time(uint64_t nanoseconds)
     imu_msg.header.stamp = t;
 
-    imu_msg.angular_velocity.x = gyro_data.m_data.x();
-    imu_msg.angular_velocity.y = gyro_data.m_data.y();
-    imu_msg.angular_velocity.z = gyro_data.m_data.z();
+    imu_msg.angular_velocity.x = -gyro_data.m_data.z();
+    imu_msg.angular_velocity.y = gyro_data.m_data.x();
+    imu_msg.angular_velocity.z = -gyro_data.m_data.y();
 
-    imu_msg.linear_acceleration.x = accel_data.m_data.x();
-    imu_msg.linear_acceleration.y = accel_data.m_data.y();
-    imu_msg.linear_acceleration.z = accel_data.m_data.z();
+    imu_msg.linear_acceleration.x = -accel_data.m_data.z();
+    imu_msg.linear_acceleration.y = accel_data.m_data.x();
+    imu_msg.linear_acceleration.z = -accel_data.m_data.y();
     return imu_msg;
 }
 

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -889,7 +889,9 @@ void BaseRealSenseNode::calcAndPublishStaticTransform(const rs2::stream_profile&
     // Transform base to stream
     stream_index_pair sip(profile.stream_type(), profile.stream_index());
     tf2::Quaternion quaternion_optical;
+    tf2::Quaternion quaternion_optical_imu;
     quaternion_optical.setRPY(-M_PI / 2, 0.0, -M_PI / 2);
+    quaternion_optical_imu.setRPY(0.0, 0.0, 0.0);
     float3 zero_trans{0, 0, 0};
     tf2::Quaternion zero_rot_quaternions;
     zero_rot_quaternions.setRPY(0, 0, 0);
@@ -932,7 +934,7 @@ void BaseRealSenseNode::calcAndPublishStaticTransform(const rs2::stream_profile&
     if ((_imu_sync_method > imu_sync_method::NONE) && (profile.stream_type() == RS2_STREAM_GYRO))
     {
         publish_static_tf(transform_ts_, zero_trans, zero_rot_quaternions, FRAME_ID(sip), IMU_FRAME_ID);
-        publish_static_tf(transform_ts_, zero_trans, quaternion_optical, IMU_FRAME_ID, IMU_OPTICAL_FRAME_ID);
+        publish_static_tf(transform_ts_, zero_trans, quaternion_optical_imu, IMU_FRAME_ID, IMU_OPTICAL_FRAME_ID);
     }
 
     publishExtrinsicsTopic(sip, ex);


### PR DESCRIPTION
The imu topic frame was published  with default name space which is "camera" even i gave different name to the camera_name parameter. The frame name was always "camera_imu_optical_frame" never changed according the camera_name