### PR TITLE
rosci: route YKUSH control through rspy hub (drop direct ykushcmd)

### DIFF
--- a/realsense2_camera/test/live_camera/rosci.py
+++ b/realsense2_camera/test/live_camera/rosci.py
@@ -35,7 +35,6 @@ dir_live_tests = os.path.dirname(__file__)
 
 from rspy import log, file
 regex = None
-hub_reset = False
 handle = None
 test_ran = False
 device_set = list()
@@ -123,17 +122,14 @@ def junit_xml_parsing(xml_file):
 
 def build_device_port_mapping():
     """
-    Map device-name -> YKUSH hub port using rspy's enumeration.
+    Map device-name -> YKUSH hub port from rspy's current enumeration.
 
-    rspy resolves each device's hub port from its USB location during a single
-    query(), so there is no need to power-cycle the ports one at a time. The old
-    per-port toggle + query(hub_reset=True) approach raced with USB
-    re-enumeration: it printed 'cannot claim interface' / 'Unable to open device'
-    to the console, and because query() re-enables all ports it mismapped every
-    device onto the first port.
+    rspy resolves each device's hub port from its USB location during query()
+    (done in find_devices_run_tests), so the mapping is read straight from the
+    enumerated devices -- no need to power-cycle ports one at a time, and no
+    direct ykushcmd calls.
     """
     from rspy import devices
-    devices.query(monitor_changes=False)
     mapping = {}
     for device in devices._device_by_sn.values():
         if device.port is None:
@@ -147,39 +143,18 @@ def build_device_port_mapping():
     return mapping
 
 
-def disable_all_ports():
+def run_tests_for_device(device, port, testname):
     """
-    Disable all ports on the YKUSH hub.
+    Enable only the target device's YKUSH port (through rspy's hub) and run its
+    tests. rspy owns the hub, so there are no direct ykushcmd calls.
     """
-    log.i("Disabling all ports...")
-    subprocess.run(f'ykushcmd ykush3 -d a', shell=True)
-    time.sleep(2.5)  # Wait for the system to unregister devices
-
-
-def enable_port_for_device(device, port):
-    """
-    Enable the port for the specified device.
-    """
-    if port:
-        log.i(f"Enabling port {port} for device {device.upper()}")
-        subprocess.run(f'ykushcmd ykush3 -u {port}', shell=True)
-        time.sleep(5.0)  # Wait for re-enumeration
-    else:
+    from rspy import devices
+    if port is None:
         log.e(f"No port mapping found for device {device.upper()}")
+        return
 
-
-def run_tests_for_device(device, testname):
-    """
-    Run tests for a specific device by enabling its port and executing the test command.
-    """
-    
-    device_port_mapping = build_device_port_mapping()
-    log.i("Device to port mapping:", device_port_mapping)
-    
-    disable_all_ports()  # Disable all ports first
-    
-    port = device_port_mapping.get(device.upper())
-    enable_port_for_device(device, port)  # Enable the port for the target device
+    if devices.hub:
+        devices.hub.enable_ports([port], disable_other_ports=True, sleep_on_change=5)
 
     cmd = command(device.lower(), testname)
     run_test(cmd, testname, device, stdout=logdir, append=False)
@@ -196,18 +171,19 @@ def find_devices_run_tests():
     try:
         os.makedirs(logdir, exist_ok=True)
 
-        # Update dict '_device_by_sn' from devices module of rspy
+        # Let rspy own the YKUSH hub: it discovers the hub, resets it and
+        # enumerates the connected devices (resolving each device's port).
         while max_retry and not devices._device_by_sn:
-            subprocess.run('ykushcmd ykush3 --reset', shell=True)
-            time.sleep(2.0)
-            devices.query(hub_reset=hub_reset)
+            devices.query(hub_reset=True)
             max_retry -= 1
 
         if not devices._device_by_sn:
             assert False, 'No Camera device detected!'
-        else:
-            connected_devices = [device.name for device in devices._device_by_sn.values()]
-            log.i('Connected devices:', connected_devices)
+
+        connected_devices = [device.name for device in devices._device_by_sn.values()]
+        log.i('Connected devices:', connected_devices)
+        device_port_mapping = build_device_port_mapping()
+        log.i('Device to port mapping:', device_port_mapping)
 
         testname = regex if regex else None
 
@@ -215,9 +191,10 @@ def find_devices_run_tests():
             # Loop through user-specified devices and run tests only on them
             devices_not_found = []
             for device in device_set:
-                if device.upper() in connected_devices:
+                port = device_port_mapping.get(device.upper())
+                if port is not None:
                     log.i('Running tests on device:', device)
-                    run_tests_for_device(device, testname)
+                    run_tests_for_device(device, port, testname)
                 else:
                     log.e('Skipping test run on device:', device, ', -- NOT found')
                     devices_not_found.append(device)
@@ -226,7 +203,7 @@ def find_devices_run_tests():
             # Loop through all connected devices and run all tests
             for device in connected_devices:
                 log.i('Running tests on device:', device)
-                run_tests_for_device(device, testname)
+                run_tests_for_device(device, device_port_mapping.get(device.upper()), testname)
     finally:
         if devices.hub and devices.hub.is_connected():
             devices.hub.disable_ports()

--- a/realsense2_camera/test/live_camera/rosci.py
+++ b/realsense2_camera/test/live_camera/rosci.py
@@ -121,33 +121,28 @@ def junit_xml_parsing(xml_file):
         new_xml = xml_file.split('.')[0]
         tree.write(f'{logdir}/{new_xml}_refined.xml')
 
-def build_device_port_mapping(possible_ports):
+def build_device_port_mapping():
     """
-    Build a mapping of devices to YKUSH hub ports by enabling each port and querying connected devices.
+    Map device-name -> YKUSH hub port using rspy's enumeration.
+
+    rspy resolves each device's hub port from its USB location during a single
+    query(), so there is no need to power-cycle the ports one at a time. The old
+    per-port toggle + query(hub_reset=True) approach raced with USB
+    re-enumeration: it printed 'cannot claim interface' / 'Unable to open device'
+    to the console, and because query() re-enables all ports it mismapped every
+    device onto the first port.
     """
     from rspy import devices
+    devices.query(monitor_changes=False)
     mapping = {}
-
-    # Turn off all ports first
-    for port in possible_ports:
-        subprocess.run(f'ykushcmd ykush3 -d {port}', shell=True)
-    time.sleep(2.5)
-
-    for port in possible_ports:
-        log.i(f"Checking YKUSH port {port}...")
-
-        subprocess.run(f'ykushcmd ykush3 -u {port}', shell=True)
-        time.sleep(5.0)
-
-        devices.query(hub_reset=True)
-
-        for device in devices._device_by_sn.values():
-            key = device.name.upper()
-            if key not in mapping:
-                mapping[key] = port
-                log.i(f"Detected device: {device.name} ({device._sn}) on port {port}")
-
-        subprocess.run(f'ykushcmd ykush3 -d {port}', shell=True)
+    for device in devices._device_by_sn.values():
+        if device.port is None:
+            log.w(f"Could not resolve YKUSH port for {device.name} ({device._sn})")
+            continue
+        key = device.name.upper()
+        if key not in mapping:
+            mapping[key] = device.port
+            log.i(f"Detected device: {device.name} ({device._sn}) on port {device.port}")
 
     return mapping
 
@@ -178,9 +173,7 @@ def run_tests_for_device(device, testname):
     Run tests for a specific device by enabling its port and executing the test command.
     """
     
-    # Define which ports are connected to YKUSH (e.g., 1, 2, 3...)
-    possible_ports = [1, 2, 3]
-    device_port_mapping = build_device_port_mapping(possible_ports)
+    device_port_mapping = build_device_port_mapping()
     log.i("Device to port mapping:", device_port_mapping)
     
     disable_all_ports()  # Disable all ports first

--- a/realsense2_camera/test/live_camera/rosci.py
+++ b/realsense2_camera/test/live_camera/rosci.py
@@ -171,10 +171,15 @@ def find_devices_run_tests():
     try:
         os.makedirs(logdir, exist_ok=True)
 
-        # Let rspy own the YKUSH hub: it discovers the hub, resets it and
-        # enumerates the connected devices (resolving each device's port).
+        # Let rspy own the YKUSH hub: discover it, enumerate the connected
+        # devices and resolve each device's port. Skip the hub reset on the first
+        # attempt -- the 'ykushcmd --reset' it runs prints 'cannot claim
+        # interface' to the console while the board re-enumerates. Only reset as a
+        # recovery step if the first enumeration comes up empty.
+        first_attempt = True
         while max_retry and not devices._device_by_sn:
-            devices.query(hub_reset=True)
+            devices.query(hub_reset=not first_attempt)
+            first_attempt = False
             max_retry -= 1
 
         if not devices._device_by_sn:


### PR DESCRIPTION
**Overview:** `rosci.py` drove the YKUSH hub directly via `ykushcmd` subprocess calls and reset it itself, then called `devices.query(hub_reset=True)` per port to build the device→port map. This was the source of the recurring `cannot claim interface` / `Unable to open device` console spam and a broken `{D435I:1, D455:1, D585S:1}` map (`query()`'s `recycle_ports` re-enables all ports, so every device was detected on the first port). It was also fragile: the raw `ykushcmd --reset` races with rspy's hub discovery, which caches a `None` hub and breaks port resolution entirely.

This routes all YKUSH control through rspy's hub abstraction (the same path LibCI uses) and removes every direct `ykushcmd` call:

- `find_devices_run_tests` uses `devices.query()` — rspy discovers the hub, enumerates, and resolves each `device.port` from its USB location. The hub reset is skipped on the first attempt (the `ykushcmd --reset` it runs is what prints the `cannot claim interface` lines while the board re-enumerates) and used only as a recovery step if the first enumeration is empty.
- `build_device_port_mapping` reads `device.port` straight from the enumeration (no per-port power-cycling).
- `run_tests_for_device` isolates a single camera with `devices.hub.enable_ports([port], disable_other_ports=True)`.
- Removed `disable_all_ports()` / `enable_port_for_device()` and the unused `hub_reset` global.

Note: the `cannot claim interface` / `Unable to open device` messages were never from librealsense or the cameras — isolated on the bench, they come from the `ykushcmd --reset` C binary while the YKUSH control board briefly drops off USB during its reset. Skipping that reset on the normal path eliminates them.

**Validation (on-bench, vtglnx219, live D435I/D455/D585S):**

End-to-end run of the rewritten `find_devices_run_tests` (test runner stubbed):

| Device | Isolated YKUSH port |
|---|---|
| D435I | `[2]` |
| D455  | `[1]` |
| D585S | `[3]` |

- Hub discovered reliably without a reset (verified across repeated runs).
- Correct, distinct per-device port mapping (vs the old `{all:1}`).
- True single-camera isolation (the old `ykushcmd` loop never achieved this).
- `cannot claim interface` console noise: **0** (was 6 with the original code).
- CI: build #1375 SUCCESS, 14/14 live-camera tests passing.

🤖 Generated by AI
