### PR TITLE
Assert Fail if camera not found

### DIFF
--- a/realsense2_camera/test/live_camera/test_camera_aligned_tests.py
+++ b/realsense2_camera/test/live_camera/test_camera_aligned_tests.py
@@ -79,6 +79,7 @@ class TestCamera_AlignDepthColor(pytest_rs_utils.RsTestBaseClass):
         params = launch_descr_with_parameters[1]
         if pytest_live_camera_utils.check_if_camera_connected(params['device_type']) == False:
             print("Device not found? : " + params['device_type'])
+            assert False
             return
         themes = [
         {'topic':get_node_heirarchy(params)+'/color/image_raw',
@@ -144,9 +145,9 @@ test_params_all_profiles_d415 = {
     'rgb_camera.profile':'640x480x30',    
     'align_depth.enable':'true'
     }
-test_params_all_profiles_d435 = {
-    'camera_name': 'D435',
-    'device_type': 'D435',
+test_params_all_profiles_d435i = {
+    'camera_name': 'D435I',
+    'device_type': 'D435I',
     'enable_color':'true',
     'enable_depth':'true',
     'depth_module.profile':'848x480x30',    
@@ -166,7 +167,7 @@ machines that don't have the D455 connected.
 @pytest.mark.parametrize("launch_descr_with_parameters", [
     pytest.param(test_params_all_profiles_d455, marks=pytest.mark.d455),
     pytest.param(test_params_all_profiles_d415, marks=pytest.mark.d415),
-    pytest.param(test_params_all_profiles_d435, marks=pytest.mark.d435),]
+    pytest.param(test_params_all_profiles_d435i, marks=pytest.mark.d435i),]
     ,indirect=True)
 @pytest.mark.launch(fixture=launch_descr_with_parameters)
 class TestCamera_AllAlignDepthColor(pytest_rs_utils.RsTestBaseClass):
@@ -178,6 +179,7 @@ class TestCamera_AllAlignDepthColor(pytest_rs_utils.RsTestBaseClass):
         params = launch_descr_with_parameters[1]
         if pytest_live_camera_utils.check_if_camera_connected(params['device_type']) == False:
             print("Device not found? : " + params['device_type'])
+            assert False
             return
         themes = [
         {'topic':get_node_heirarchy(params)+'/color/image_raw',

--- a/realsense2_camera/test/live_camera/test_camera_all_profile_tests.py
+++ b/realsense2_camera/test/live_camera/test_camera_all_profile_tests.py
@@ -127,9 +127,9 @@ test_params_all_profiles_d415 = {
     'camera_name': 'D415',
     'device_type': 'D415',
     }
-test_params_all_profiles_d435 = {
-    'camera_name': 'D435',
-    'device_type': 'D435',
+test_params_all_profiles_d435i = {
+    'camera_name': 'D435I',
+    'device_type': 'D435I',
     }
 
 
@@ -144,7 +144,7 @@ machines that don't have the D455 connected.
 @pytest.mark.parametrize("launch_descr_with_parameters", [
     pytest.param(test_params_all_profiles_d455, marks=pytest.mark.d455),
     pytest.param(test_params_all_profiles_d415, marks=pytest.mark.d415),
-    pytest.param(test_params_all_profiles_d435, marks=pytest.mark.d435),]
+    pytest.param(test_params_all_profiles_d435i, marks=pytest.mark.d435i),]
     ,indirect=True)
 @pytest.mark.launch(fixture=launch_descr_with_parameters)
 class TestLiveCamera_Change_Resolution(pytest_rs_utils.RsTestBaseClass):
@@ -154,6 +154,10 @@ class TestLiveCamera_Change_Resolution(pytest_rs_utils.RsTestBaseClass):
         num_passed = 0
         num_failed = 0
         params = launch_descr_with_parameters[1]
+        if pytest_live_camera_utils.check_if_camera_connected(params['device_type']) == False:
+            print("Device not found? : " + params['device_type'])
+            assert False
+            return
         themes = [{'topic':get_node_heirarchy(params)+'/color/image_raw', 'msg_type':msg_Image,'expected_data_chunks':1}]
         config = pytest_live_camera_utils.get_profile_config(get_node_heirarchy(params))
         try:

--- a/realsense2_camera/test/live_camera/test_camera_fps_tests.py
+++ b/realsense2_camera/test/live_camera/test_camera_fps_tests.py
@@ -74,6 +74,7 @@ class TestCamera_TestFPS(pytest_rs_utils.RsTestBaseClass):
         params = launch_descr_with_parameters[1]
         if pytest_live_camera_utils.check_if_camera_connected(params['device_type']) == False:
             print("Device not found? : " + params['device_type'])
+            assert False
             return
         try:
             ''' 

--- a/realsense2_camera/test/live_camera/test_camera_imu_tests.py
+++ b/realsense2_camera/test/live_camera/test_camera_imu_tests.py
@@ -57,6 +57,7 @@ class TestLiveCamera_TestMotionSensor(pytest_rs_utils.RsTestBaseClass):
         params = launch_descr_with_parameters[1]
         if pytest_live_camera_utils.check_if_camera_connected(params['device_type']) == False:
             print("Device not found? : " + params['device_type'])
+            assert False
             return
         themes = [{'topic':get_node_heirarchy(params)+'/imu', 'msg_type':msg_Imu,'expected_data_chunks':1},
                 {'topic':get_node_heirarchy(params)+'/gyro/sample', 'msg_type':msg_Imu,'expected_data_chunks':1},

--- a/realsense2_camera/test/live_camera/test_camera_point_cloud_tests.py
+++ b/realsense2_camera/test/live_camera/test_camera_point_cloud_tests.py
@@ -55,9 +55,9 @@ test_params_points_cloud_d455 = {
     'device_type': 'D455',
     'pointcloud.enable': 'true'
     }
-test_params_points_cloud_d435 = {
-    'camera_name': 'D435',
-    'device_type': 'D435',
+test_params_points_cloud_d435i = {
+    'camera_name': 'D435I',
+    'device_type': 'D435I',
     'pointcloud.enable': 'true'
     }
 
@@ -76,7 +76,7 @@ the command used to run is "python3 realsense2_camera/scripts/rs2_test.py points
 '''
 @pytest.mark.parametrize("launch_descr_with_parameters", [
     pytest.param(test_params_points_cloud_d455, marks=pytest.mark.d455),
-    pytest.param(test_params_points_cloud_d435, marks=pytest.mark.d435),
+    pytest.param(test_params_points_cloud_d435i, marks=pytest.mark.d435i),
     pytest.param(test_params_points_cloud_d415, marks=pytest.mark.d415),
     ],indirect=True)
 @pytest.mark.launch(fixture=launch_descr_with_parameters)
@@ -85,6 +85,7 @@ class TestCamera_TestPointCloud(pytest_rs_utils.RsTestBaseClass):
         self.params = launch_descr_with_parameters[1]
         if pytest_live_camera_utils.check_if_camera_connected(self.params['device_type']) == False:
             print("Device not found? : " + self.params['device_type'])
+            assert False
             return
         themes = [
         {

--- a/realsense2_camera/test/live_camera/test_camera_tf_tests.py
+++ b/realsense2_camera/test/live_camera/test_camera_tf_tests.py
@@ -58,9 +58,9 @@ test_params_tf_static_change_d455 = {
     'enable_accel': 'true',
     'enable_gyro': 'true',
     }
-test_params_tf_static_change_d435 = {
-    'camera_name': 'D435',
-    'device_type': 'D435',
+test_params_tf_static_change_d435i = {
+    'camera_name': 'D435I',
+    'device_type': 'D435I',
     'enable_infra1': 'false',
     'enable_infra2': 'true',
     'enable_accel': 'true',
@@ -77,7 +77,7 @@ test_params_tf_static_change_d415 = {
     }    
 @pytest.mark.parametrize("launch_descr_with_parameters", [
     pytest.param(test_params_tf_static_change_d455, marks=pytest.mark.d455),
-    pytest.param(test_params_tf_static_change_d435, marks=pytest.mark.d435),
+    pytest.param(test_params_tf_static_change_d435i, marks=pytest.mark.d435i),
     pytest.param(test_params_tf_static_change_d415, marks=pytest.mark.d415),
     ],indirect=True)
 @pytest.mark.launch(fixture=launch_descr_with_parameters)
@@ -86,6 +86,7 @@ class TestCamera_TestTF_Static_change(pytest_rs_utils.RsTestBaseClass):
         self.params = launch_descr_with_parameters[1]
         if pytest_live_camera_utils.check_if_camera_connected(self.params['device_type']) == False:
             print("Device not found? : " + self.params['device_type'])
+            assert False
             return
         themes = [
         {'topic':'/tf_static',
@@ -145,9 +146,9 @@ test_params_tf_d455 = {
     'tf_publish_rate': '1.1',
     }
 
-test_params_tf_d435 = {
-    'camera_name': 'D435',
-    'device_type': 'D435',
+test_params_tf_d435i = {
+    'camera_name': 'D435I',
+    'device_type': 'D435I',
     'publish_tf': 'true',
     'tf_publish_rate': '1.1',
     }
@@ -160,7 +161,7 @@ test_params_tf_d415 = {
     }
 @pytest.mark.parametrize("launch_descr_with_parameters", [
     pytest.param(test_params_tf_d455, marks=pytest.mark.d455),
-    pytest.param(test_params_tf_d435, marks=pytest.mark.d435),
+    pytest.param(test_params_tf_d435i, marks=pytest.mark.d435i),
     pytest.param(test_params_tf_d415, marks=pytest.mark.d415),
     ],indirect=True)
 @pytest.mark.launch(fixture=launch_descr_with_parameters)
@@ -169,6 +170,7 @@ class TestCamera_TestTF_DYN(pytest_rs_utils.RsTestBaseClass):
         self.params = launch_descr_with_parameters[1]
         if pytest_live_camera_utils.check_if_camera_connected(self.params['device_type']) == False:
             print("Device not found? : " + self.params['device_type'])
+            assert False
             return
         themes = [
         {'topic':'/tf',

--- a/realsense2_camera/test/live_camera/test_d415_basic_tests.py
+++ b/realsense2_camera/test/live_camera/test_d415_basic_tests.py
@@ -57,6 +57,7 @@ class TestD415_Change_Resolution(pytest_rs_utils.RsTestBaseClass):
         params = launch_descr_with_parameters[1]
         if pytest_live_camera_utils.check_if_camera_connected(params['device_type']) == False:
             print("Device not found? : " + params['device_type'])
+            assert False
             return
         failed_tests = []
         num_passed = 0

--- a/realsense2_camera/test/live_camera/test_d455_basic_tests.py
+++ b/realsense2_camera/test/live_camera/test_d455_basic_tests.py
@@ -58,6 +58,7 @@ class TestD455_Change_Resolution(pytest_rs_utils.RsTestBaseClass):
         params = launch_descr_with_parameters[1]
         if pytest_live_camera_utils.check_if_camera_connected(params['device_type']) == False:
             print("Device not found? : " + params['device_type'])
+            assert False
             return
 
         themes = [
@@ -116,6 +117,7 @@ class Test_D455_Seq_ID_Update(pytest_rs_utils.RsTestBaseClass):
         params = launch_descr_with_parameters[1]
         if pytest_live_camera_utils.check_if_camera_connected(params['device_type']) == False:
             print("Device not found? : " + params['device_type'])
+            assert False
             return
 
         try:


### PR DESCRIPTION
Live camera tests updated to have assertion when the camera device not connected to avoid false CI pass