### PR TITLE
fix missing else due to merge from ros2-development

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -537,17 +537,19 @@ void BaseRealSenseNode::frame_callback(rs2::frame frame)
             {
                 publishPointCloud(f.as<rs2::points>(), t, frameset);
             }
-            if (stream_type == RS2_STREAM_DEPTH)
-            {
-                if (sent_depth_frame) continue;
-                sent_depth_frame = true;
-                if (original_color_frame && _align_depth_filter->is_enabled())
+            else {
+                if (stream_type == RS2_STREAM_DEPTH)
                 {
-                    publishFrame(f, t, COLOR, _depth_aligned_image, _depth_aligned_info_publisher, _depth_aligned_image_publishers, false);
-                    continue;
+                    if (sent_depth_frame) continue;
+                    sent_depth_frame = true;
+                    if (original_color_frame && _align_depth_filter->is_enabled())
+                    {
+                        publishFrame(f, t, COLOR, _depth_aligned_image, _depth_aligned_info_publisher, _depth_aligned_image_publishers, false);
+                        continue;
+                    }
                 }
+                publishFrame(f, t, sip, _images, _info_publishers, _image_publishers);
             }
-            publishFrame(f, t, sip, _images, _info_publishers, _image_publishers);
         }
         if (original_depth_frame && _align_depth_filter->is_enabled())
         {


### PR DESCRIPTION
Fixing a bug from a previous commit, while aligning ros2-hkr branch to the ros2-development (a bug during the merge, in base_realsense_node.cpp file)
[Commit#1314d5d177504e0ab2762d083fb06f0cb9bcc870](https://github.com/IntelRealSense/realsense-ros/commit/1314d5d177504e0ab2762d083fb06f0cb9bcc870)

the "else" was accidentally omitted
![image](https://github.com/IntelRealSense/realsense-ros/assets/99127997/da5b3f36-8276-4365-ab37-a581557554dc)

This caused rs2::points (depth point cloud), to override normal depth images in the ifs underneath.

Thanks @benlev for finding this issue.
