### PR TITLE
Fixing TF frame links b/w multi camera nodes when using custom names

### DIFF
--- a/realsense2_camera/launch/rs_multi_camera_launch.py
+++ b/realsense2_camera/launch/rs_multi_camera_launch.py
@@ -23,9 +23,9 @@
 
 """Launch realsense2_camera node."""
 import copy
-from launch import LaunchDescription
+from launch import LaunchDescription, LaunchContext
 import launch_ros.actions
-from launch.actions import IncludeLaunchDescription
+from launch.actions import IncludeLaunchDescription, OpaqueFunction
 from launch.substitutions import LaunchConfiguration, ThisLaunchFileDir
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 import sys
@@ -47,6 +47,16 @@ def duplicate_params(general_params, posix):
         param['name'] += posix
     return local_params
     
+def add_node_action(context : LaunchContext):
+    # dummy static transformation from camera1 to camera2
+    node = launch_ros.actions.Node(
+            package = "tf2_ros",
+            executable = "static_transform_publisher",
+            arguments = ["0", "0", "0", "0", "0", "0",
+                          context.launch_configurations['camera_name1'] + "_link",
+                          context.launch_configurations['camera_name2'] + "_link"]
+    )
+    return [node]
 
 def generate_launch_description():
     params1 = duplicate_params(rs_launch.configurable_parameters, '1')
@@ -64,10 +74,5 @@ def generate_launch_description():
             PythonLaunchDescriptionSource([ThisLaunchFileDir(), '/rs_launch.py']),
             launch_arguments=set_configurable_parameters(params2).items(),
         ),
-        # dummy static transformation from camera1 to camera2
-        launch_ros.actions.Node(
-            package = "tf2_ros",
-            executable = "static_transform_publisher",
-            arguments = ["0", "0", "0", "0", "0", "0", "camera1_link", "camera2_link"]
-        ),
+        OpaqueFunction(function=add_node_action)
     ])


### PR DESCRIPTION
When two camera nodes are launched using *multi_camera_launch.py*, 
- if default camera names are used, the TF frames of those two cameras are linked as below:
![image](https://user-images.githubusercontent.com/127019120/234169048-f7df8fe7-1d2e-4aee-b6be-881dbe9c84fe.png)

- if customs camera names are used, they are not linked
![image](https://user-images.githubusercontent.com/127019120/234169101-bbe976c3-b982-46e8-b693-b6c6e066b2b4.png)
