### PR TITLE
replace stereo module with depth module

### DIFF
--- a/realsense2_camera/src/ros_sensor.cpp
+++ b/realsense2_camera/src/ros_sensor.cpp
@@ -244,7 +244,7 @@ void RosSensor::stop()
 {
     if (get_active_streams().size() == 0)
         return;
-    ROS_INFO_STREAM("Stop Sensor: " << get_info(RS2_CAMERA_INFO_NAME));
+    ROS_INFO_STREAM("Stop Sensor: " << rs2_to_ros(get_info(RS2_CAMERA_INFO_NAME)));
     _frequency_diagnostics.clear();
 
     try
@@ -337,13 +337,13 @@ bool RosSensor::getUpdatedProfiles(std::vector<stream_profile>& wanted_profiles)
         profile_manager->addWantedProfiles(wanted_profiles);        
     }
 
-    ROS_DEBUG_STREAM(get_info(RS2_CAMERA_INFO_NAME) << ":" << "active_profiles.size() = " << active_profiles.size());
+    ROS_DEBUG_STREAM(rs2_to_ros(get_info(RS2_CAMERA_INFO_NAME)) << ":" << "active_profiles.size() = " << active_profiles.size());
     for (auto& profile : active_profiles)
     {
         ROS_DEBUG_STREAM("Sensor profile: " << ProfilesManager::profile_string(profile));
     }
 
-    ROS_DEBUG_STREAM(get_info(RS2_CAMERA_INFO_NAME) << ":" << "wanted_profiles");
+    ROS_DEBUG_STREAM(rs2_to_ros(get_info(RS2_CAMERA_INFO_NAME)) << ":" << "wanted_profiles");
     for (auto& profile : wanted_profiles)
     {
         ROS_DEBUG_STREAM("Sensor profile: " << ProfilesManager::profile_string(profile));

--- a/realsense2_camera/src/rs_node_setup.cpp
+++ b/realsense2_camera/src/rs_node_setup.cpp
@@ -139,7 +139,7 @@ void BaseRealSenseNode::setAvailableSensors()
 
     for(auto&& sensor : _dev_sensors)
     {
-        const std::string module_name(sensor.get_info(RS2_CAMERA_INFO_NAME));
+        const std::string module_name(rs2_to_ros(sensor.get_info(RS2_CAMERA_INFO_NAME)));
         std::unique_ptr<RosSensor> rosSensor;
         if (sensor.is<rs2::depth_sensor>() || 
             sensor.is<rs2::color_sensor>() ||
@@ -304,7 +304,7 @@ void BaseRealSenseNode::updateSensors()
     try{
         for(auto&& sensor : _available_ros_sensors)
         {
-            std::string module_name(sensor->get_info(RS2_CAMERA_INFO_NAME));
+            std::string module_name(rs2_to_ros(sensor->get_info(RS2_CAMERA_INFO_NAME)));
             // if active_profiles != wanted_profiles: stop sensor.
             std::vector<stream_profile> wanted_profiles;
 
@@ -386,7 +386,7 @@ void BaseRealSenseNode::getDeviceInfo(const realsense2_camera_msgs::srv::DeviceI
 
     for(auto&& sensor : _available_ros_sensors)
     {
-        sensors_names << create_graph_resource_name(sensor->get_info(RS2_CAMERA_INFO_NAME)) << ",";
+        sensors_names << create_graph_resource_name(rs2_to_ros(sensor->get_info(RS2_CAMERA_INFO_NAME))) << ",";
     }
 
     res->sensors = sensors_names.str().substr(0, sensors_names.str().size()-1);


### PR DESCRIPTION
Tracked by [DSO-18538]

Replace Info and Debug output including "Stereo Module" with "Depth Module"
Used "rs2_to_ros" function, which is in a common use inside our ROS wrapper, but was missing in some other places.

For example:

with new change, service sensor output includes depth_module instead of stereo_module
```
administrator@perclnx466 ~/ros2_humble $ ros2 service call /camera/device_info realsense2_camera_msgs/srv/DeviceInfo
requester: making request: realsense2_camera_msgs.srv.DeviceInfo_Request()

response:
realsense2_camera_msgs.srv.DeviceInfo_Response(device_name='intel_realsense_d435i', serial_number='912112073098', firmware_version='5.13.0.54', usb_type_descriptor='3.2', firmware_update_id='012345678901', sensors='depth_module,rgb_camera,motion_module', physical_port='/sys/devices/pci0000:00/0000:00:14.0/usb2/2-2/2-2:1.0/video4linux/video0')

```

also when launching / stopping the node, new changes are on (depth module instead of stereo module):
```
[realsense2_camera_node-1] [INFO] [1681232696.776424459] [camera.camera]: Stopping Sensor: Depth Module
[realsense2_camera_node-1] [INFO] [1681232696.800069233] [camera.camera]: Starting Sensor: Depth Module
[realsense2_camera_node-1] [INFO] [1681232696.854024481] [camera.camera]: Open profile: stream_type: Depth(0), Format: Z16, Width: 848, Height: 480, FPS: 30
[realsense2_camera_node-1] [INFO] [1681232767.603262833] [camera.camera]: Stop Sensor: Depth Module
[realsense2_camera_node-1] [INFO] [1681232767.603350548] [camera.camera]: Close Sensor.
[realsense2_camera_node-1] [INFO] [1681232767.614454247] [camera.camera]: Close Sensor - Done.

```

also when running with log_level:=debug, the changes are on (depth module instead of stereo module)
```
[realsense2_camera_node-1] [DEBUG] [1681233253.327902192] [camera.camera]: Set Depth Module as VideoSensor.
[realsense2_camera_node-1] [DEBUG] [1681233253.448831225] [camera.camera]: Depth Module:active_profiles.size() = 0
[realsense2_camera_node-1] [DEBUG] [1681233253.448852202] [camera.camera]: Depth Module:wanted_profiles

```