### PR TITLE
Fix device ID of D405

### DIFF
--- a/realsense2_camera/include/realsense2_camera/constants.h
+++ b/realsense2_camera/include/realsense2_camera/constants.h
@@ -34,7 +34,7 @@ namespace realsense2_camera
     const uint16_t RS435i_RGB_PID   = 0x0B3A; // AWGC_MM
     const uint16_t RS465_PID        = 0x0b4d; // D465
     const uint16_t RS416_RGB_PID    = 0x0B52; // F416 RGB
-    const uint16_t RS405_PID        = 0x0b0c; // DS5U
+    const uint16_t RS405_PID        = 0x0B5B; // DS5U
     const uint16_t RS455_PID        = 0x0B5C; // D455
     const uint16_t RS_T265_PID      = 0x0b37; // 
     const uint16_t RS_L515_PID_PRE_PRQ = 0x0B3D; // 


### PR DESCRIPTION
The camera is not found with the original ID. Please check!