### PR TITLE
fix ros random crash with error hw monitor command for asic temperature failed

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -1140,10 +1140,18 @@ void BaseRealSenseNode::startDiagnosticsUpdater()
             {
                 for (rs2_option option : _monitor_options)
                 {
-                    if (sensor->supports(option))
+                    try
                     {
-                        status.add(rs2_option_to_string(option), sensor->get_option(option));
-                        got_temperature = true;
+                        if (sensor->supports(option))
+                        {
+                            status.add(rs2_option_to_string(option), sensor->get_option(option));
+                            got_temperature = true;
+                        }
+                    }
+                    catch(const std::exception& ex)
+                    {
+                        got_temperature = false;
+                        ROS_WARN_STREAM("An error has occurred during monitoring: " << ex.what());
                     }
                 }
                 if (got_temperature) break;


### PR DESCRIPTION
fix ros random crash with error hw monitor command for asic temperature failed

changes:
add error handling to avoid crash when asic temperature monitor occasionally fails and throws exception

Tracked on: LRS-982