### PR TITLE
Detect and handle hardware clock reset for ros1

### DIFF
--- a/realsense2_camera/include/realsense2_camera/base_realsense_node.h
+++ b/realsense2_camera/include/realsense2_camera/base_realsense_node.h
@@ -300,6 +300,7 @@ namespace realsense2_camera
         std::map<stream_index_pair, sensor_msgs::CameraInfo> _camera_info;
         std::atomic_bool _is_initialized_time_base;
         double _camera_time_base;
+        double _previous_frame_time;
         std::map<stream_index_pair, std::vector<rs2::stream_profile>> _enabled_profiles;
 
         ros::Publisher _pointcloud_publisher;

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -1807,6 +1807,7 @@ bool BaseRealSenseNode::setBaseTime(double frame_time, rs2_timestamp_domain time
         ROS_WARN("frame's time domain is HARDWARE_CLOCK. Timestamps may reset periodically.");
         _ros_time_base = ros::Time::now();
         _camera_time_base = frame_time;
+        _previous_frame_time = frame_time;
         return true;
     }
     return false;
@@ -1816,6 +1817,14 @@ double BaseRealSenseNode::frameSystemTimeSec(rs2::frame frame)
 {
     if (frame.get_frame_timestamp_domain() == RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK)
     {
+        if (_previous_frame_time > frame.get_timestamp())
+        {
+            ROS_WARN("Hardware clock reset detected. Resetting ROS time base.");
+            _ros_time_base = ros::Time::now();
+            _camera_time_base = frame.get_timestamp();
+        }
+        _previous_frame_time = frame.get_timestamp();
+
         double elapsed_camera_ms = (/*ms*/ frame.get_timestamp() - /*ms*/ _camera_time_base) / 1000.0;
         return (_ros_time_base.toSec() + elapsed_camera_ms);
     }


### PR DESCRIPTION
Changes to ros1-legacy branch for the following

Every 2^32ms (71min), camera clock timestamp resets back to 0 because of the 32bit resolution of the clock. This creates an issue where elapsed_camera_ms becomes negative and produces a ros timestamp that is in the past, causing synchronization errors on the camera.

This PR detects when the hw clock wraps around and re-initializes the ros time base in this case.