### PR TITLE
Fix build on ROS Rolling by using non-deprecated tf2 header Quaternion.hpp

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -45,7 +45,7 @@
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 
-#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Quaternion.hpp>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/static_transform_broadcaster.h>
 #include <eigen3/Eigen/Geometry>

--- a/realsense2_camera/package.xml
+++ b/realsense2_camera/package.xml
@@ -31,7 +31,9 @@
   <depend>std_srvs</depend>
   <depend>std_msgs</depend>
   <depend>nav_msgs</depend>
-  <depend>tf2</depend>
+  <depend condition="$ROS_DISTRO != jazzy and $ROS_DISTRO != humble" version_gte="0.40.0">tf2</depend>
+  <depend condition="$ROS_DISTRO == jazzy" version_gte="0.36.7">tf2</depend>
+  <depend condition="$ROS_DISTRO == humble" version_gte="0.25.10">tf2</depend>
   <depend>tf2_ros</depend>
   <depend>diagnostic_updater</depend>
   <test_depend condition="$ROS_DISTRO != foxy">ament_cmake_gtest</test_depend>


### PR DESCRIPTION
Quaternion.h was deprecated in https://github.com/ros2/geometry2/pull/720 and removed in https://github.com/ros2/geometry2/pull/789 .

This PR updates base_realsense_node.h to use Quaternion.hpp. This fixes the build on Rolling that I saw in the CI of #3374