### PR TITLE
Fix D555 DDS device detection to not depend on Intel name prefix

### DIFF
--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -448,12 +448,14 @@ void RealSenseNodeFactory::startDevice()
     if (_realSenseNode) _realSenseNode.reset();
     std::string device_name(_device.get_info(RS2_CAMERA_INFO_NAME));
     std::string pid_str(_device.get_info(RS2_CAMERA_INFO_PRODUCT_ID));
+    std::string connection_type(_device.supports(RS2_CAMERA_INFO_CONNECTION_TYPE) ?
+                                _device.get_info(RS2_CAMERA_INFO_CONNECTION_TYPE) : "");
     uint16_t pid;
 
-    if (device_name == "Intel RealSense D555")
+    if (connection_type == "DDS" && device_name.find("D555") != std::string::npos)
     {
-        // currently the PID of DDS devices is hardcoded as "DDS"
-        // need to be fixed in librealsense
+        // DDS devices don't expose a real USB PID (PRODUCT_ID is hardcoded as "DDS"
+        // in librealsense), so resolve the model by name instead.
         pid = RS555_PID;
     }
     else


### PR DESCRIPTION
**Overview:** A pending librealsense change drops the `Intel ` prefix from `RS2_CAMERA_INFO_NAME` (e.g. `Intel RealSense D555` -> `RealSense D555`). The ROS2 wrapper detects DDS-connected D555 by exact name match, so after that change a D555 over DDS is no longer recognized and the node fails to start.

## Why this special-case exists
DDS devices are discovered over the network, and the realdds discovery protocol carries no USB PID. librealsense therefore hardcodes `RS2_CAMERA_INFO_PRODUCT_ID` as the literal string `"DDS"` for DDS devices, so `std::stoi(pid_str, 0, 16)` cannot resolve the model. The wrapper falls back to the only stable identifier a DDS device broadcasts - its name - to force `RS555_PID`. (USB/GMSL D555 expose a real PID and use the normal path.)

## Change
- Detect the DDS D555 by `connection_type == "DDS"` combined with a prefix-tolerant `device_name.find("D555")`, instead of the exact string `"Intel RealSense D555"`.
- Guard `RS2_CAMERA_INFO_CONNECTION_TYPE` with `supports()` so `get_info` cannot throw.

This survives the librealsense rename (matches both old and new names), keeps USB/GMSL devices on the real-PID path, and won't misfire on recovery devices.
