### PR TITLE
Publish /aligned_depth_to_color topic only when color frame present

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -499,6 +499,8 @@ void BaseRealSenseNode::frame_callback(rs2::frame frame)
             clip_depth(original_depth_frame, _clipping_distance);
         }
 
+        rs2::video_frame original_color_frame = frameset.get_color_frame();
+
         ROS_DEBUG("num_filters: %d", static_cast<int>(_filters.size()));
         for (auto filter_it : _filters)
         {
@@ -529,7 +531,7 @@ void BaseRealSenseNode::frame_callback(rs2::frame frame)
             {
                 if (sent_depth_frame) continue;
                 sent_depth_frame = true;
-                if (_align_depth_filter->is_enabled())
+                if (original_color_frame && _align_depth_filter->is_enabled())
                 {
                     publishFrame(f, t, COLOR,
                             _depth_aligned_image,


### PR DESCRIPTION
**Issue:**
- /aligned_depth_to_color topic has unaligned images as well published randomly
- Happens especially when rgb module frame rate is less than depth module frame rate

**Root cause:**
- When a particular frameset have only depth frame and not color frame, alignment will not happen. But still, the unaligned image is getting published 

**Fix:**
- Publish aligned image only when both color and depth frames are present in the frameset