### PR TITLE
Use package:// to discover meshes

### DIFF
--- a/realsense2_description/urdf/_d405.urdf.xacro
+++ b/realsense2_description/urdf/_d405.urdf.xacro
@@ -75,7 +75,7 @@ aluminum peripherial evaluation case.
         <!-- the mesh origin is at front plate in between the two infrared camera axes -->
         <origin xyz="${d405_zero_depth_to_glass + d405_glass_to_front} ${-d405_cam_depth_py} 0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
         <geometry>
-	        <mesh filename="file://$(find realsense2_description)/meshes/d405.stl" scale="0.001 0.001 0.001" />
+	        <mesh filename="package://realsense2_description/meshes/d405.stl" scale="0.001 0.001 0.001" />
         </geometry>
         <material name="aluminum"/>
       </visual>

--- a/realsense2_description/urdf/_d415.urdf.xacro
+++ b/realsense2_description/urdf/_d415.urdf.xacro
@@ -68,7 +68,7 @@ aluminum peripherial evaluation case.
         <xacro:if value="${use_mesh}">
           <origin xyz="${d415_cam_mount_from_center_offset} ${-d415_cam_depth_py} 0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
           <geometry>
-            <mesh filename="file://$(find realsense2_description)/meshes/d415.stl" />
+            <mesh filename="package://realsense2_description/meshes/d415.stl" />
           </geometry>
           <material name="aluminum"/>
         </xacro:if>

--- a/realsense2_description/urdf/_d435.urdf.xacro
+++ b/realsense2_description/urdf/_d435.urdf.xacro
@@ -75,7 +75,7 @@ aluminum peripherial evaluation case.
           <!-- the mesh origin is at front plate in between the two infrared camera axes -->
           <origin xyz="${d435_zero_depth_to_glass + d435_glass_to_front} ${-d435_cam_depth_py} 0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
           <geometry>
-            <mesh filename="file://$(find realsense2_description)/meshes/d435.dae" />
+            <mesh filename="package://realsense2_description/meshes/d435.dae" />
           </geometry>
         </xacro:if>
         <xacro:unless value="${use_mesh}">

--- a/realsense2_description/urdf/_d455.urdf.xacro
+++ b/realsense2_description/urdf/_d455.urdf.xacro
@@ -78,7 +78,7 @@ aluminum peripherial evaluation case.
         <origin xyz="${d455_zero_depth_to_glass + d455_glass_to_front} ${-d455_cam_depth_py} 0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
         <geometry>
           <!-- <box size="${d455_cam_depth} ${d455_cam_width} ${d455_cam_height}"/> -->
-	        <mesh filename="file://$(find realsense2_description)/meshes/d455.stl" scale="0.001 0.001 0.001" />
+	        <mesh filename="package://realsense2_description/meshes/d455.stl" scale="0.001 0.001 0.001" />
         </geometry>
         <material name="aluminum"/>
       </visual>

--- a/realsense2_description/urdf/_r410.urdf.xacro
+++ b/realsense2_description/urdf/_r410.urdf.xacro
@@ -59,7 +59,7 @@ aluminum peripherial evaluation case.
       <origin xyz="0 ${-r410_cam_mount_from_center_offset} ${r410_cam_height/2}" rpy="${M_PI/2} 0 ${M_PI/2}"/>
         <geometry>
           <box size="${r410_cam_width} ${r410_cam_height} ${r410_cam_depth}"/>
-          <!--<mesh filename="file://$(find realsense2_description)/meshes/r410/r410.dae" />-->
+          <!--<mesh filename="package://realsense2_description/meshes/r410/r410.dae" />-->
         </geometry>
         <material name="aluminum"/>
       </visual>

--- a/realsense2_description/urdf/_r430.urdf.xacro
+++ b/realsense2_description/urdf/_r430.urdf.xacro
@@ -59,7 +59,7 @@ aluminum peripherial evaluation case.
       <origin xyz="0 ${-r430_cam_mount_from_center_offset} ${r430_cam_height/2}" rpy="${M_PI/2} 0 ${M_PI/2}"/>
         <geometry>
           <box size="${r430_cam_width} ${r430_cam_height} ${r430_cam_depth}"/>
-          <!--<mesh filename="file://$(find realsense2_description)/meshes/r430/r430.dae" />-->
+          <!--<mesh filename="package://realsense2_description/meshes/r430/r430.dae" />-->
         </geometry>
         <material name="aluminum"/>
       </visual>

--- a/realsense2_description/urdf/_usb_plug.urdf.xacro
+++ b/realsense2_description/urdf/_usb_plug.urdf.xacro
@@ -36,7 +36,7 @@ aluminum peripherial evaluation case.
         <origin xyz="0. -0.022425 0." rpy="0 0 ${M_PI/2}"/>
         <geometry>
           <!--box size="0.044850 0.008 0.0185" /-->
-          <mesh filename="file://$(find realsense2_description)/meshes/plug.stl" />
+          <mesh filename="package://realsense2_description/meshes/plug.stl" />
         </geometry>
         <material name="plastic"/>
       </visual>
@@ -44,7 +44,7 @@ aluminum peripherial evaluation case.
         <origin xyz="0. -0.022425 0." rpy="0 0 ${M_PI/2}"/>
         <geometry>
           <!--box size="0.044850 0.008 0.0185" /-->
-          <mesh filename="file://$(find realsense2_description)/meshes/plug_collision.stl" />
+          <mesh filename="package://realsense2_description/meshes/plug_collision.stl" />
         </geometry>
       </collision>
     </link>


### PR DESCRIPTION
This is a very small change to the URDFs to allow better portability of the robot_description between computers

I found when the robot description was published by my robot I couldn't view them in RViz on my main PC as the path the the `install/share/realsense2_description/` directory was different between the two workspaces

By replacing the `file://$(find realsense2_description)` with `package://realsense2_description` then the ros resource_retriever can run on the receiving PC and meshes will be retrieved in a more robust manner 