### PR TITLE
Rotation Filter

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -229,7 +229,7 @@ void BaseRealSenseNode::setupFilters()
     _filters.push_back(std::make_shared<NamedFilter>(std::make_shared<rs2::temporal_filter>(), _parameters, _logger));
     _filters.push_back(std::make_shared<NamedFilter>(std::make_shared<rs2::hole_filling_filter>(), _parameters, _logger));
     _filters.push_back(std::make_shared<NamedFilter>(std::make_shared<rs2::disparity_transform>(false), _parameters, _logger));
-    _filters.push_back(std::make_shared<NamedFilter>(std::make_shared<rs2::rotation_filter>(std::vector< rs2_stream >{ RS2_STREAM_DEPTH, RS2_STREAM_COLOR, RS2_STREAM_INFRARED }), _parameters, _logger));
+    //_filters.push_back(std::make_shared<NamedFilter>(std::make_shared<rs2::rotation_filter>(std::vector< rs2_stream >{ RS2_STREAM_DEPTH, RS2_STREAM_COLOR, RS2_STREAM_INFRARED }), _parameters, _logger));
 
     /* 
     update_align_depth_func is being used in the align depth filter for triggiring the thread that monitors profile


### PR DESCRIPTION
# Bug Description for realsense-ros Wrapper

## Overview
The bug occurred in the `realsense-ros` wrapper (ROS2, `ros2-development` branch) during the build of the `realsense2_camera` package in a ROS2 Humble Docker container, preventing successful compilation when used with the latest versions of Realsense SDK and affecting integration with an Intel RealSense D435i for ORB-SLAM3.

## Primary Issue
- **File**: `base_realsense_node.cpp`
- **Location**: Line 232, within the `setupFilters()` function
- **Error**:
  ```
  error: 'rotation_filter' is not a member of 'rs2'; did you mean 'spatial_filter'?
  ```
  ```
  error: no matching function for call to 'make_shared<<expression error> >(std::vector<rs2_stream>)'
  ```
- **Description**: The code attempted to use `rs2::rotation_filter`, which does not exist in the RealSense SDK (`librealsense2`). The SDK supports filters like `spatial_filter`, `temporal_filter`, and `decimation_filter`. The invalid filter reference caused a template error in `std::make_shared`.

## Secondary Issue
- **File**: `rs_processing.hpp` (from `librealsense2`)
- **Location**: Line 128, within the `frame_processor_callback` template
- **Error**:
  ```
  error: no match for call to '(std::vector<rs2_stream>) (std::remove_reference<rs2::frame&>::type, rs2::frame_source&)'
  ```
- **Description**: After modifying the primary issue, a secondary error emerged where a `std::vector<rs2_stream>` was incorrectly treated as a callable function in a frame processor callback, indicating a deeper issue in the filter setup or SDK compatibility.

## Additional Observations
- A subsequent runtime issue produced `Unknown IMU stream type` errors when enabling IMU streams (`enable_gyro:=true`, `enable_accel:=true`), suggesting improper handling of `RS2_STREAM_GYRO` and `RS2_STREAM_ACCEL` in the wrapper.
- A version mismatch warning was noted: the wrapper was compiled with `librealsense2` v2.56.2 but ran with v2.56.3, potentially contributing to instability.

## Resolution
- **Primary Fix**: Commented out the problematic line in `base_realsense_node.cpp`:
  ```cpp
  // _filters.push_back(std::make_shared<NamedFilter>(std::make_shared<rs2::rotation_filter>(std::vector< rs2_stream >{ RS2_STREAM_DEPTH, RS2_STREAM_COLOR, RS2_STREAM_INFRARED }), _parameters, _logger));
  ```
  This allowed the package to build successfully.
- **IMU Workaround**: Disabled IMU streams (`enable_gyro:=false`, `enable_accel:=false`) to avoid IMU errors, as they were not critical for RGB-D ORB-SLAM3.
- **Version Alignment**: Rebuilt `librealsense2` v2.56.2 to match the wrapper’s expected version, reducing potential issues.

## Impact
The bug prevented the `realsense2_camera` package from building, halting the setup of ORB-SLAM3 with the D435i. The fix enabled RGB-D data publication, but IMU support remained unresolved, requiring further investigation or a stable branch (e.g., 4.54.1).