### PR TITLE
Install specific numpy version to avoid errors in github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,7 +113,8 @@ jobs:
     #    wget $bag_filename -P "records/"
     #    sudo apt install ros-${{ matrix.ros_distro}}-launch-pytest
        
-    - name: Install Packages For Tests
+    - name: Install Packages For Foxy Tests
+      if: ${{ matrix.ros_distro == 'foxy' }}
       run: |
         # To avoid mixing of 'apt' provided packages and 'pip' provided packages, one way is to create virtual env
         # and manage python packages within it. Ref: https://peps.python.org/pep-0668/
@@ -121,9 +122,23 @@ jobs:
         # Activate the virtual env such that following python related commands run within it.
         source .venv/bin/activate
         sudo apt-get install python3-pip
-        pip3 install numpy --upgrade
+        # numpy-quaternion needs numpy<2.0.0. Chose 1.24.1 as it is the highest version that support foxy.
+        pip3 install --force-reinstall numpy==1.24.1
         pip3 install numpy-quaternion tqdm pyyaml
 
+    - name: Install Packages For Humble/Iron/Rolling/Jazzy Tests
+      if: ${{ matrix.ros_distro != 'foxy' }}
+      run: |
+        # To avoid mixing of 'apt' provided packages and 'pip' provided packages, one way is to create virtual env
+        # and manage python packages within it. Ref: https://peps.python.org/pep-0668/
+        python3 -m venv .venv
+        # Activate the virtual env such that following python related commands run within it.
+        source .venv/bin/activate
+        sudo apt-get install python3-pip
+        # numpy-quaternion needs numpy<2.0.0. Chose 1.26.4 as it is the lowest working version for ubuntu 24.04.
+        pip3 install --force-reinstall numpy==1.26.4
+        pip3 install numpy-quaternion tqdm pyyaml
+  
  
     - name: Run Tests
       run: |


### PR DESCRIPTION
Numpy has released a new version (2.0.0) before a couple of hours.. and it is failing our GitHub workflows in the testing section... because we have `pip3 install numpy --upgrade` which will install latest version..
 
![image](https://github.com/IntelRealSense/realsense-ros/assets/99127997/0da824ee-7020-4f8a-bc38-35397fdea08a)
