### PR TITLE
LRS-1181: Make TF tests robust to split /tf_static publishing

### DIFF
--- a/realsense2_camera/test/live_camera/test_camera_tf_tests.py
+++ b/realsense2_camera/test/live_camera/test_camera_tf_tests.py
@@ -206,8 +206,7 @@ class TestCamera_TestTF_DYN(pytest_rs_utils.RsTestBaseClass):
         frame_ids = [self.params['camera_name']+'_link', 
             self.params['camera_name']+'_depth_frame', 
             self.params['camera_name']+'_color_frame']
-        data = self.node.pop_first_chunk('/tf_static')
-        ret = self.check_transform_data(data, frame_ids, True)
+        ret = self.check_static_transform_data('/tf_static', frame_ids)
         assert ret[0], ret[1]
         data = self.node.pop_first_chunk('/tf')
         ret = self.check_transform_data(data, frame_ids)
@@ -275,11 +274,9 @@ class TestCamera_TestTF_Prefix(pytest_rs_utils.RsTestBaseClass):
             prefix + self.params['camera_name']+'_depth_frame', 
             prefix + self.params['camera_name']+'_color_frame'
         ]
-        data = self.node.pop_first_chunk('/tf_static')
-        print(data)
-        ret = self.check_transform_data(data, frame_ids, True)
+        ret = self.check_static_transform_data('/tf_static', frame_ids)
         assert ret[0], ret[1]
-        
+
         # Check dynamic transforms
         for _ in range(3):  # We expect 3 chunks as per expected_data_chunks
             data = self.node.pop_first_chunk('/tf')

--- a/realsense2_camera/test/utils/pytest_rs_utils.py
+++ b/realsense2_camera/test/utils/pytest_rs_utils.py
@@ -1005,7 +1005,7 @@ class RsTestBaseClass():
         # /tf_static is latched and the node resets its static broadcaster when
         # (re)publishing, so the first message received can be incomplete.
         # Aggregate the transforms from ALL received messages before checking,
-        # to avoid a flaky race (RSDSO/LRS-1181).
+        # to avoid a flaky race.
         coupled_frame_ids = [xx for xx in itertools.combinations(frame_ids, 2)]
         tfBuffer = tf2_ros.Buffer()
         while self.node.get_num_chunks(topic) > 0:

--- a/realsense2_camera/test/utils/pytest_rs_utils.py
+++ b/realsense2_camera/test/utils/pytest_rs_utils.py
@@ -1000,6 +1000,22 @@ class RsTestBaseClass():
             if res[couple] == None:
                 return False, str(couple) + ": didn't get any tf data"
         return True,""
+
+    def check_static_transform_data(self, topic, frame_ids):
+        # /tf_static is latched and the node resets its static broadcaster when
+        # (re)publishing, so the first message received can be incomplete.
+        # Aggregate the transforms from ALL received messages before checking,
+        # to avoid a flaky race (RSDSO/LRS-1181).
+        coupled_frame_ids = [xx for xx in itertools.combinations(frame_ids, 2)]
+        tfBuffer = tf2_ros.Buffer()
+        while self.node.get_num_chunks(topic) > 0:
+            for transform in self.node.pop_first_chunk(topic).transforms:
+                tfBuffer.set_transform_static(transform, "default_authority")
+        for couple in coupled_frame_ids:
+            from_id, to_id = couple
+            if not tfBuffer.can_transform(from_id, to_id, rclpy.time.Time(), rclpy.time.Duration(nanoseconds=3e6)):
+                return False, str(couple) + ": didn't get any tf data"
+        return True, ""
     
     '''
     Please override and use your own process_data if the default check is not suitable.


### PR DESCRIPTION
**Overview:** Fixes the intermittently-failing `test_camera_test_tf_dyn` and `test_camera_test_tf_prefix` (`"didn't get any tf data"`), tracked in [LRS-1181](https://rsjira.realsenseai.com/browse/LRS-1181).

### Root cause
`/tf_static` is a latched topic, and the node resets its static broadcaster on (re)publish (`tfs.cpp: restartStaticTransformBroadcaster`), so a subscriber can capture a **partial first message**. The tests used `pop_first_chunk('/tf_static')` and validated only that single message in isolation (`can_transform`, 3 ms) — so when the first captured message didn't contain the `link→depth_frame` edge, the lookup returned nothing. It's timing-dependent, hence flaky under CI load. The dynamic `/tf` checks were unaffected because each `/tf` message republishes the full set.

### Fix (test-only)
Added `check_static_transform_data()` to the test base class, which aggregates the transforms from **all** received `/tf_static` messages into one buffer before checking. The two affected tests now use it; `/tf` checks are unchanged.

### Validation
Built and ran on the ROS 2 Humble CI job — the fix branch passed the TF tests on 3 consecutive runs (14/0/5), while the unfixed `ros2-development` baseline failed the same test in between.

Files: `test/utils/pytest_rs_utils.py` (+helper), `test/live_camera/test_camera_tf_tests.py` (two `process_data` methods). +19/−6.

🤖 Generated by AI
