### PR TITLE
Applying AlignDepth filter after Pointcloud

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -195,14 +195,15 @@ void BaseRealSenseNode::setupFilters()
         }
         _cv_mpc.notify_one();
     };
-    _align_depth_filter = std::make_shared<AlignDepthFilter>(std::make_shared<rs2::align>(RS2_STREAM_COLOR), update_align_depth_func, _parameters, _logger);
-    _filters.push_back(_align_depth_filter);
 
     _colorizer_filter = std::make_shared<NamedFilter>(std::make_shared<rs2::colorizer>(), _parameters, _logger); 
     _filters.push_back(_colorizer_filter);
 
     _pc_filter = std::make_shared<PointcloudFilter>(std::make_shared<rs2::pointcloud>(), _node, _parameters, _logger);
     _filters.push_back(_pc_filter);
+
+    _align_depth_filter = std::make_shared<AlignDepthFilter>(std::make_shared<rs2::align>(RS2_STREAM_COLOR), update_align_depth_func, _parameters, _logger);
+    _filters.push_back(_align_depth_filter);
 }
 
 cv::Mat& BaseRealSenseNode::fix_depth_scale(const cv::Mat& from_image, cv::Mat& to_image)


### PR DESCRIPTION
Fixing #2595. 

**Issue**:
- When both PointCloud and AlignDepth filters are enabled, the point cloud output has misaligned colored point cloud

**Root cause**:
- First Align Depth filter process the frame and then Point Cloud filter uses the same processed frame and internally align again
- That's why color is getting registered twice

**Proposed Solution**:
- Apply the Point Cloud filter first
    - So, it will get the unprocessed frame and internally do the alignment
    - The alignment will only happen on point cloud's data and the original depth frame will be untouched 
- Then, apply the Align Depth filter
    - It will get the original depth frame and does the alignment