### PR TITLE
Fix Swapped TFs Axes

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,9 @@ The `/diagnostics` topic includes information regarding the device temperatures 
 
 - ROS2 Coordinate System: (X: Forward, Y:Left, Z: Up)
 - Camera Optical Coordinate System: (X: Right, Y: Down, Z: Forward)
-- References: [REP-0103](https://www.ros.org/reps/rep-0103.html#coordinate-frame-conventions) [REP-0105](https://www.ros.org/reps/rep-0105.html#coordinate-frames) 
+- References: [REP-0103](https://www.ros.org/reps/rep-0103.html#coordinate-frame-conventions), [REP-0105](https://www.ros.org/reps/rep-0105.html#coordinate-frames)
+- All data published in our wrapper topics is optical data taken directly from our camera sensors.
+- static and dynamic TF topics publish optical CS and ROS CS to give the user the ability to move from one CS to other CS.
 
 <hr>
 

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -205,7 +205,6 @@ namespace realsense2_camera
         void publishDynamicTransforms();
         void publishPointCloud(rs2::points f, const rclcpp::Time& t, const rs2::frameset& frameset);
         Extrinsics rsExtrinsicsToMsg(const rs2_extrinsics& extrinsics) const;
-        rs2_extrinsics invertExtrinsics(const rs2_extrinsics& ex) const;
 
         IMUInfo getImuInfo(const rs2::stream_profile& profile);
         

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -205,6 +205,7 @@ namespace realsense2_camera
         void publishDynamicTransforms();
         void publishPointCloud(rs2::points f, const rclcpp::Time& t, const rs2::frameset& frameset);
         Extrinsics rsExtrinsicsToMsg(const rs2_extrinsics& extrinsics) const;
+        rs2_extrinsics invertExtrinsics(const rs2_extrinsics& ex) const;
 
         IMUInfo getImuInfo(const rs2::stream_profile& profile);
         

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -888,30 +888,6 @@ void BaseRealSenseNode::publishExtrinsicsTopic(const stream_index_pair& sip, con
     }
 }
 
-
-rs2_extrinsics BaseRealSenseNode::invertExtrinsics(const rs2_extrinsics& ex) const
-{
-    rs2_extrinsics result;
-
-    // invert translation vector
-    result.translation[0] = -ex.translation[0];
-    result.translation[1] = -ex.translation[1];
-    result.translation[2] = -ex.translation[2];
-
-    // invert rotation matrix
-    result.rotation[0] = ex.rotation[0];
-    result.rotation[1] = ex.rotation[3];
-    result.rotation[2] = ex.rotation[6];
-    result.rotation[3] = ex.rotation[1];
-    result.rotation[4] = ex.rotation[4];
-    result.rotation[5] = ex.rotation[7];
-    result.rotation[6] = ex.rotation[2];
-    result.rotation[7] = ex.rotation[5];
-    result.rotation[8] = ex.rotation[8];
-
-    return result;
-}
-
 void BaseRealSenseNode::calcAndPublishStaticTransform(const rs2::stream_profile& profile, const rs2::stream_profile& base_profile)
 {
     // Transform base to stream
@@ -924,17 +900,25 @@ void BaseRealSenseNode::calcAndPublishStaticTransform(const rs2::stream_profile&
 
     rclcpp::Time transform_ts_ = _node.now();
 
-    rs2_extrinsics ex;
+    // extrinsic from A to B is the position of A relative to B
+    // TF from A to B is the transformation to be done on A to get to B
+    // so, we need to calculate extrinsics in two opposite ways, one for extrinsic topic
+    // and the second is for transformation topic (TF)
+    rs2_extrinsics normal_ex;  // used to for extrinsics topic
+    rs2_extrinsics tf_ex; // used for TF
+
     try
     {
-        ex = base_profile.get_extrinsics_to(profile);
+        normal_ex = base_profile.get_extrinsics_to(profile);
+        tf_ex = profile.get_extrinsics_to(base_profile);
     }
     catch (std::exception& e)
     {
         if (!strcmp(e.what(), "Requested extrinsics are not available!"))
         {
-            ROS_WARN_STREAM("(" << rs2_stream_to_string(profile.stream_type()) << ", " << profile.stream_index() << ") -> (" << rs2_stream_to_string(base_profile.stream_type()) << ", " << base_profile.stream_index() << "): " << e.what() << " : using unity as default.");
-            ex = rs2_extrinsics({{1, 0, 0, 0, 1, 0, 0, 0, 1}, {0,0,0}});
+            ROS_WARN_STREAM("(" << rs2_stream_to_string(base_profile.stream_type()) << ", " << base_profile.stream_index() << ") -> (" << rs2_stream_to_string(profile.stream_type()) << ", " << profile.stream_index() << "): " << e.what() << " : using unity as default.");
+            normal_ex = rs2_extrinsics({{1, 0, 0, 0, 1, 0, 0, 0, 1}, {0,0,0}});
+            tf_ex = normal_ex;
         }
         else
         {
@@ -942,20 +926,16 @@ void BaseRealSenseNode::calcAndPublishStaticTransform(const rs2::stream_profile&
         }
     }
 
-    publishExtrinsicsTopic(sip, ex);
+    // publish normal extrinsics e.g. /camera/extrinsics/depth_to_color
+    publishExtrinsicsTopic(sip, normal_ex);
 
-    // Invert extrinsic translation vector and rotation matrix before sending this as TF translation
-    // because extrinsic from A to B is the position of A relative to B
-    // while TF from A to B is the transformation to be done on A to get to B
-    ex = invertExtrinsics(ex);
-
-    auto Q = rotationMatrixToQuaternion(ex.rotation);
+    // publish static TF
+    auto Q = rotationMatrixToQuaternion(tf_ex.rotation);
     Q = quaternion_optical * Q * quaternion_optical.inverse();
-    float3 trans{ex.translation[0], ex.translation[1], ex.translation[2]};
-
+    float3 trans{tf_ex.translation[0], tf_ex.translation[1], tf_ex.translation[2]};
     publish_static_tf(transform_ts_, trans, Q, _base_frame_id, FRAME_ID(sip));
 
-    // Transform stream frame to stream optical frame
+    // Transform stream frame to stream optical frame and publish it
     publish_static_tf(transform_ts_, zero_trans, quaternion_optical, FRAME_ID(sip), OPTICAL_FRAME_ID(sip));
 
     if (profile.is<rs2::video_stream_profile>() && profile.stream_type() != RS2_STREAM_DEPTH && profile.stream_index() == 1)


### PR DESCRIPTION
Fixing issues #2500 #2637 #2583 
These issues related to static TFs and Extrinsic


### Background and Terminology:
- Point of view: Imagine we are standing behind of the camera, and looking forward.
- ROS2 Coordinates System (X: Forward, Y:Left, Z: Up). Everything related to TFs should be calculated in this coordination system.
- Camera Optical Coordinates System (X: Right, Y: Down, Z: Forward). Everything related to extrinsics should be calculated in this coordination system.
![image](https://user-images.githubusercontent.com/99127997/230150735-bc31fedf-d715-4e35-b462-fe2c338832c3.png)
- Static TF msg expresses a transform from coordinate frame header.frame_id (parent) to the coordinate frame child_frame_id [Reference](http://docs.ros.org/en/noetic/api/geometry_msgs/html/msg/Transform.html)
- Extrinsic from sensor A to sensor B means the position and orientation of sensor A relative to sensor B
- As you see, TF(A->B) translation should be the inversion of Extrinsic(A->B)
- In a previous [PR](https://github.com/IntelRealSense/realsense-ros/pull/2477), we fixed the Extrinsic calculation, which made the /camera/extrinsics/<A_TO_B> correct.
**For example, depth_to_color, in D435i:**
If we look from behind of the D435i, extrinsic from depth to color, means, where is the depth in relative to the color.
If we just look at X coordinates (again, from behind), we can say that Depth is on the right of RGB (color) sensor by 0.0148m (1.48cm), which is correct.

```
administrator@perclnx466 ~/ros2_humble $ ros2 topic echo /camera/extrinsics/depth_to_color
rotation:
...
translation:
- 0.01485931035131216
- 0.0010161789832636714
- 0.0005317096947692335
---
```
![image](https://user-images.githubusercontent.com/99127997/230220297-e392f0fc-63bf-4bab-8001-af1ddf0ed00e.png)


The problem we are trying to fix in this PR, is that when publishing this data as TF message, in the ROS2 coordinates system, we forgot to invert the extrinsic data. Please read the top of this description again if you still confused why we need to invert extrinsic data when we are moving from Optical coordinates system to ROS2 coordinates system.

Attaching rviz2 screenshots that describe the change.

### Before the fix:
You can see that INFRA1 is in the right side, and INFRA2 is in the left, while we are looking from behind of the camera, and this is wrong !
![before_the_fix](https://user-images.githubusercontent.com/99127997/230148060-61b1c39c-504e-44ce-93fc-5b026b4e6eab.png)


### After the fix:
![after_fix_camera](https://user-images.githubusercontent.com/99127997/230148106-0f79cbdb-c401-4d09-b386-a366af18e5f7.png)
![after_fix_2](https://user-images.githubusercontent.com/99127997/230148141-15544fc3-0987-41dd-a9eb-a20072cce17d.png)
