### PR TITLE
Fix collision offset

### DIFF
--- a/realsense2_description/urdf/_d435.urdf.xacro
+++ b/realsense2_description/urdf/_d435.urdf.xacro
@@ -74,7 +74,7 @@ aluminum peripherial evaluation case.
         </xacro:unless>     
       </visual>
       <collision>
-        <origin xyz="0 ${-d435_cam_depth_py} 0" rpy="0 0 0"/>
+        <origin xyz="-0.0085 ${-d435_cam_depth_py} 0" rpy="0 0 0"/>
         <geometry>
           <box size="${d435_cam_depth} ${d435_cam_width} ${d435_cam_height}"/>
         </geometry>


### PR DESCRIPTION
Realsense d435 collision and visual were misaligned, so an offset was added to collision to align them.
- fix #3085 