### PR TITLE
Added base_frame_id param to the rs_launch.py file

### DIFF
--- a/realsense2_camera/launch/rs_launch.py
+++ b/realsense2_camera/launch/rs_launch.py
@@ -90,6 +90,7 @@ configurable_parameters = [{'name': 'camera_name',                  'default': '
                            {'name': 'hdr_merge.enable',             'default': 'false', 'description': 'hdr_merge filter enablement flag'},
                            {'name': 'wait_for_device_timeout',      'default': '-1.', 'description': 'Timeout for waiting for device to connect (Seconds)'},
                            {'name': 'reconnect_timeout',            'default': '6.', 'description': 'Timeout(seconds) between consequtive reconnection attempts'},
+                           {'name': 'base_frame_id',                'default': 'link', 'description': 'Root frame of the sensors transform tree'},
                           ]
 
 def declare_configurable_parameters(parameters):


### PR DESCRIPTION
Updates with reference to Issue #3312 .

The PR aims to expose the base_frame_id param which was missing in the `rs_launch.py` file. This allows the user to modify the default base_frame_id from `link` to something of the user's choice when using the launch file.

Following the specified guidelines, I have executed the `pr_check.sh` script, and no errors were reported!