### PR TITLE
Detect and handle hardware timestamp reset

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -387,6 +387,7 @@ namespace realsense2_camera
         std::map<stream_index_pair, sensor_msgs::msg::CameraInfo> _camera_info;
         std::atomic_bool _is_initialized_time_base;
         double _camera_time_base;
+        double _previous_frame_time;
 
         rclcpp::Time _ros_time_base;
         bool _sync_frames;

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -769,14 +769,23 @@ rclcpp::Time BaseRealSenseNode::frameSystemTimeSec(rs2::frame frame)
     {
         double elapsed_camera_ns = millisecondsToNanoseconds(timestamp_ms - _camera_time_base);
 
-        /*
-        Fixing deprecated-declarations compilation error for EOL distro (foxy)
-        */
 #if defined(FOXY)
         auto duration = rclcpp::Duration(elapsed_camera_ns);
 #else
         auto duration = rclcpp::Duration::from_nanoseconds(elapsed_camera_ns);
 #endif
+
+        if ((_ros_time_base + duration).nanoseconds() < _ros_time_base.nanoseconds())
+        {
+            _ros_time_base = _node.now();
+            _camera_time_base = timestamp_ms;
+            elapsed_camera_ns = millisecondsToNanoseconds(timestamp_ms - _camera_time_base);
+#if defined(FOXY)
+            duration = rclcpp::Duration(elapsed_camera_ns);
+#else
+            duration = rclcpp::Duration::from_nanoseconds(elapsed_camera_ns);
+#endif
+        }
 
         return rclcpp::Time(_ros_time_base + duration);
     }

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -743,6 +743,7 @@ bool BaseRealSenseNode::setBaseTime(double frame_time, rs2_timestamp_domain time
         ROS_WARN("frame's time domain is HARDWARE_CLOCK. Timestamps may reset periodically.");
         _ros_time_base = _node.now();
         _camera_time_base = frame_time;
+        _previous_frame_time = frame_time;
         return true;
     }
     return false;
@@ -767,6 +768,14 @@ rclcpp::Time BaseRealSenseNode::frameSystemTimeSec(rs2::frame frame)
     double timestamp_ms = frame.get_timestamp();
     if (frame.get_frame_timestamp_domain() == RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK)
     {
+        if (_previous_frame_time > timestamp_ms)
+        {
+            ROS_WARN("Hardware clock reset detected. Resetting ROS time base.");
+            _ros_time_base = _node.now();
+            _camera_time_base = timestamp_ms;
+        }
+        _previous_frame_time = timestamp_ms;
+
         double elapsed_camera_ns = millisecondsToNanoseconds(timestamp_ms - _camera_time_base);
 
         /*
@@ -777,19 +786,6 @@ rclcpp::Time BaseRealSenseNode::frameSystemTimeSec(rs2::frame frame)
 #else
         auto duration = rclcpp::Duration::from_nanoseconds(elapsed_camera_ns);
 #endif
-
-        if ((_ros_time_base + duration).nanoseconds() < _ros_time_base.nanoseconds())
-        {
-            ROS_WARN("Hardware clock reset detected. Resetting ROS time base.");
-            _ros_time_base = _node.now();
-            _camera_time_base = timestamp_ms;
-            elapsed_camera_ns = millisecondsToNanoseconds(timestamp_ms - _camera_time_base);
-#if defined(FOXY)
-            duration = rclcpp::Duration(elapsed_camera_ns);
-#else
-            duration = rclcpp::Duration::from_nanoseconds(elapsed_camera_ns);
-#endif
-        }
 
         return rclcpp::Time(_ros_time_base + duration);
     }

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -780,6 +780,7 @@ rclcpp::Time BaseRealSenseNode::frameSystemTimeSec(rs2::frame frame)
 
         if ((_ros_time_base + duration).nanoseconds() < _ros_time_base.nanoseconds())
         {
+            ROS_WARN("Hardware clock reset detected. Resetting ROS time base.");
             _ros_time_base = _node.now();
             _camera_time_base = timestamp_ms;
             elapsed_camera_ns = millisecondsToNanoseconds(timestamp_ms - _camera_time_base);

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -769,6 +769,9 @@ rclcpp::Time BaseRealSenseNode::frameSystemTimeSec(rs2::frame frame)
     {
         double elapsed_camera_ns = millisecondsToNanoseconds(timestamp_ms - _camera_time_base);
 
+        /*
+        Fixing deprecated-declarations compilation error for EOL distro (foxy)
+        */
 #if defined(FOXY)
         auto duration = rclcpp::Duration(elapsed_camera_ns);
 #else


### PR DESCRIPTION
Every 2^32ms (71min), camera clock timestamp resets back to 0 because of the 32bit resolution of the clock. This creates an issue where elapsed_camera_ms becomes negative and produces a ros timestamp that is in the past, causing synchronization errors on the camera.

This PR detects when the hw clock wraps around and re-initializes the ros time base in this case.