### PR TITLE
Add support for Intel RealSense D436 Camera

### DIFF
--- a/realsense2_description/urdf/_d436.urdf.xacro
+++ b/realsense2_description/urdf/_d436.urdf.xacro
@@ -18,7 +18,7 @@
 
 <!--
 This is the URDF model for the Intel RealSense D436 camera, in its
-aluminum peripherial evaluation case.
+aluminum peripheral evaluation case.
 -->
 
 <robot name="sensor_d436" xmlns:xacro="http://ros.org/wiki/xacro">
@@ -36,9 +36,9 @@ aluminum peripherial evaluation case.
     <xacro:property name="d436_cam_depth_to_color_offset_y" value="0.015"/>
     <xacro:property name="d436_cam_depth_to_color_offset_x" value="-0.00555"/>
 
-    <!-- The following values model the aluminum peripherial case for the
+    <!-- The following values model the aluminum peripheral case for the
   	d436 camera, with the camera joint represented by the actual
-  	peripherial camera tripod mount -->
+  	peripheral camera tripod mount -->
     <xacro:property name="d436_cam_width" value="0.090"/>
     <xacro:property name="d436_cam_height" value="0.025"/>
     <xacro:property name="d436_cam_depth" value="0.02505"/>
@@ -49,7 +49,7 @@ aluminum peripherial evaluation case.
     <!-- convenience precomputation to avoid clutter-->
     <xacro:property name="d436_mesh_x_offset" value="${d436_cam_mount_from_center_offset-d436_glass_to_front-d436_zero_depth_to_glass}"/>
 
-    <!-- The following offset is relative to the physical d436 camera peripherial
+    <!-- The following offset is relative to the physical d436 camera peripheral
   	camera tripod mount -->
     <xacro:property name="d436_cam_depth_px" value="${d436_cam_mount_from_center_offset}"/>
     <xacro:property name="d436_cam_depth_py" value="0.0175"/>

--- a/realsense2_description/urdf/_d436.urdf.xacro
+++ b/realsense2_description/urdf/_d436.urdf.xacro
@@ -1,0 +1,205 @@
+<?xml version="1.0"?>
+
+<!--
+# Copyright 2026 RealSense, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+
+<!--
+This is the URDF model for the Intel RealSense D436 camera, in its
+aluminum peripherial evaluation case.
+-->
+
+<robot name="sensor_d436" xmlns:xacro="http://ros.org/wiki/xacro">
+  <!-- Includes -->
+  <xacro:include filename="$(find realsense2_description)/urdf/_materials.urdf.xacro" />
+  <xacro:include filename="$(find realsense2_description)/urdf/_usb_plug.urdf.xacro" />
+
+  <xacro:macro name="sensor_d436" params="parent *origin name:=camera use_nominal_extrinsics:=false add_plug:=false use_mesh:=true">
+    <xacro:property name="M_PI" value="3.1415926535897931" />
+
+    <!-- The following values are approximate, and the camera node
+     publishing TF values with actual calibrated camera extrinsic values -->
+    <xacro:property name="d436_cam_depth_to_infra1_offset" value="0.0"/>
+    <xacro:property name="d436_cam_depth_to_infra2_offset" value="-0.050"/>
+    <xacro:property name="d436_cam_depth_to_color_offset_y" value="0.015"/>
+    <xacro:property name="d436_cam_depth_to_color_offset_x" value="-0.00555"/>
+
+    <!-- The following values model the aluminum peripherial case for the
+  	d436 camera, with the camera joint represented by the actual
+  	peripherial camera tripod mount -->
+    <xacro:property name="d436_cam_width" value="0.090"/>
+    <xacro:property name="d436_cam_height" value="0.025"/>
+    <xacro:property name="d436_cam_depth" value="0.02505"/>
+    <xacro:property name="d436_cam_mount_from_center_offset" value="0.0149"/>
+    <!-- glass cover is 0.1 mm inwards from front aluminium plate -->
+    <xacro:property name="d436_glass_to_front" value="0.1e-3"/>
+    <xacro:property name="d436_zero_depth_to_glass" value="4.2e-3"/>
+    <!-- convenience precomputation to avoid clutter-->
+    <xacro:property name="d436_mesh_x_offset" value="${d436_cam_mount_from_center_offset-d436_glass_to_front-d436_zero_depth_to_glass}"/>
+
+    <!-- The following offset is relative to the physical d436 camera peripherial
+  	camera tripod mount -->
+    <xacro:property name="d436_cam_depth_px" value="${d436_cam_mount_from_center_offset}"/>
+    <xacro:property name="d436_cam_depth_py" value="0.0175"/>
+    <xacro:property name="d436_cam_depth_pz" value="${d436_cam_height/2}"/>
+
+    <!-- camera body, with origin at bottom screw mount -->
+    <joint name="${name}_joint" type="fixed">
+      <xacro:insert_block name="origin" />
+      <parent link="${parent}"/>
+      <child link="${name}_bottom_screw_frame" />
+    </joint>
+    <link name="${name}_bottom_screw_frame"/>
+
+    <joint name="${name}_link_joint" type="fixed">
+      <origin xyz="${d436_mesh_x_offset} ${d436_cam_depth_py} ${d436_cam_depth_pz}" rpy="0 0 0"/>
+      <parent link="${name}_bottom_screw_frame"/>
+      <child link="${name}_link" />
+    </joint>
+
+    <link name="${name}_link">
+      <visual>
+        <xacro:if value="${use_mesh}">
+          <!-- the mesh origin is at front plate in between the two infrared camera axes -->
+          <origin xyz="${d436_zero_depth_to_glass + d436_glass_to_front} ${-d436_cam_depth_py} 0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
+          <geometry>
+            <mesh filename="package://realsense2_description/meshes/d435.dae" />
+          </geometry>
+        </xacro:if>
+        <xacro:unless value="${use_mesh}">
+          <origin xyz="0 ${-d436_cam_depth_py} 0" rpy="0 0 0"/>
+          <geometry>
+            <box size="${d436_cam_depth} ${d436_cam_width} ${d436_cam_height}"/>
+          </geometry>
+          <material name="aluminum"/>
+        </xacro:unless>
+      </visual>
+      <collision>
+        <origin xyz="0 ${-d436_cam_depth_py} 0" rpy="0 0 0"/>
+        <geometry>
+          <box size="${d436_cam_depth} ${d436_cam_width} ${d436_cam_height}"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <!-- The following are not reliable values, and should not be used for modeling -->
+        <mass value="0.072" />
+        <origin xyz="0 0 0" />
+        <inertia ixx="0.003881243" ixy="0.0" ixz="0.0" iyy="0.000498940" iyz="0.0" izz="0.003879257" />
+      </inertial>
+    </link>
+
+    <!-- Use the nominal extrinsics between camera frames if the calibrated extrinsics aren't being published. e.g. running the device in simulation  -->
+    <xacro:if value="${use_nominal_extrinsics}">
+      <!-- camera depth joints and links -->
+      <joint name="${name}_depth_joint" type="fixed">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="${name}_link"/>
+        <child link="${name}_depth_frame" />
+      </joint>
+      <link name="${name}_depth_frame"/>
+
+      <joint name="${name}_depth_optical_joint" type="fixed">
+        <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
+        <parent link="${name}_depth_frame" />
+        <child link="${name}_depth_optical_frame" />
+      </joint>
+      <link name="${name}_depth_optical_frame"/>
+
+      <!-- camera left IR joints and links -->
+      <joint name="${name}_infra1_joint" type="fixed">
+        <origin xyz="0 ${d436_cam_depth_to_infra1_offset} 0" rpy="0 0 0" />
+        <parent link="${name}_link" />
+        <child link="${name}_infra1_frame" />
+      </joint>
+      <link name="${name}_infra1_frame"/>
+
+      <joint name="${name}_infra1_optical_joint" type="fixed">
+        <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
+        <parent link="${name}_infra1_frame" />
+        <child link="${name}_infra1_optical_frame" />
+      </joint>
+      <link name="${name}_infra1_optical_frame"/>
+
+      <!-- camera right IR joints and links -->
+      <joint name="${name}_infra2_joint" type="fixed">
+        <origin xyz="0 ${d436_cam_depth_to_infra2_offset} 0" rpy="0 0 0" />
+        <parent link="${name}_link" />
+        <child link="${name}_infra2_frame" />
+      </joint>
+      <link name="${name}_infra2_frame"/>
+
+      <joint name="${name}_infra2_optical_joint" type="fixed">
+        <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
+        <parent link="${name}_infra2_frame" />
+        <child link="${name}_infra2_optical_frame" />
+      </joint>
+      <link name="${name}_infra2_optical_frame"/>
+
+      <!-- camera color joints and links -->
+      <joint name="${name}_color_joint" type="fixed">
+        <origin xyz="${d436_cam_depth_to_color_offset_x} ${d436_cam_depth_to_color_offset_y} 0" rpy="0 0 0" />
+        <parent link="${name}_link" />
+        <child link="${name}_color_frame" />
+      </joint>
+      <link name="${name}_color_frame"/>
+
+      <joint name="${name}_color_optical_joint" type="fixed">
+        <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
+        <parent link="${name}_color_frame" />
+        <child link="${name}_color_optical_frame" />
+      </joint>
+      <link name="${name}_color_optical_frame"/>
+
+      <!-- IMU accel joints and links -->
+      <link name="${name}_accel_frame" />
+      <link name="${name}_accel_optical_frame" />
+
+      <joint name="${name}_accel_joint" type="fixed">
+        <origin xyz = "-0.01174 -0.00552 0.0051" rpy = "0 0 0" />
+        <parent link="${name}_link" />
+        <child link="${name}_accel_frame" />
+      </joint>
+
+      <joint name="${name}_accel_optical_joint" type="fixed">
+        <origin xyz = "0 0 0" rpy = "${-M_PI/2} 0 ${-M_PI/2}" />
+        <parent link="${name}_accel_frame" />
+        <child link="${name}_accel_optical_frame" />
+      </joint>
+
+      <!-- IMU gyro joints and links -->
+      <link name="${name}_gyro_frame" />
+      <link name="${name}_gyro_optical_frame" />
+
+      <joint name="${name}_gyro_joint" type="fixed">
+        <origin xyz = "-0.01174 -0.00552 0.0051" rpy = "0 0 0" />
+        <parent link="${name}_link" />
+        <child link="${name}_gyro_frame" />
+      </joint>
+
+      <joint name="${name}_gyro_optical_joint" type="fixed">
+        <origin xyz = "0 0 0" rpy = "${-M_PI/2} 0 ${-M_PI/2}" />
+        <parent link="${name}_gyro_frame" />
+        <child link="${name}_gyro_optical_frame" />
+      </joint>
+
+    </xacro:if>
+
+    <xacro:if value="${add_plug}">
+      <xacro:usb_plug parent="${name}_link" name="${name}_usb_plug">
+        <origin xyz="${d436_cam_mount_from_center_offset - 0.02095} ${-d436_cam_depth_py - 0.0353} 0" rpy="0 0 0"/>
+      </xacro:usb_plug>
+    </xacro:if>
+  </xacro:macro>
+</robot>

--- a/realsense2_description/urdf/test_d436_camera.urdf.xacro
+++ b/realsense2_description/urdf/test_d436_camera.urdf.xacro
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<robot name="realsense2_camera" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:arg name="use_nominal_extrinsics" default="false"/>
+  <xacro:arg name="add_plug" default="false" />
+  <xacro:arg name="use_mesh" default="true" />
+  <xacro:include filename="$(find realsense2_description)/urdf/_d436.urdf.xacro" />
+  
+  <link name="base_link" />
+  <xacro:sensor_d436 parent="base_link" use_nominal_extrinsics="$(arg use_nominal_extrinsics)" add_plug="$(arg add_plug)" use_mesh="$(arg use_mesh)">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </xacro:sensor_d436>
+</robot>


### PR DESCRIPTION
This PR adds support for the Intel RealSense D436 camera to the realsense2_description package. 
It introduces a new URDF and a test configuration to verify the camera's description.