### PR TITLE
ci: switch rolling job to ubuntu-26.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
         ros_distro: [rolling, iron, humble, jazzy, kilted]
         include:
         - ros_distro: 'rolling'
-          os: ubuntu-24.04
+          os: ubuntu-26.04
         - ros_distro: 'kilted'
           os: ubuntu-24.04
         - ros_distro: 'jazzy'


### PR DESCRIPTION
## Summary
- ROS 2 Rolling's `distribution.yaml` now lists only `ubuntu: [resolute]` (26.04) under `release_platforms`. Noble (24.04) is no longer supported by the rolling distro.
- Result: `rosdep install --rosdistro rolling` on ubuntu-24.04 fails with `No definition of [xacro] for OS version [noble]` and the same for `diagnostic_updater` (seen on PR #3516's CI, unrelated to that PR's content).
- This PR moves the rolling matrix entry to `ubuntu-26.04` to align the runner with rolling's supported platform.

## Test plan
- [ ] Confirm GitHub-hosted `ubuntu-26.04` runner is available and picks up the job
- [ ] `rosdep install` resolves `xacro` and `diagnostic_updater` on the rolling job
- [ ] Rolling build + tests pass
- [ ] Other distros (humble/iron/jazzy/kilted) remain green

?? Generated with [Claude Code](https://claude.com/claude-code)