### PR TITLE
to_urdf fun retrun a str, not a BufferedRandom

### DIFF
--- a/realsense2_description/launch/launch_utils.py
+++ b/realsense2_description/launch/launch_utils.py
@@ -21,12 +21,13 @@ def to_urdf(xacro_path, parameters=None):
     * xacro_path -- the path to the xacro file
     * parameters -- to be used when xacro file is parsed.
     """
-    urdf_path = tempfile.TemporaryFile(prefix="%s_" % os.path.basename(xacro_path))
+    with tempfile.NamedTemporaryFile(prefix="%s_" % os.path.basename(xacro_path), delete=False) as xacro_file:
+        urdf_path = xacro_file.name
 
     # open and process file
     doc = xacro.process_file(xacro_path, mappings=parameters)
     # open the output file
-    out = xacro.open_output(urdf_path)
-    out.write(doc.toprettyxml(indent='  '))
+    with open(urdf_path, 'w') as urdf_file:
+        urdf_file.write(doc.toprettyxml(indent='  '))
 
     return urdf_path


### PR DESCRIPTION
My env:
Ubuntu22.04
ros2 humble

When I run `ros2 launch realsense2_description view_model.launch.py model:=test_d435i_camera.urdf.xacro`, I received a error message
`[ERROR] [launch]: Caught exception in launch (see debug for traceback): Caught exception when trying to load file of format [py]: expected str, bytes or os.PathLike object, not BufferedRandom`

I used Github's copilot to fix this error and it gives this modification.
It works now, but I don't know Whether this modification is appropriate