### PR TITLE
Fix: Pointcloud topic's frame_id

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -814,7 +814,7 @@ void BaseRealSenseNode::SetBaseStream()
 
 void BaseRealSenseNode::publishPointCloud(rs2::points pc, const rclcpp::Time& t, const rs2::frameset& frameset)
 {
-    std::string frame_id = (_align_depth_filter->is_enabled() ? OPTICAL_FRAME_ID(COLOR) : OPTICAL_FRAME_ID(DEPTH));
+    std::string frame_id = OPTICAL_FRAME_ID(DEPTH);
     _pc_filter->Publish(pc, t, frameset, frame_id);
 }
 


### PR DESCRIPTION
Fixing: Issue [#2810](https://github.com/IntelRealSense/realsense-ros/issues/2810)

As per the previously merged PR [#2775](https://github.com/IntelRealSense/realsense-ros/pull/2775), Align_depth filter will be applied after applying pointcloud filter. Thus, the dependency of align_depth filter on pointcloud filter had been removed in that PR. But, missed to update the frame_id of pointcloud topic accordingly. 

So, fixing it here.

