### PR TITLE
Imu handling in component

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -398,6 +398,7 @@ namespace realsense2_camera
         bool _is_gyro_enabled;
         bool _pointcloud;
         imu_sync_method _imu_sync_method;
+        std::deque<CimuData> _imu_history;
         stream_index_pair _pointcloud_texture;
         PipelineSyncer _syncer;
         rs2::asynchronous_syncer _asyncer;

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -260,7 +260,6 @@ namespace realsense2_camera
         void setupPublishers();
         void enable_devices();
         void setupFilters();
-        bool setBaseTime(double frame_time, rs2_timestamp_domain time_domain);
         uint64_t millisecondsToNanoseconds(double timestamp_ms);
         rclcpp::Time frameSystemTimeSec(rs2::frame frame);
         cv::Mat& fix_depth_scale(const cv::Mat& from_image, cv::Mat& to_image);
@@ -385,7 +384,7 @@ namespace realsense2_camera
         std::map<rs2_format, int> _rs_format_to_cv_format;
 
         std::map<stream_index_pair, sensor_msgs::msg::CameraInfo> _camera_info;
-        std::atomic_bool _is_initialized_time_base;
+        bool _is_initialized_time_base;
         double _camera_time_base;
         double _previous_frame_time;
 
@@ -400,6 +399,7 @@ namespace realsense2_camera
         imu_sync_method _imu_sync_method;
         std::deque<CimuData> _imu_history;
         std::mutex _imu_callback_mutex;
+        std::mutex _time_base_mutex;
         stream_index_pair _pointcloud_texture;
         PipelineSyncer _syncer;
         rs2::asynchronous_syncer _asyncer;

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -399,6 +399,7 @@ namespace realsense2_camera
         bool _pointcloud;
         imu_sync_method _imu_sync_method;
         std::deque<CimuData> _imu_history;
+        std::mutex _imu_callback_mutex;
         stream_index_pair _pointcloud_texture;
         PipelineSyncer _syncer;
         rs2::asynchronous_syncer _asyncer;

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -353,7 +353,6 @@ template <typename T> T lerp(const T &a, const T &b, const double t) {
 
 void BaseRealSenseNode::FillImuData_LinearInterpolation(const CimuData imu_data, std::deque<sensor_msgs::msg::Imu>& imu_msgs)
 {
-    static std::deque<CimuData> _imu_history;
     _imu_history.push_back(imu_data);
     stream_index_pair type(imu_data.m_type);
     imu_msgs.clear();
@@ -400,16 +399,16 @@ void BaseRealSenseNode::FillImuData_Copy(const CimuData imu_data, std::deque<sen
 {
     stream_index_pair type(imu_data.m_type);
 
-    static CimuData _accel_data(ACCEL, {0,0,0}, -1.0);
     if (ACCEL == type)
     {
-        _accel_data = imu_data;
+        _imu_history.clear();
+        _imu_history.push_back(imu_data);
         return;
     }
-    if (!_accel_data.is_set())
+    if (_imu_history.empty())
         return;
 
-    imu_msgs.push_back(CreateUnitedMessage(_accel_data, imu_data));
+    imu_msgs.push_back(CreateUnitedMessage(_imu_history.back(), imu_data));
 }
 
 void BaseRealSenseNode::ImuMessage_AddDefaultValues(sensor_msgs::msg::Imu& imu_msg)

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -430,13 +430,6 @@ void BaseRealSenseNode::imu_callback_sync(rs2::frame frame, imu_sync_method sync
 
     auto stream = frame.get_profile().stream_type();
     auto stream_index = (stream == GYRO.first)?GYRO:ACCEL;
-    double frame_time = frame.get_timestamp();
-
-    bool placeholder_false(false);
-    if (_is_initialized_time_base.compare_exchange_strong(placeholder_false, true) )
-    {
-        _is_initialized_time_base = setBaseTime(frame_time, frame.get_frame_timestamp_domain());
-    }
 
     if (_synced_imu_publisher && (0 != _synced_imu_publisher->getNumSubscribers()))
     {
@@ -470,12 +463,6 @@ void BaseRealSenseNode::imu_callback_sync(rs2::frame frame, imu_sync_method sync
 void BaseRealSenseNode::imu_callback(rs2::frame frame)
 {
     auto stream = frame.get_profile().stream_type();
-    double frame_time = frame.get_timestamp();
-    bool placeholder_false(false);
-    if (_is_initialized_time_base.compare_exchange_strong(placeholder_false, true) )
-    {
-        _is_initialized_time_base = setBaseTime(frame_time, frame.get_frame_timestamp_domain());
-    }
 
     ROS_DEBUG("Frame arrived: stream: %s ; index: %d ; Timestamp Domain: %s",
                 ros_stream_to_string(frame.get_profile().stream_type()).c_str(),
@@ -564,15 +551,6 @@ void BaseRealSenseNode::frame_callback(rs2::frame frame)
     if (_synced_imu_publisher)
         _synced_imu_publisher->Pause();
     double frame_time = frame.get_timestamp();
-
-    // We compute a ROS timestamp which is based on an initial ROS time at point of first frame,
-    // and the incremental timestamp from the camera.
-    // In sync mode the timestamp is based on ROS time
-    bool placeholder_false(false);
-    if (_is_initialized_time_base.compare_exchange_strong(placeholder_false, true) )
-    {
-        _is_initialized_time_base = setBaseTime(frame_time, frame.get_frame_timestamp_domain());
-    }
 
     rclcpp::Time t(frameSystemTimeSec(frame));
     if (frame.is<rs2::frameset>())
@@ -727,23 +705,6 @@ void BaseRealSenseNode::multiple_message_callback(rs2::frame frame, imu_sync_met
     }
 }
 
-bool BaseRealSenseNode::setBaseTime(double frame_time, rs2_timestamp_domain time_domain)
-{
-    if (time_domain == RS2_TIMESTAMP_DOMAIN_SYSTEM_TIME)
-    {
-        ROS_WARN_ONCE("Frame metadata isn't available! (frame_timestamp_domain = RS2_TIMESTAMP_DOMAIN_SYSTEM_TIME)");
-    }
-
-    if (time_domain == RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK)
-    {
-        ROS_WARN("frame's time domain is HARDWARE_CLOCK. Timestamps may reset periodically.");
-        _ros_time_base = _node.now();
-        _camera_time_base = frame_time;
-        _previous_frame_time = frame_time;
-        return true;
-    }
-    return false;
-}
 
 uint64_t BaseRealSenseNode::millisecondsToNanoseconds(double timestamp_ms)
 {
@@ -764,7 +725,16 @@ rclcpp::Time BaseRealSenseNode::frameSystemTimeSec(rs2::frame frame)
     double timestamp_ms = frame.get_timestamp();
     if (frame.get_frame_timestamp_domain() == RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK)
     {
-        if (_previous_frame_time > timestamp_ms)
+        std::lock_guard<std::mutex> lock(_time_base_mutex);
+        if (!_is_initialized_time_base)
+        {
+            ROS_WARN("frame's time domain is HARDWARE_CLOCK. Timestamps may reset periodically.");
+            _ros_time_base = _node.now();
+            _camera_time_base = timestamp_ms;
+            _previous_frame_time = timestamp_ms;
+            _is_initialized_time_base = true;
+        }
+        else if (_previous_frame_time > timestamp_ms)
         {
             ROS_WARN("Hardware clock reset detected. Resetting ROS time base.");
             _ros_time_base = _node.now();
@@ -787,6 +757,8 @@ rclcpp::Time BaseRealSenseNode::frameSystemTimeSec(rs2::frame frame)
     }
     else
     {
+        if (frame.get_frame_timestamp_domain() == RS2_TIMESTAMP_DOMAIN_SYSTEM_TIME)
+            ROS_WARN_ONCE("Frame metadata isn't available! (frame_timestamp_domain = RS2_TIMESTAMP_DOMAIN_SYSTEM_TIME)");
         return rclcpp::Time(millisecondsToNanoseconds(timestamp_ms));
     }
 }

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -426,9 +426,7 @@ void BaseRealSenseNode::ImuMessage_AddDefaultValues(sensor_msgs::msg::Imu& imu_m
 
 void BaseRealSenseNode::imu_callback_sync(rs2::frame frame, imu_sync_method sync_method)
 {
-    static std::mutex m_mutex;
-
-    m_mutex.lock();
+    std::lock_guard<std::mutex> lock(_imu_callback_mutex);
 
     auto stream = frame.get_profile().stream_type();
     auto stream_index = (stream == GYRO.first)?GYRO:ACCEL;
@@ -467,7 +465,6 @@ void BaseRealSenseNode::imu_callback_sync(rs2::frame frame, imu_sync_method sync
             imu_msgs.pop_front();
          }
     }
-    m_mutex.unlock();
 }
 
 void BaseRealSenseNode::imu_callback(rs2::frame frame)

--- a/realsense2_camera/src/parameters.cpp
+++ b/realsense2_camera/src/parameters.cpp
@@ -154,6 +154,10 @@ void BaseRealSenseNode::setDynamicParams()
                             [this](const rclcpp::Parameter& parameter)
                             {
                                 _imu_sync_method = imu_sync_method(parameter.get_value<int>());
+                                {
+                                    std::lock_guard<std::mutex> lock(_imu_callback_mutex);
+                                    _imu_history.clear();
+                                }
                                 ROS_WARN("For the 'unite_imu_method' param update to take effect, "
                                          "re-enable either gyro or accel stream.");
                             }, crnt_descriptor);


### PR DESCRIPTION
When multiple camera nodes are loaded into the same composable node container they share a process, which exposes several bugs caused by static local variables behaving as process-wide singletons instead of per-instance state.

Commit 1: IMU message pollution
FillImuData_LinearInterpolation and FillImuData_Copy each used a static local variable (_imu_history, _accel_data) to carry state between frames. These were shared across all instances, causing IMU data from one camera to corrupt the output of another.
Replaced both with a single deque member variable.

Commit 2: Shared IMU callback mutex
imu_callback_sync used a static std::mutex to serialize access to IMU state. In a composable container all instances shared the same mutex, meaning cameras serialized against each other rather than independently. Promoted to a member mutex and switched to std::lock_guard for RAII safety.

Commit 3: Race on time base initialization
The hardware-clock time base (_ros_time_base, _camera_time_base, _previous_frame_time) was initialized via atomic_bool::compare_exchange_strong from three different callbacks (frame_callback, imu_callback, imu_callback_sync). This left the non-atomic members unprotected against concurrent writes. Initialization is now consolidated into frameSystemTimeSec under a dedicated _time_base_mutex, and _is_initialized_time_base is a plain bool (protected by the same mutex).

Commit 4: _imu_history corruption on unite_imu_method change
_imu_history is shared between FillImuData_Copy and FillImuData_LinearInterpolation. When unite_imu_method is changed at runtime, stale entries from the previous mode remain in the deque. In the worst case a GYRO sample is used as accel data in COPY mode. The parameter callback now clears _imu_history under _imu_callback_mutex on every mode change.

Testing
Validated with two RealSense D436 cameras in the same composable node container with unite_imu_method set to COPY