### PR TITLE
Replaced Deprecated function mktemp to TemporaryFile

### DIFF
--- a/realsense2_description/launch/launch_utils.py
+++ b/realsense2_description/launch/launch_utils.py
@@ -21,7 +21,7 @@ def to_urdf(xacro_path, parameters=None):
     * xacro_path -- the path to the xacro file
     * parameters -- to be used when xacro file is parsed.
     """
-    urdf_path = tempfile.mktemp(prefix="%s_" % os.path.basename(xacro_path))
+    urdf_path = tempfile.TemporaryFile(prefix="%s_" % os.path.basename(xacro_path))
 
     # open and process file
     doc = xacro.process_file(xacro_path, mappings=parameters)


### PR DESCRIPTION
The mktemp function in launch launch_utils.py presents a security vulnerability for my team that utilizes realsense-ros. To fix this, I utilized the function TemporaryFile which has the same purpose as mktemp but is a safe function to use whereas mktemp is a call to a deprecated function, which can be insecure. 