### PR TITLE
Remove PID whitelist in startDevice (let librealsense gate which cameras are supported)

### DIFF
--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -448,52 +448,16 @@ void RealSenseNodeFactory::startDevice()
     if (_realSenseNode) _realSenseNode.reset();
     std::string device_name(_device.get_info(RS2_CAMERA_INFO_NAME));
     std::string pid_str(_device.get_info(RS2_CAMERA_INFO_PRODUCT_ID));
-    std::string connection_type(_device.supports(RS2_CAMERA_INFO_CONNECTION_TYPE) ?
-                                _device.get_info(RS2_CAMERA_INFO_CONNECTION_TYPE) : "");
-    uint16_t pid;
+    // No PID whitelist: librealsense's context (see query_devices() in the
+    // query thread) only ever enumerates RealSense hardware, so any device that
+    // reaches this point is already supported by the installed librealsense2 and
+    // is enabled. This lets newly released cameras work without having to add
+    // their PID to the wrapper first.
+    ROS_INFO_STREAM("Starting device " << device_name << " (Product ID: 0x" << pid_str << ")");
 
-    if (connection_type == "DDS" && device_name.find("D555") != std::string::npos)
-    {
-        // DDS devices don't expose a real USB PID (PRODUCT_ID is hardcoded as "DDS"
-        // in librealsense), so resolve the model by name instead.
-        pid = RS555_PID;
-    }
-    else
-    {
-        pid = std::stoi(pid_str, 0, 16);
-    }
     try
     {
-        switch(pid)
-        {
-        case RS400_PID:
-        case RS405_PID:
-        case RS410_PID:
-        case RS460_PID:
-        case RS415_PID:
-        case RS420_PID:
-        case RS421_PID:
-        case RS420_MM_PID:
-        case RS430_PID:
-        case RS430i_PID:
-        case RS430_MM_PID:
-        case RS430_MM_RGB_PID:
-        case RS435_RGB_PID:
-        case RS435i_RGB_PID:
-        case RS455_PID:
-        case RS457_PID:
-        case RS555_PID:
-        case RS436_PID:
-        case RS_USB2_PID:
-        case RS_D585_PID:
-        case RS_D585S_PID:
-            _realSenseNode = std::unique_ptr<BaseRealSenseNode>(new BaseRealSenseNode(*this, _device, _parameters, this->get_node_options().use_intra_process_comms()));
-            break;
-        default:
-            ROS_FATAL_STREAM("Unsupported device!" << " Product ID: 0x" << pid_str);
-            rclcpp::shutdown();
-            exit(1);
-        }
+        _realSenseNode = std::unique_ptr<BaseRealSenseNode>(new BaseRealSenseNode(*this, _device, _parameters, this->get_node_options().use_intra_process_comms()));
         _realSenseNode->publishTopics();
     }
     catch(const rs2::backend_error& e)


### PR DESCRIPTION
## Summary
Removes the hard-coded PID whitelist (and the D555-over-DDS special case) inside `RealSenseNodeFactory::startDevice()`. The wrapper now instantiates `BaseRealSenseNode` for any device that reaches `startDevice()`, deferring the \"is this a RealSense camera I support?\" question to the installed librealsense2.

## Why
Every path that reaches `startDevice()` is already gated by librealsense itself:

| Path | Source of `_device` |
|---|---|
| Live enumeration (`_query_thread`) | `RSContextSingletonWrapper::getInstance().query_devices()` |
| Hot-plug callback (`changeDeviceCallback`) | `rs2::event_information::get_new_devices()` |
| Bag playback | `RSContextSingletonWrapper::getInstance().load_device(rosbag_filename)` |

None of these can produce a non-RealSense device. So the wrapper's switch-over-PID was a redundant second filter — but a fragile one: every new camera model required adding its PID to the wrapper before it would work, even if the librealsense version on the machine already supported it. This was the motivation for the D555/DDS special case (DDS devices report `PRODUCT_ID` as the literal string `\"DDS\"` rather than a hex PID, so the whitelist couldn't match by PID and had to fall through a name-based override).

## What changes
- Delete the `switch(pid) { case RS400_PID: ... default: ROS_FATAL_STREAM(\"Unsupported device!\") }` block.
- Delete the `connection_type == \"DDS\" && device_name.find(\"D555\")` special case.
- Replace with a single `ROS_INFO_STREAM` announcing the device that's starting.

No public API change. Net diff is **+7 / -43** in one file (`realsense_node_factory.cpp`).

## Effects
- Newly-released cameras work as soon as the user's installed librealsense2 enumerates them — no wrapper rebuild required.
- Devices that librealsense doesn't enumerate at all never reach `startDevice()`, so the old `\"Unsupported device!\"` fatal path is unreachable by construction.
- If a future librealsense were to enumerate something the wrapper's `BaseRealSenseNode` truly can't drive, the failure now surfaces from the `BaseRealSenseNode` constructor / `publishTopics()` path (already wrapped in the existing `try/catch (rs2::backend_error&)` below) rather than from a wrapper-side fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)