### PR TITLE
Updated rs_launch configurations

### DIFF
--- a/realsense2_camera/launch/rs_launch.py
+++ b/realsense2_camera/launch/rs_launch.py
@@ -85,43 +85,42 @@ def yaml_to_dict(path_to_yaml):
     with open(path_to_yaml, "r") as f:
         return yaml.load(f, Loader=yaml.SafeLoader)
 
-def launch_setup(context, *args, **kwargs):
-    _config_file = LaunchConfiguration("config_file").perform(context)
+def launch_setup(context, params, param_name_suffix=''):
+    _config_file = LaunchConfiguration('config_file' + param_name_suffix).perform(context)
     params_from_file = {} if _config_file == "''" else yaml_to_dict(_config_file)
-    log_level = 'info'
     # Realsense
     if (os.getenv('ROS_DISTRO') == "dashing") or (os.getenv('ROS_DISTRO') == "eloquent"):
         return [
             launch_ros.actions.Node(
                 package='realsense2_camera',
-                node_namespace=LaunchConfiguration("camera_name"),
-                node_name=LaunchConfiguration("camera_name"),
+                node_namespace=LaunchConfiguration('camera_name' + param_name_suffix),
+                node_name=LaunchConfiguration('camera_name' + param_name_suffix),
                 node_executable='realsense2_camera_node',
                 prefix=['stdbuf -o L'],
-                parameters=[set_configurable_parameters(configurable_parameters)
+                parameters=[params
                             , params_from_file
                             ],
                 output='screen',
-                arguments=['--ros-args', '--log-level', LaunchConfiguration('log_level')],
+                arguments=['--ros-args', '--log-level', LaunchConfiguration('log_level' + param_name_suffix)],
                 )
             ]
     else:
         return [
             launch_ros.actions.Node(
                 package='realsense2_camera',
-                namespace=LaunchConfiguration("camera_name"),
-                name=LaunchConfiguration("camera_name"),
+                namespace=LaunchConfiguration('camera_name' + param_name_suffix),
+                name=LaunchConfiguration('camera_name' + param_name_suffix),
                 executable='realsense2_camera_node',
-                parameters=[set_configurable_parameters(configurable_parameters)
+                parameters=[params
                             , params_from_file
                             ],
                 output='screen',
-                arguments=['--ros-args', '--log-level', LaunchConfiguration('log_level')],
+                arguments=['--ros-args', '--log-level', LaunchConfiguration('log_level' + param_name_suffix)],
                 emulate_tty=True,
                 )
         ]
     
 def generate_launch_description():
     return LaunchDescription(declare_configurable_parameters(configurable_parameters) + [
-        OpaqueFunction(function=launch_setup)
+        OpaqueFunction(function=launch_setup, kwargs = {'params' : set_configurable_parameters(configurable_parameters)})
     ])

--- a/realsense2_camera/launch/rs_multi_camera_launch.py
+++ b/realsense2_camera/launch/rs_multi_camera_launch.py
@@ -66,13 +66,11 @@ def generate_launch_description():
         rs_launch.declare_configurable_parameters(params1) + 
         rs_launch.declare_configurable_parameters(params2) + 
         [
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([ThisLaunchFileDir(), '/rs_launch.py']),
-            launch_arguments=set_configurable_parameters(params1).items(),
-        ),
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([ThisLaunchFileDir(), '/rs_launch.py']),
-            launch_arguments=set_configurable_parameters(params2).items(),
-        ),
+        OpaqueFunction(function=rs_launch.launch_setup,
+                       kwargs = {'params'           : set_configurable_parameters(params1),
+                                 'param_name_suffix': '1'}),
+        OpaqueFunction(function=rs_launch.launch_setup,
+                       kwargs = {'params'           : set_configurable_parameters(params2),
+                                 'param_name_suffix': '2'}),
         OpaqueFunction(function=add_node_action)
     ])


### PR DESCRIPTION
**Issue:**
- In `rs_multi_camera_launch.py`, '1' and '2' are appended as suffix of actual param names listed in `rs_launch.py`. For example: `enable_infra` param name from `rs_launch.py` becomes `enable_infra1` and `enable_infra2`. But, there are already params with those names in `rs_launch.py`. This leads to misconfiguration of params.

**Root cause:**
- Misconfiguration happens because while running `rs_multi_camera_launch.py` both actual and appended param names are getting registered
- No need to register actual param names from `rs_launch.py`
- Should register only appended param names

**Fix:**
- Updating `rs_launch.py` to support getting only required param names dynamically and register them