### PR TITLE
Ashraf/glsl pointcloud

### DIFF
--- a/realsense2_camera/src/pointcloud_filter.cpp
+++ b/realsense2_camera/src/pointcloud_filter.cpp
@@ -15,6 +15,7 @@
 #include <pointcloud_filter.h>
 #include <fstream>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
+#include "dynamic_params.h"
 
 
 using namespace realsense2_camera;
@@ -95,11 +96,13 @@ void PointcloudFilter::Publish(rs2::points pc, const rclcpp::Time& t, const rs2:
         if ((!_pointcloud_publisher) || (!(_pointcloud_publisher->get_subscription_count())))
             return;
     }
+    
     rs2_stream texture_source_id = static_cast<rs2_stream>(_filter->get_option(rs2_option::RS2_OPTION_STREAM_FILTER));
     bool use_texture = texture_source_id != RS2_STREAM_ANY;
     static int warn_count(0);
     static const int DISPLAY_WARN_NUMBER(5);
     rs2::frameset::iterator texture_frame_itr = frameset.end();
+    
     if (use_texture)
     {
         std::set<rs2_format> available_formats{ RS2_FORMAT_RGB8, RS2_FORMAT_Y8, RS2_FORMAT_Z16 };
@@ -115,12 +118,15 @@ void PointcloudFilter::Publish(rs2::points pc, const rclcpp::Time& t, const rs2:
             return;
         }
         warn_count = 0;
-    } else {
+    } 
+    else {
         warn_count++;
         std::string texture_source_name = _filter->get_option_value_description(rs2_option::RS2_OPTION_STREAM_FILTER, static_cast<float>(texture_source_id));
-        ROS_WARN_STREAM_COND(warn_count == DISPLAY_WARN_NUMBER, "No stream match for pointcloud chosen texture " \
-            << texture_source_name << " - " << "set pointcloud.stream_profile parameter to color/depth/infra stream");
-        return;
+        ROS_WARN_STREAM_COND(
+            warn_count == DISPLAY_WARN_NUMBER,
+            "No stream match for pointcloud chosen texture: " << texture_source_name
+            << ". The 'pointcloud.stream_profile' parameter is set to 'any'"
+        );        
     }
 
     int texture_width(0), texture_height(0);

--- a/realsense2_camera/src/pointcloud_filter.cpp
+++ b/realsense2_camera/src/pointcloud_filter.cpp
@@ -102,7 +102,7 @@ void PointcloudFilter::Publish(rs2::points pc, const rclcpp::Time& t, const rs2:
     rs2::frameset::iterator texture_frame_itr = frameset.end();
     if (use_texture)
     {
-        std::set<rs2_format> available_formats{ rs2_format::RS2_FORMAT_RGB8, rs2_format::RS2_FORMAT_Y8 };
+        std::set<rs2_format> available_formats{ RS2_FORMAT_RGB8, RS2_FORMAT_Y8, RS2_FORMAT_Z16 };
 
         texture_frame_itr = std::find_if(frameset.begin(), frameset.end(), [&texture_source_id, &available_formats] (rs2::frame f)
                                 {return (rs2_stream(f.get_profile().stream_type()) == texture_source_id) &&
@@ -155,9 +155,14 @@ void PointcloudFilter::Publish(rs2::points pc, const rclcpp::Time& t, const rs2:
             case RS2_FORMAT_Y8:
                 format_str = "intensity";
                 break;
+            case RS2_FORMAT_Z16:
+                // Depth can't be used as color texture — skip coloring
+                format_str = "";  // Don't add any color field
+                break;
             default:
-                throw std::runtime_error("Unhandled texture format passed in pointcloud " + std::to_string(texture_frame.get_profile().format()));
-        }
+                RCLCPP_WARN(_logger, "Skipping unsupported texture format %d for pointcloud", texture_frame.get_profile().format());
+                return;
+        }        
         msg_pointcloud->point_step = addPointField(*msg_pointcloud, format_str.c_str(), 1, sensor_msgs::msg::PointField::FLOAT32, msg_pointcloud->point_step);
         msg_pointcloud->row_step = msg_pointcloud->width * msg_pointcloud->point_step;
         msg_pointcloud->data.resize(msg_pointcloud->height * msg_pointcloud->row_step);

--- a/realsense2_camera/src/pointcloud_filter.cpp
+++ b/realsense2_camera/src/pointcloud_filter.cpp
@@ -98,7 +98,7 @@ void PointcloudFilter::Publish(rs2::points pc, const rclcpp::Time& t, const rs2:
     rs2_stream texture_source_id = static_cast<rs2_stream>(_filter->get_option(rs2_option::RS2_OPTION_STREAM_FILTER));
     bool use_texture = texture_source_id != RS2_STREAM_ANY;
     static int warn_count(0);
-    static const int DISPLAY_WARN_NUMBER(5);
+    static const int DISPLAY_WARN_NUMBER(15);
     rs2::frameset::iterator texture_frame_itr = frameset.end();
     
     if (use_texture)

--- a/realsense2_camera/src/pointcloud_filter.cpp
+++ b/realsense2_camera/src/pointcloud_filter.cpp
@@ -103,7 +103,7 @@ void PointcloudFilter::Publish(rs2::points pc, const rclcpp::Time& t, const rs2:
     
     if (use_texture)
     {
-        std::set<rs2_format> available_formats{ RS2_FORMAT_RGB8, RS2_FORMAT_Y8, RS2_FORMAT_Z16 };
+        std::set<rs2_format> available_formats{ rs2_format::RS2_FORMAT_RGB8, rs2_format::RS2_FORMAT_Y8, rs2_format::RS2_FORMAT_Z16 };
 
         texture_frame_itr = std::find_if(frameset.begin(), frameset.end(), [&texture_source_id, &available_formats] (rs2::frame f)
                                 {return (rs2_stream(f.get_profile().stream_type()) == texture_source_id) &&

--- a/realsense2_camera/src/pointcloud_filter.cpp
+++ b/realsense2_camera/src/pointcloud_filter.cpp
@@ -119,11 +119,14 @@ void PointcloudFilter::Publish(rs2::points pc, const rclcpp::Time& t, const rs2:
     } 
     else {
         warn_count++;
-        std::string texture_source_name = _filter->get_option_value_description(rs2_option::RS2_OPTION_STREAM_FILTER, static_cast<float>(texture_source_id));
+        std::string texture_source_name = _filter->get_option_value_description(
+            rs2_option::RS2_OPTION_STREAM_FILTER,
+            static_cast<float>(texture_source_id)
+        );
         ROS_WARN_STREAM_COND(
             warn_count == DISPLAY_WARN_NUMBER,
-            "No stream match for pointcloud chosen texture: " << texture_source_name
-            << ". The 'pointcloud.stream_profile' parameter is set to 'any'"
+            "No matching stream for texture '" << texture_source_name
+            << "'. Set 'pointcloud.stream_profile' to 'depth(1)', 'color(2)', or 'infrared(3)' to enable textured pointclouds."
         );        
     }
 

--- a/realsense2_camera/src/pointcloud_filter.cpp
+++ b/realsense2_camera/src/pointcloud_filter.cpp
@@ -115,6 +115,12 @@ void PointcloudFilter::Publish(rs2::points pc, const rclcpp::Time& t, const rs2:
             return;
         }
         warn_count = 0;
+    } else {
+        warn_count++;
+        std::string texture_source_name = _filter->get_option_value_description(rs2_option::RS2_OPTION_STREAM_FILTER, static_cast<float>(texture_source_id));
+        ROS_WARN_STREAM_COND(warn_count == DISPLAY_WARN_NUMBER, "No stream match for pointcloud chosen texture " \
+            << texture_source_name << " - " << "set pointcloud.stream_profile parameter to color/depth/infra stream");
+        return;
     }
 
     int texture_width(0), texture_height(0);

--- a/realsense2_camera/src/pointcloud_filter.cpp
+++ b/realsense2_camera/src/pointcloud_filter.cpp
@@ -15,8 +15,6 @@
 #include <pointcloud_filter.h>
 #include <fstream>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
-#include "dynamic_params.h"
-
 
 using namespace realsense2_camera;
 
@@ -172,8 +170,7 @@ void PointcloudFilter::Publish(rs2::points pc, const rclcpp::Time& t, const rs2:
                 format_str = "";  // Don't add any color field
                 break;
             default:
-                RCLCPP_WARN(_logger, "Skipping unsupported texture format %d for pointcloud", texture_frame.get_profile().format());
-                return;
+                throw std::runtime_error("Unhandled texture format passed in pointcloud " + std::to_string(texture_frame.get_profile().format()));
         }        
         msg_pointcloud->point_step = addPointField(*msg_pointcloud, format_str.c_str(), 1, sensor_msgs::msg::PointField::FLOAT32, msg_pointcloud->point_step);
         msg_pointcloud->row_step = msg_pointcloud->width * msg_pointcloud->point_step;


### PR DESCRIPTION
Following this PR
https://github.com/IntelRealSense/librealsense/pull/13462#event-17470833592
and issue
https://github.com/IntelRealSense/realsense-ros/issues/3206

While debugging pointcloud behavior with GLSL acceleration enabled, I noticed that in the RealSense Viewer, pointclouds were being generated and rendered correctly. However, in the ROS 2 wrapper (realsense2_camera), pointclouds would not appear under certain conditions — specifically when the parameter pointcloud.stream_profile was left at its default value: any (RS2_STREAM_ANY).

Digging deeper into the ROS pipeline, I observed that when stream_profile is set to any, the system is unable to find a valid texture frame to associate with the pointcloud.
https://github.com/IntelRealSense/realsense-ros/blob/711d1f726ef2b424b4047fe1bcf5ec48128eb811/realsense2_camera/src/pointcloud_filter.cpp#L99

As a result GLSL-based pointcloud computation silently fails due to the lack of a texture stream.

Unlike CPU-based fallback implementations, GLSL requires a valid texture stream (e.g., color or IR) to drive the pointcloud generation pipeline.

This explains why realsense-viewer works while ros2 wrapper doesnt -- it explicitly assigns a texture stream.

To resolve this, I verified that explicitly setting the parameter pointcloud.stream_profile to a valid stream 
successfully enables the pointcloud pipeline, even when GLSL acceleration is used (e.g.,):
```
1 → RS2_STREAM_DEPTH
2 → RS2_STREAM_COLOR
3 → RS2_STREAM_INFRARED
```

RS2_STREAM_DEPTH pointcloud
![image](https://github.com/user-attachments/assets/3bb743db-7c81-4061-9dbe-0a33a9a39e47)

RS2_STREAM_COLOR pointcloud
![image](https://github.com/user-attachments/assets/980c639c-9826-469c-8de6-2423a4326ba1)

RS2_STREAM_INFRARED pointcloud
![image](https://github.com/user-attachments/assets/2c8d7f23-09fd-409e-a2e5-e5549113ec64)


