### PR TITLE
<material name="aluminum"/> is already defined as _materials.urdf.xacro

### DIFF
--- a/realsense2_description/urdf/_d435.urdf.xacro
+++ b/realsense2_description/urdf/_d435.urdf.xacro
@@ -70,7 +70,6 @@ aluminum peripherial evaluation case.
           <geometry>
             <box size="${d435_cam_depth} ${d435_cam_width} ${d435_cam_height}"/>
           </geometry>
-          <material name="aluminum"/>
         </xacro:unless>     
       </visual>
       <collision>


### PR DESCRIPTION

`<material name="aluminum"/>` is already defined in   `<xacro:include filename="$(find realsense2_description)/urdf/_materials.urdf.xacro" />`