### PR TITLE
Create a singleton wrapper to rs2::context

### DIFF
--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -206,6 +206,7 @@ if (BUILD_ACCELERATE_GPU_WITH_GLSL)
 endif()
 
 set(INCLUDES
+    include/context_singleton_wrapper.h
     include/constants.h
     include/realsense_node_factory.h
     include/base_realsense_node.h

--- a/realsense2_camera/include/context_singleton_wrapper.h
+++ b/realsense2_camera/include/context_singleton_wrapper.h
@@ -1,0 +1,32 @@
+// Copyright 2025 RealSense, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <librealsense2/rs.hpp>
+#include <memory>
+
+class RSContextSingletonWrapper {
+public:
+    static rs2::context& getInstance() {
+        static rs2::context ctx;
+        return ctx;
+    }
+
+private:
+    RSContextSingletonWrapper() = delete;
+    ~RSContextSingletonWrapper() = delete;
+    RSContextSingletonWrapper(const RSContextSingletonWrapper&) = delete;
+    RSContextSingletonWrapper& operator=(const RSContextSingletonWrapper&) = delete;
+};

--- a/realsense2_camera/include/realsense_node_factory.h
+++ b/realsense2_camera/include/realsense_node_factory.h
@@ -65,7 +65,6 @@ namespace realsense2_camera
         RosNodeBase::SharedPtr _node;
         rs2::device _device;
         std::unique_ptr<BaseRealSenseNode> _realSenseNode;
-        rs2::context _ctx;
         std::string _serial_no;
         std::string _usb_port_id;
         std::string _device_type;

--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "../include/realsense_node_factory.h"
-#include "../include/base_realsense_node.h"
+#include "realsense_node_factory.h"
+#include "base_realsense_node.h"
+#include "context_singleton_wrapper.h"
 #include <iostream>
 #include <map>
 #include <mutex>
@@ -340,8 +341,7 @@ void RealSenseNodeFactory::init()
         {
             {
                 ROS_INFO_STREAM("publish topics from rosbag file: " << rosbag_filename.c_str());
-                rs2::context ctx;
-                _device = ctx.load_device(rosbag_filename.c_str());
+                _device = RSContextSingletonWrapper::getInstance().load_device(rosbag_filename.c_str());
                 _serial_no = _device.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
             }
             if (_device)
@@ -393,11 +393,11 @@ void RealSenseNodeFactory::init()
                 {
                     try
                     {
-                        getDevice(_ctx.query_devices());
+                        getDevice(RSContextSingletonWrapper::getInstance().query_devices());
                         if (_device)
                         {
                             std::function<void(rs2::event_information&)> change_device_callback_function = [this](rs2::event_information& info){changeDeviceCallback(info);};
-                            _ctx.set_devices_changed_callback(change_device_callback_function);
+                            RSContextSingletonWrapper::getInstance().set_devices_changed_callback(change_device_callback_function);
                             // unconfigure lifecycle state ends here for lifecycled node
                             #ifndef USE_LIFECYCLE_NODE
                             startDevice();
@@ -523,7 +523,7 @@ void RealSenseNodeFactory::closeDevice()
     if (_device)
     {
         ROS_INFO("Closing RealSense device...");
-        _ctx.set_devices_changed_callback([](rs2::event_information&) {});
+        RSContextSingletonWrapper::getInstance().set_devices_changed_callback([](rs2::event_information&) {});
 
         // To go into unconfigured lifecycle state for lifecycled node we have to also disconnect the device
         _device = rs2::device();


### PR DESCRIPTION
Maintain a single context when running in a composable node. This should help with having just a single realsense SDK and single source that access shared resources.

Extra minor change: modified some header file includes to just reference the file instead of having a relative path.