### PR TITLE
Disabling hdr while updating exposure & gain values

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ The following post processing filters are available:
   - `depth_module.hdr_enabled`: to enable/disable HDR
   - The way to set exposure and gain values for each sequence in runtime is by first selecting the sequence id, using the `depth_module.sequence_id` parameter and then modifying the `depth_module.gain`, and `depth_module.exposure`.
     - From FW versions 5.14.x.x and above, if HDR is enabled, the preset configs (like exposure, gain, etc.,) cannot be updated.
-    - The user should disable the HDR first using `depth_module.hdr_enabled` parameter and then, update the required presets.
+      - Disable the HDR first using `depth_module.hdr_enabled` parameter and then, update the required presets.
   - To view the effect on the infrared image for each sequence id use the `filter_by_sequence_id.sequence_id` parameter.
   - To initialize these parameters in start time use the following parameters:
     - `depth_module.exposure.1`

--- a/README.md
+++ b/README.md
@@ -531,7 +531,10 @@ The following post processing filters are available:
     * The depth FOV and the texture FOV are not similar. By default, pointcloud is limited to the section of depth containing the texture. You can have a full depth to pointcloud, coloring the regions beyond the texture with zeros, by setting `pointcloud.allow_no_texture_points` to true.
     * pointcloud is of an unordered format by default. This can be changed by setting `pointcloud.ordered_pc` to true.
  - ```hdr_merge```: Allows depth image to be created by merging the information from 2 consecutive frames, taken with different exposure and gain values.
+  - `depth_module.hdr_enabled`: to enable/disable HDR
   - The way to set exposure and gain values for each sequence in runtime is by first selecting the sequence id, using the `depth_module.sequence_id` parameter and then modifying the `depth_module.gain`, and `depth_module.exposure`.
+    - From FW versions 5.14.x.x and above, if HDR is enabled, the preset configs (like exposure, gain, etc.,) cannot be updated.
+    - The user should disable the HDR first using `depth_module.hdr_enabled` parameter and then, update the required presets.
   - To view the effect on the infrared image for each sequence id use the `filter_by_sequence_id.sequence_id` parameter.
   - To initialize these parameters in start time use the following parameters:
     - `depth_module.exposure.1`

--- a/realsense2_camera/src/dynamic_params.cpp
+++ b/realsense2_camera/src/dynamic_params.cpp
@@ -25,6 +25,8 @@ namespace realsense2_camera
         _params_backend.add_on_set_parameters_callback(
             [this](const std::vector<rclcpp::Parameter> & parameters) 
                 { 
+                    rcl_interfaces::msg::SetParametersResult result;
+                    result.successful = true;
                     for (const auto & parameter : parameters) 
                     {
                         try
@@ -43,15 +45,15 @@ namespace realsense2_camera
                                 }
                             }
                         }
-                        catch(const std::out_of_range& e)
-                        {}
                         catch(const std::exception& e)
                         {
-                            std::cerr << e.what() << ":" << parameter.get_name() << '\n';
+                            result.successful = false;
+                            result.reason = e.what();
+                            ROS_WARN_STREAM("Set parameter {" << parameter.get_name()
+                                                            << "} failed: " << e.what());
                         }                            
                     }
-                    rcl_interfaces::msg::SetParametersResult result;
-                    result.successful = true;
+
                     return result;
                 });
         monitor_update_functions(); // Start parameters update thread

--- a/realsense2_camera/src/sensor_params.cpp
+++ b/realsense2_camera/src/sensor_params.cpp
@@ -70,14 +70,7 @@ std::map<std::string, int> get_enum_method(rs2::options sensor, rs2_option optio
 template<class T>
 void param_set_option(rs2::options sensor, rs2_option option, const rclcpp::Parameter& parameter)
 { 
-    try
-    {
-        sensor.set_option(option, parameter.get_value<T>());
-    }
-    catch(const std::exception& e)
-    {
-        std::cout << "Failed to set value: " << e.what() << std::endl;
-    }
+    sensor.set_option(option, parameter.get_value<T>());
 }
 
 void SensorParams::clearParameters()


### PR DESCRIPTION
Tracked on LRS-962

**Overview**:
- On FW versions 5.13.0.50 and below, the FW allowed to set the preset values (like exposure, gain, etc) when HDR is enabled.
- But in later FW versions 5.14.x.x and above, updating preset values are restricted when HDR is enabled.
- This FW change affected the ROS wrapper's flow for setting the exposure and gain of sequence IDs 1 & 2 (**during launch time**) through below params:
  - depth_module.exposure.1
  - depth_module.gain.1
  - depth_module.exposure.2
  - depth_module.gain.2

This PR makes sure that the HDR is disabled while setting those params during launch time.

During runtime, if the HDR is enabled, the presets cannot be updated. To update them, should disable HDR first and then try.