### PR TITLE
ci: drop ROS 2 Iron from main workflow matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ros_distro: [rolling, iron, humble, jazzy, kilted]
+        ros_distro: [rolling, humble, jazzy, kilted]
         include:
         - ros_distro: 'rolling'
           os: ubuntu-24.04
@@ -39,8 +39,6 @@ jobs:
           os: ubuntu-24.04
         - ros_distro: 'jazzy'
           os: ubuntu-24.04
-        - ros_distro: 'iron'
-          os: ubuntu-22.04
         - ros_distro: 'humble'
           os: ubuntu-22.04
 
@@ -122,7 +120,7 @@ jobs:
     #    wget $bag_filename -P "records/"
     #    sudo apt install ros-${{ matrix.ros_distro}}-launch-pytest
 
-    - name: Install Packages For Humble/Iron/Rolling/Jazzy/Kilted Tests
+    - name: Install Packages For Humble/Rolling/Jazzy/Kilted Tests
       shell: bash
       run: |
         apt-get install -y python3-pip python3-venv


### PR DESCRIPTION
## Summary
- Remove `iron` from the ROS distro matrix and its `include` entry in `.github/workflows/main.yml`.
- Update the test-install step name to drop the `Iron/` token.
- Iron is EOL upstream; this stops scheduling builds against it.

## Scope
- CI-only change. **No source code is removed.** The `IRON` CMake branch and `defined(IRON)` preprocessor guards stay in place — they live inside multi-distro conditionals (foxy/humble/iron/jazzy/kilted/rolling), so removing iron from CI leaves no dead branches. We can clean those up in a follow-up if we want a true source-level drop.

## Test plan
- [x] CI workflow runs only against `rolling`, `humble`, `jazzy`, `kilted`.
- [x] No matrix job is named `... iron and ubuntu-22.04`.
- [x] `pre-release.yml` and `static_analysis.yaml` unaffected (they didn't reference iron).

🤖 Generated with [Claude Code](https://claude.com/claude-code)