### PR TITLE
Update package.xml to incude missing depends

### DIFF
--- a/realsense2_camera_msgs/package.xml
+++ b/realsense2_camera_msgs/package.xml
@@ -16,6 +16,7 @@
  
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
+  <depend>action_msgs</depend>
   <build_depend>builtin_interfaces</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>

--- a/realsense2_camera_msgs/package.xml
+++ b/realsense2_camera_msgs/package.xml
@@ -16,12 +16,13 @@
  
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
-  <depend>action_msgs</depend>
+  <build_depend>action_msgs</build_depend>
   <build_depend>builtin_interfaces</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>action_msgs</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>


### PR DESCRIPTION
Build Failure Root Cause

  Package: realsense2_camera_msgs v4.57.7 (Humble, Ubuntu Jammy ARM64)

  Error:
  CMake Error at rosidl_generate_interfaces.cmake:147:
    Unable to generate action interface for 'action/TriggeredCalibration.action'.
    In order to generate action interfaces you must add a depend tag for
    'action_msgs' in your package.xml.

  What happened: The package defines an action interface (TriggeredCalibration.action) but the package.xml is missing a required
  dependency on action_msgs. ROS2 action interfaces require action_msgs to generate the goal/result/feedback boilerplate.

  Fix: Add the following to the package.xml of realsense2_camera_msgs:
  <depend>action_msgs</depend>

  This is likely a new .action file that was added (or recently moved into this package) without updating the dependency list.


09:26:20 -- Found builtin_interfaces: 1.2.2 (/opt/ros/humble/share/builtin_interfaces/cmake)
09:26:20 -- Found std_msgs: 4.9.1 (/opt/ros/humble/share/std_msgs/cmake)
09:26:20 -- Found sensor_msgs: 4.9.1 (/opt/ros/humble/share/sensor_msgs/cmake)
09:26:20 CMake Error at /opt/ros/humble/share/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake:147 (message):
09:26:20   Unable to generate action interface for
09:26:20   'action/TriggeredCalibration.action'.  In order to generate action
09:26:20   interfaces you must add a depend tag for 'action_msgs' in your package.xml.
09:26:20 Call Stack (most recent call first):
09:26:20   CMakeLists.txt:43 (rosidl_generate_interfaces)