### PR TITLE
Fix align_depth + add test

### DIFF
--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -300,6 +300,7 @@ if(BUILD_TESTING)
     test
     test/templates
     test/rosbag
+    test/post_processing_filters
   )
   foreach(test_folder ${_pytest_folders})
     file(GLOB files "${test_folder}/test_*.py")

--- a/realsense2_camera/include/ros_sensor.h
+++ b/realsense2_camera/include/ros_sensor.h
@@ -95,7 +95,7 @@ namespace realsense2_camera
             template<class T> 
             bool is() const
             {
-                return (dynamic_cast<const T*> (&(*this)));
+                return rs2::sensor::is<T>();
             }
 
         private:

--- a/realsense2_camera/test/post_processing_filters/test_align_depth.py
+++ b/realsense2_camera/test/post_processing_filters/test_align_depth.py
@@ -1,0 +1,89 @@
+# Copyright 2023 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+import sys
+import subprocess
+import time
+
+import pytest
+from launch import LaunchDescription
+import launch_ros.actions
+import launch_pytest
+import rclpy
+from rclpy import qos
+from rclpy.node import Node
+from sensor_msgs.msg import Image as msg_Image
+from sensor_msgs.msg import Imu as msg_Imu
+
+sys.path.append(os.path.abspath(os.path.dirname(__file__)+"/../utils"))
+import pytest_rs_utils
+from pytest_rs_utils import launch_descr_with_yaml
+from pytest_rs_utils import get_rosbag_file_path
+
+
+'''
+This test imitates the ros2 launch rs_launch.py realsense2_camera with the given parameters below
+Full command to reproduce locally
+ros2 launch rs_launch.py realsense2_camera camera_name:=camera enable_color:=true \
+    enable_depth:=true rgb_camera.profile:=1280x720x30 depth_module.profile:=640x480x30 \
+    align_depth.enable:true rosbag_filename:=`realpath outdoors_1color.bag`
+
+Then we check if these topics exist:
+/camera/color/image_raw
+/camera/depth/image_rect_raw
+/camera/aligned_depth_to_color/image_raw
+
+Also we check that the recieved frames of each topic are in the right width and height
+'''
+test_params = {
+    "rosbag_filename":get_rosbag_file_path("outdoors_1color.bag"),
+    'camera_name': 'camera',
+    'enable_color': 'true',
+    'enable_depth': 'true',
+    'depth_module.profile': '1280x720x30',
+    'rgb_camera.profile': '640x480x30',
+    'align_depth.enable': 'true',
+    }
+
+
+@pytest.mark.rosbag
+@pytest.mark.launch(fixture=pytest_rs_utils.launch_descr_with_yaml)
+@pytest.mark.parametrize("launch_descr_with_yaml", [test_params],indirect=True)
+class TestBasicAlignDepthEnable(pytest_rs_utils.RsTestBaseClass):
+    def test_camera_1(self, launch_descr_with_yaml):
+        params = launch_descr_with_yaml[1]
+        data = pytest_rs_utils.ImageDepthGetData(params["rosbag_filename"])
+        themes = [
+            {'topic': '/'+params['camera_name']+'/color/image_raw', 'msg_type': msg_Image,
+             'expected_data_chunks': 1, 'width': 640, 'height': 480},
+            {'topic': '/'+params['camera_name']+'/depth/image_rect_raw', 'msg_type': msg_Image,
+             'expected_data_chunks': 1, 'width': 1280, 'height': 720},
+            {'topic': '/'+params['camera_name']+'/aligned_depth_to_color/image_raw', 'msg_type': msg_Image,
+             'expected_data_chunks': 1, 'width': 640, 'height': 480}
+        ]
+        try:
+            ''' 
+            initialize, run and check the data 
+            '''
+            self.init_test('RsTest'+params['camera_name'])
+            ret = self.run_test(themes)
+            assert ret[0], ret[1]
+            assert self.process_data(themes)
+        finally:
+            self.shutdown()
+
+    def process_data(self, themes):
+        return super().process_data(themes)

--- a/realsense2_camera/test/post_processing_filters/test_align_depth.py
+++ b/realsense2_camera/test/post_processing_filters/test_align_depth.py
@@ -50,7 +50,7 @@ Also we check that the recieved frames of each topic are in the right width and 
 '''
 test_params = {
     "rosbag_filename":get_rosbag_file_path("outdoors_1color.bag"),
-    'camera_name': 'camera',
+    'camera_name': 'camera_1',
     'enable_color': 'true',
     'enable_depth': 'true',
     'depth_module.profile': '1280x720x30',
@@ -63,9 +63,8 @@ test_params = {
 @pytest.mark.launch(fixture=pytest_rs_utils.launch_descr_with_yaml)
 @pytest.mark.parametrize("launch_descr_with_yaml", [test_params],indirect=True)
 class TestBasicAlignDepthEnable(pytest_rs_utils.RsTestBaseClass):
-    def test_camera_1(self, launch_descr_with_yaml):
+    def test_align_depth_on(self, launch_descr_with_yaml):
         params = launch_descr_with_yaml[1]
-        data = pytest_rs_utils.ImageDepthGetData(params["rosbag_filename"])
         themes = [
             {'topic': '/'+params['camera_name']+'/color/image_raw', 'msg_type': msg_Image,
              'expected_data_chunks': 1, 'width': 640, 'height': 480},
@@ -84,6 +83,3 @@ class TestBasicAlignDepthEnable(pytest_rs_utils.RsTestBaseClass):
             assert self.process_data(themes)
         finally:
             self.shutdown()
-
-    def process_data(self, themes):
-        return super().process_data(themes)

--- a/realsense2_camera/test/utils/pytest_rs_utils.py
+++ b/realsense2_camera/test/utils/pytest_rs_utils.py
@@ -770,6 +770,10 @@ class RsTestBaseClass():
     def process_data(self, themes):
         for theme in themes:
             data = self.node.pop_first_chunk(theme['topic'])
+            if 'width' in theme:
+                assert theme['width'] == data['shape'][0][1]  # (get from numpy image the width)
+            if 'height' in theme:
+                assert theme['height'] == data['shape'][0][0]  # (get from numpy image the height)
             if 'data' not in theme:
                 print('No data to compare for ' + theme['topic'])
                 #print(data)


### PR DESCRIPTION
Tracked in LRS-446
1- Fixed RosSensor is() method, which fixed the align_depth enable/disable during runtime
2- Added new folder for post processing tests, and added new basic test under it for align_depth
3- Fixed pytest_rs_utils.py to check also height and width if they exists in the received data