### PR TITLE
Fix GHA Warning - Remove deprecated nodes usages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,10 +37,10 @@ jobs:
     steps:
 
     - name: Setup ROS2 Workspace
-      run: | 
+      run: |
         mkdir -p ${{github.workspace}}/ros2/src
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         path: 'ros2/src/realsense-ros'
     

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -45,6 +45,6 @@ jobs:
       BASEDIR: ${{ github.workspace }}/.work
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: industrial_ci
         uses: ros-industrial/industrial_ci@master


### PR DESCRIPTION
Remove GHA warnings like this:
![image](https://github.com/IntelRealSense/realsense-ros/assets/99127997/0e5eaabc-f391-4b6c-8283-697caf819ec3)

The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info:[ https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/)