### PR TITLE
fix: track frame timestamp per-stream in HW clock mode (silences false reset warnings on DDS)

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -386,7 +386,10 @@ namespace realsense2_camera
         std::map<stream_index_pair, sensor_msgs::msg::CameraInfo> _camera_info;
         bool _is_initialized_time_base;
         double _camera_time_base;
-        double _previous_frame_time;
+        // Keyed by rs2::stream_profile::unique_id(). Tracking per-stream avoids
+        // false "clock reset" detections when frames from streams running at
+        // different rates interleave out of order on the shared HW clock.
+        std::map<int, double> _previous_frame_time;
 
         rclcpp::Time _ros_time_base;
         bool _sync_frames;

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -726,21 +726,28 @@ rclcpp::Time BaseRealSenseNode::frameSystemTimeSec(rs2::frame frame)
     if (frame.get_frame_timestamp_domain() == RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK)
     {
         std::lock_guard<std::mutex> lock(_time_base_mutex);
+        const int stream_uid = frame.get_profile().unique_id();
         if (!_is_initialized_time_base)
         {
             ROS_WARN("frame's time domain is HARDWARE_CLOCK. Timestamps may reset periodically.");
             _ros_time_base = _node.now();
             _camera_time_base = timestamp_ms;
-            _previous_frame_time = timestamp_ms;
             _is_initialized_time_base = true;
         }
-        else if (_previous_frame_time > timestamp_ms)
+        else
         {
-            ROS_WARN("Hardware clock reset detected. Resetting ROS time base.");
-            _ros_time_base = _node.now();
-            _camera_time_base = timestamp_ms;
+            auto it = _previous_frame_time.find(stream_uid);
+            if (it != _previous_frame_time.end() && it->second > timestamp_ms)
+            {
+                ROS_WARN("Hardware clock reset detected. Resetting ROS time base.");
+                _ros_time_base = _node.now();
+                _camera_time_base = timestamp_ms;
+                // Other streams' previous timestamps are stale w.r.t. the new
+                // time base; drop them so they re-seed silently on next frame.
+                _previous_frame_time.clear();
+            }
         }
-        _previous_frame_time = timestamp_ms;
+        _previous_frame_time[stream_uid] = timestamp_ms;
 
         double elapsed_camera_ns = millisecondsToNanoseconds(timestamp_ms - _camera_time_base);
 


### PR DESCRIPTION
## Summary
Fixes a wrapper-side false positive in `BaseRealSenseNode::frameSystemTimeSec()` that floods the logs with `Hardware clock reset detected. Resetting ROS time base.` warnings — and forces a spurious time-base rebase on most frames — when running with multi-stream sources that report timestamps in `RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK` (currently: DDS devices, e.g. D555).

USB devices report `RS2_TIMESTAMP_DOMAIN_GLOBAL_TIME` and never enter this branch, so they're unaffected.

## Root cause
`_previous_frame_time` was a single shared `double` compared against the timestamp of *every* incoming frame regardless of which stream it came from. With multiple streams running at different rates (depth/color/IMU), frames legitimately interleave out of order against that one global value, so the `_previous_frame_time > timestamp_ms` check trips on most frames and is interpreted as a hardware clock reset.

## Fix
Make `_previous_frame_time` a per-stream `std::map<int, double>` keyed by `rs2::stream_profile::unique_id()`. Each stream's monotonicity is now checked only against itself. On a genuine backward jump, clear the whole map so other streams re-seed silently on their next frame (the new time base would make their stored "previous" values stale anyway).

## Validation
Tested on Ubuntu 22.04 / Humble against a D555 over DDS (librealsense 2.59.9 from source).

**Before:** `Hardware clock reset detected` repeating continuously throughout the run.

**After:** exactly one `frame's time domain is HARDWARE_CLOCK. Timestamps may reset periodically.` informational notice at startup (the expected first-frame seed), and zero `Hardware clock reset detected` messages during steady-state streaming.

The remaining log lines from `dds-metadata-syncer` / `dds-topic-reader` / `color-formats-converter` originate in librealsense's DDS layer, not the wrapper, and are out of scope for this PR.

## Risk
- USB / `GLOBAL_TIME` path: untouched (early-out before this branch).
- Real HW clock wraps: still produce one warning + rebase, then quiet — same observable behavior as before, just no longer spammed by interleave artifacts.
- No public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)