### PR TITLE
Update actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
       run: |
         mkdir -p ${{github.workspace}}/ros2/src
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: 'ros2/src/realsense-ros'
     

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -45,6 +45,6 @@ jobs:
       BASEDIR: ${{ github.workspace }}/.work
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: industrial_ci
         uses: ros-industrial/industrial_ci@master


### PR DESCRIPTION
remove github actions warning about node 16 that is still used in checkout v3
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

![image](https://github.com/IntelRealSense/realsense-ros/assets/99127997/4ec7d868-5db7-40b8-904a-ff9a66815e88)


still need to see if we can fix the ros-tooling setup ros issue