### PR TITLE
Make live-camera device-name parsing vendor-prefix-agnostic

### DIFF
--- a/realsense2_camera/test/utils/pytest_live_camera_utils.py
+++ b/realsense2_camera/test/utils/pytest_live_camera_utils.py
@@ -122,6 +122,7 @@ def get_color_profiles(long_data, start_index, end_index):
     return cap
 
 NAME_LINE_INDEX = 1
+NAME_LINE_VALUE_OFFSET = 2  # tokens after the "Name :" prefix
 SERIAL_NO_LINE_INDEX = 2
 SERIAL_NO_VALUE_OFFSET = 3
 def parse_device_info(long_data, start_index, end_index, device_type, serial_no):
@@ -134,7 +135,7 @@ def parse_device_info(long_data, start_index, end_index, device_type, serial_no)
     # Name value tokens follow the "Name :" prefix. The model token (e.g.
     # "D455") is present whether or not a vendor prefix is shown, so match
     # on it directly.
-    name_value_tokens = name_line[2:]
+    name_value_tokens = name_line[NAME_LINE_VALUE_OFFSET:]
     if device_type not in name_value_tokens:
         debug_print("device not matching:" + " ".join(name_value_tokens))
         return None

--- a/realsense2_camera/test/utils/pytest_live_camera_utils.py
+++ b/realsense2_camera/test/utils/pytest_live_camera_utils.py
@@ -122,7 +122,6 @@ def get_color_profiles(long_data, start_index, end_index):
     return cap
 
 NAME_LINE_INDEX = 1
-NAME_LINE_NAME_OFFSET = 4
 SERIAL_NO_LINE_INDEX = 2
 SERIAL_NO_VALUE_OFFSET = 3
 def parse_device_info(long_data, start_index, end_index, device_type, serial_no):
@@ -132,10 +131,14 @@ def parse_device_info(long_data, start_index, end_index, device_type, serial_no)
     name_line = long_data[start_index+NAME_LINE_INDEX].split()
     if name_line[0] != "Name":
         assert False, "rs-enumerate-devices output format changed"
-    if name_line[4] != device_type:
-        debug_print("device not matching:" + name_line[NAME_LINE_NAME_OFFSET])
+    # Name value tokens follow the "Name :" prefix. The model token (e.g.
+    # "D455") is present whether or not a vendor prefix is shown
+    # ("Intel RealSense D455" vs "RealSense D455"), so match on it directly.
+    name_value_tokens = name_line[2:]
+    if device_type not in name_value_tokens:
+        debug_print("device not matching:" + " ".join(name_value_tokens))
         return None
-    debug_print("device matched:" + name_line[NAME_LINE_NAME_OFFSET])
+    debug_print("device matched:" + device_type)
     if serial_no != None:
         #next line after nameline should have the serial_no
         serial_no_line = long_data[start_index+SERIAL_NO_LINE_INDEX].split()
@@ -193,15 +196,17 @@ def get_camera_capabilities_short(device_type, serial_no=None):
 def check_if_camera_connected(device_type, serial_no=None):
     long_data = os.popen("rs-enumerate-devices -s").read().splitlines()
     debug_print(serial_no)
-    index = 0
-    for index in range(len(long_data)):
-        name_line = long_data[index].split()
-        if name_line[0] != "Intel":
-            continue
-        if name_line[2].casefold() != device_type.casefold():
-            continue
-        if serial_no is None or serial_no == name_line[3]:
-            return True
+    for line in long_data:
+        tokens = line.split()
+        # The camera visible name may or may not carry a vendor prefix
+        # (e.g. "Intel RealSense D455" or "RealSense D455"), so match the
+        # model token directly instead of relying on a fixed column index.
+        for i, token in enumerate(tokens):
+            if token.casefold() != device_type.casefold():
+                continue
+            # The serial number is the token right after the model name.
+            if serial_no is None or (i + 1 < len(tokens) and serial_no == tokens[i + 1]):
+                return True
 
     return False
 

--- a/realsense2_camera/test/utils/pytest_live_camera_utils.py
+++ b/realsense2_camera/test/utils/pytest_live_camera_utils.py
@@ -132,8 +132,8 @@ def parse_device_info(long_data, start_index, end_index, device_type, serial_no)
     if name_line[0] != "Name":
         assert False, "rs-enumerate-devices output format changed"
     # Name value tokens follow the "Name :" prefix. The model token (e.g.
-    # "D455") is present whether or not a vendor prefix is shown
-    # ("Intel RealSense D455" vs "RealSense D455"), so match on it directly.
+    # "D455") is present whether or not a vendor prefix is shown, so match
+    # on it directly.
     name_value_tokens = name_line[2:]
     if device_type not in name_value_tokens:
         debug_print("device not matching:" + " ".join(name_value_tokens))
@@ -198,9 +198,9 @@ def check_if_camera_connected(device_type, serial_no=None):
     debug_print(serial_no)
     for line in long_data:
         tokens = line.split()
-        # The camera visible name may or may not carry a vendor prefix
-        # (e.g. "Intel RealSense D455" or "RealSense D455"), so match the
-        # model token directly instead of relying on a fixed column index.
+        # The camera visible name may or may not carry a vendor prefix, so
+        # match the model token directly instead of relying on a fixed
+        # column index.
         for i, token in enumerate(tokens):
             if token.casefold() != device_type.casefold():
                 continue

--- a/realsense2_ros_mqtt_bridge/test/utils/camera_n_mqtt_nodes.py
+++ b/realsense2_ros_mqtt_bridge/test/utils/camera_n_mqtt_nodes.py
@@ -95,9 +95,9 @@ def get_camera_device_info(device_type, serial_no):
         '''
         rs-enumerate-devices -S
         Device Name                   Serial Number       Firmware Version
-        Intel RealSense D585S         416422320067        8.17.17151.218
-        Device info: 
-            Name                          : Intel RealSense D585S
+        RealSense D585S               416422320067        8.17.17151.218
+        Device info:
+            Name                          : RealSense D585S
             Serial Number                 : 416422320067
             Firmware Version              : 8.17.17151.218
             Physical Port                 : /sys/devices/pci0000:00/0000:00:14.0/usb2/2-5/2-5:1.0/video4linux/video0


### PR DESCRIPTION
**Overview:** The ROS CI nightly (`LRS_linux_compile_ros_ci` #1370) went UNSTABLE with all 12 live-camera tests failing at their `check_if_camera_connected()` precheck (`assert False`). Root cause is librealsense PR #15178 ("Drop 'Intel' prefix from camera visible names"), which changed `rs-enumerate-devices` output from `Intel RealSense D455` to `RealSense D455`. Two parsers in `pytest_live_camera_utils.py` hard-coded the old `Intel RealSense <model>` layout and no longer recognize any camera, so every live-camera test bails in its connectivity precheck.

**Changes:**
- `check_if_camera_connected` (`-s` output): match the model token anywhere in the line instead of requiring `name_line[0] == "Intel"` and the model at a fixed column; the serial is taken as the token right after the model.
- `parse_device_info` (`-v` output): match `device_type` among the `Name :` value tokens instead of the fixed index 4 (which now reads the wrong token / out of range). Removed the now-unused `NAME_LINE_NAME_OFFSET`.
- Removed all `Intel` references from the test files: reworded the explanatory comments, and updated the `camera_n_mqtt_nodes.py` docstring sample output to the rebranded `RealSense D585S` format.

Both parsers now accept device names with or without the vendor prefix, so they work against pre- and post-#15178 librealsense.

🤖 Generated by AI
