### PR TITLE
Fix argument names (`_usb_port_id` and `_device_type`)

### DIFF
--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -327,8 +327,8 @@ void RealSenseNodeFactory::init()
 #endif
         // Using `getOrDeclareParameter()` to avoid re-declaration issues
         _serial_no = _parameters->getOrDeclareParameter<std::string>("serial_no", "");
-        _usb_port_id = _parameters->getOrDeclareParameter<std::string>("_usb_port_id", "");
-        _device_type = _parameters->getOrDeclareParameter<std::string>("_device_type", "");
+        _usb_port_id = _parameters->getOrDeclareParameter<std::string>("usb_port_id", "");
+        _device_type = _parameters->getOrDeclareParameter<std::string>("device_type", "");
         _wait_for_device_timeout = _parameters->getOrDeclareParameter<double>("wait_for_device_timeout", -1.0);
         _reconnect_timeout = _parameters->getOrDeclareParameter<double>("reconnect_timeout", 6.0);
 


### PR DESCRIPTION
Related issue: https://github.com/IntelRealSense/realsense-ros/issues/3420

realsense2_camera node's parameter `usb_port_id` and `device_type` were renamed to `_usb_port_id` and `_device_type` at 09e9f8e, but this update contradicts with [README.md](https://github.com/IntelRealSense/realsense-ros) and also loses backward compatibility, so this PR renames them back to the original.