### PR TITLE
Ngoren/occupancy gridcells fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,11 @@ User can set the camera name and camera namespace, to distinguish between camera
 - **clip_distance**:
   - Remove from the depth image all values above a given value (meters). Disable by giving negative value (default)
   - For example: `clip_distance:=1.5`
+- **occupancy_max_range**:
+  - Maximum reliable range (meters) for the occupancy grid raycasting. Cells beyond this distance are published as unknown (-1) rather than free, since the absence of a detection there is not evidence of free space.
+  - Defaults to 2.5. Set to 0 or a negative value to use the full grid extent.
+  - For example: `occupancy_max_range:=3.0`
+  - Relevant only when the occupancy stream is enabled (`enable_occupancy:=true`); requires the depth stream for its intrinsics.
 - **linear_accel_cov**, **angular_velocity_cov**: sets the variance given to the Imu readings.
 - **hold_back_imu_for_frames**: Images processing takes time. Therefor there is a time gap between the moment the image arrives at the wrapper and the moment the image is published to the ROS environment. During this time, Imu messages keep on arriving and a situation is created where an image with earlier timestamp is published after Imu message with later timestamp. If that is a problem, setting *hold_back_imu_for_frames* to *true* will hold the Imu messages back while processing the images and then publish them all in a burst, thus keeping the order of publication as the order of arrival. Note that in either case, the timestamp in each message's header reflects the time of it's origin.
 - **publish_tf**:

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -47,7 +47,7 @@
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/imu.hpp>
-#include <nav_msgs/msg/grid_cells.hpp>
+#include <nav_msgs/msg/occupancy_grid.hpp>
 
 #if defined(HUMBLE) || defined(IRON) || defined(JAZZY) || defined(FOXY) 
 #include <tf2/LinearMath/Quaternion.h>
@@ -371,7 +371,7 @@ namespace realsense2_camera
         bool _use_intra_process;      
         std::map<stream_index_pair, std::shared_ptr<image_publisher>> _image_publishers;
         rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr _labeled_pointcloud_publisher;
-        rclcpp::Publisher<nav_msgs::msg::GridCells>::SharedPtr _occupancy_publisher;
+        rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr _occupancy_publisher;
         std::map<stream_index_pair, rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr> _imu_publishers;
         std::shared_ptr<SyncedImuPublisher> _synced_imu_publisher;
         std::map<stream_index_pair, rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr> _info_publishers;

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -350,6 +350,7 @@ namespace realsense2_camera
         std::string _json_file_path;
         float _depth_scale_meters;
         float _clipping_distance;
+        float _occupancy_max_range;
 
         double _linear_accel_cov;
         double _angular_velocity_cov;

--- a/realsense2_camera/launch/rs_launch.py
+++ b/realsense2_camera/launch/rs_launch.py
@@ -68,6 +68,7 @@ configurable_parameters = [{'name': 'camera_name',                  'default': '
                            {'name': 'motion_fps',                   'default': '0', 'description': "'motion stream samples per second'"},
                            {'name': 'unite_imu_method',             'default': "0", 'description': '[0-None, 1-copy, 2-linear_interpolation]'},
                            {'name': 'clip_distance',                'default': '-2.', 'description': "''"},
+                           {'name': 'occupancy_max_range',          'default': '2.5', 'description': "'max reliable range for occupancy raycasting in meters; cells beyond this are unknown (-1)'"},
                            {'name': 'angular_velocity_cov',         'default': '0.01', 'description': "''"},
                            {'name': 'linear_accel_cov',             'default': '0.01', 'description': "''"},
                            {'name': 'diagnostics_period',           'default': '0.0', 'description': 'Rate of publishing diagnostics. 0=Disabled'},

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -922,41 +922,52 @@ void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& 
     if(!_occupancy_publisher || 0 == _occupancy_publisher->get_subscription_count())
         return;
 
-    ROS_DEBUG("Publishing Occupancy GridCells Frame");
+    ROS_DEBUG("Publishing Occupancy Grid Frame");
 
-    // get frame bytes and frame metadata relevant info
     auto frame_as_uint8_arr = (uint8_t*)f.get_data();
-    auto cols = static_cast<int>(f.get_frame_metadata(RS2_FRAME_METADATA_OCCUPANCY_GRID_COLUMNS)); // grid cells width
-    auto rows = static_cast<int>(f.get_frame_metadata(RS2_FRAME_METADATA_OCCUPANCY_GRID_ROWS)); // grid cells height
-    auto cell_size = static_cast<float>(f.get_frame_metadata(RS2_FRAME_METADATA_OCCUPANCY_CELL_SIZE) / 100.0f); // convert to meters
+    auto cols = static_cast<int>(f.get_frame_metadata(RS2_FRAME_METADATA_OCCUPANCY_GRID_COLUMNS));
+    auto rows = static_cast<int>(f.get_frame_metadata(RS2_FRAME_METADATA_OCCUPANCY_GRID_ROWS));
+    auto cell_size = static_cast<float>(f.get_frame_metadata(RS2_FRAME_METADATA_OCCUPANCY_CELL_SIZE) / 100.0f); // cm -> m
 
-    // create GridCells msg and start filling it
-    nav_msgs::msg::GridCells msg;
+    nav_msgs::msg::OccupancyGrid msg;
     msg.header.stamp = t;
     msg.header.frame_id = FRAME_ID(OCCUPANCY);
-    msg.cell_width = cell_size;
-    msg.cell_height = cell_size;
+
+    // Grid metadata — self-describing so subscribers need no out-of-band knowledge.
+    // Axes follow ROS convention (X: Forward, Y: Left):
+    //   width  = cells along X (forward) = rows in firmware
+    //   height = cells along Y (left)    = cols in firmware
+    // Origin is the lower-left corner of cell (width-1, 0) in map frame:
+    //   origin.x = 0           (nearest boundary, X direction)
+    //   origin.y = -resolution * height / 2  (rightmost boundary, Y direction)
+    msg.info.map_load_time = t;
+    msg.info.resolution = cell_size;
+    msg.info.width  = static_cast<uint32_t>(rows);
+    msg.info.height = static_cast<uint32_t>(cols);
+    msg.info.origin.position.x = 0.0;
+    msg.info.origin.position.y = -cell_size * static_cast<float>(cols) / 2.0f;
+    msg.info.origin.position.z = 0.0;
+    msg.info.origin.orientation.w = 1.0;
+
+    // data[row_idx * width + col_idx], 0 = free, 100 = occupied.
+    // col_idx increases in +X (forward), row_idx increases in +Y (left).
+    // Firmware row 0 = farthest  → col_idx = width-1-fw_row
+    // Firmware col 0 = leftmost  → row_idx = height-1-fw_col
+    msg.data.assign(rows * cols, 0);
 
     for (auto i = 0; i < cols * rows; ++i)
     {
-        // AICV algo is packing each 8 cells into one byte. Each byte include 8 bits <--> 8 cells
-        // The rightest bit (LSB) inside the packed byte from AICV algo represnts the closest cell we want to work with in the grid.
-        // e.g. Original Occupancy Cells: 0 0 1 1 0 0 1 0 ---> AICV packing algo ---> 01001100 (not the opposite order)
-        // In this if we check if current cell is occupied.
-        // Note that we start working from the most left bit, aka, the farest point of the grid.
+        // AICV algo packs 8 cells per byte; bit i%8 of byte i/8 = cell i.
         if ((frame_as_uint8_arr[i / 8U] & (1U << i % 8)) != 0)
         {
-            // Find x,y,z positions of current index
-            // Remember, in ROS CS: (X: Forward, Y: Left, Z: Up)
-            geometry_msgs::msg::Point p3d;
-            uint32_t row = (i / cols);
-            uint32_t col = (i % cols);
-            p3d.x = (cell_size * static_cast<float>(rows)) - cell_size * (static_cast<float>(row) + 0.5f);
-            p3d.y = (cell_size * static_cast<float>(cols)) / 2 - cell_size * (static_cast<float>(col) + 0.5f);
-            p3d.z = 0;
-            msg.cells.push_back(p3d);
+            uint32_t fw_row = static_cast<uint32_t>(i / cols);
+            uint32_t fw_col = static_cast<uint32_t>(i % cols);
+            uint32_t og_col_idx = static_cast<uint32_t>(rows) - 1u - fw_row;
+            uint32_t og_row_idx = static_cast<uint32_t>(cols) - 1u - fw_col;
+            msg.data[og_row_idx * static_cast<uint32_t>(rows) + og_col_idx] = 100;
         }
     }
+
     _occupancy_publisher->publish(msg);
 }
 

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -929,7 +929,8 @@ void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& 
     // The FOV mask and ray binning are meaningless without it - drop the frame
     // rather than publish a grid built on incomplete information.
     const auto depth_info_it = _camera_info.find(DEPTH);
-    if (depth_info_it == _camera_info.end() || depth_info_it->second.k.at(0) <= 0.0)
+    if (depth_info_it == _camera_info.end() || depth_info_it->second.k.at(0) <= 0.0
+        || depth_info_it->second.width == 0)
     {
         ROS_WARN("Occupancy grid not published: depth stream intrinsics are not available");
         return;
@@ -950,14 +951,15 @@ void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& 
     //   width  = cells along X = firmware rows
     //   height = cells along Y = firmware cols
     // Origin is the corner of cell (0,0): nearest boundary in X, rightmost in Y.
-    // (cols - cols/2) instead of cols/2 keeps origin.y aligned with the integer
-    // division used in the cell coordinates below when cols is odd.
+    // The grid is symmetric about the camera axis, so the right boundary is at
+    // y = -cols/2 cells regardless of parity; the per-cell y below uses the
+    // same convention.
     msg.info.map_load_time = t;
     msg.info.resolution = cell_size;
     msg.info.width  = static_cast<uint32_t>(rows);
     msg.info.height = static_cast<uint32_t>(cols);
     msg.info.origin.position.x = 0.0;
-    msg.info.origin.position.y = -cell_size * static_cast<float>(cols - cols / 2);
+    msg.info.origin.position.y = -cell_size * static_cast<float>(cols) * 0.5f;
     msg.info.origin.position.z = 0.0;
     msg.info.origin.orientation.w = 1.0;
 
@@ -972,7 +974,7 @@ void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& 
     const auto width = msg.info.width;
 
     const float half_fov_rad = std::atan(tan_half_hfov);
-    const float bin_range = 2.0f * half_fov_rad;
+    const float fov_span = 2.0f * half_fov_rad; // total angular window covered by the bins
 
     // Full grid extent, unless limited by occupancy_max_range.
     const float x_far = (static_cast<float>(rows) - 0.5f) * cell_size;
@@ -980,7 +982,7 @@ void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& 
 
     // Enough angular bins to resolve one cell width at the farthest depth.
     const int N_bins = std::max(cols,
-        static_cast<int>(std::ceil(x_far * bin_range / cell_size)) + 1);
+        static_cast<int>(std::ceil(x_far * fov_span / cell_size)) + 1);
 
     // Rows are scanned nearest-first while bin_occluded tracks which rays are
     // already blocked. Occlusion is applied only after a row completes, so cells
@@ -993,22 +995,25 @@ void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& 
     for (int fw_row = rows - 1; fw_row >= 0; --fw_row)
     {
         const float x = (static_cast<float>(rows - fw_row) - 0.5f) * cell_size;
-        if (x > max_range) continue; // beyond max range: leave unknown
+        // Rows are scanned nearest-first, so past max_range every remaining row
+        // is also beyond it: stop, leaving them unknown.
+        if (x > max_range) break;
 
         pending.clear();
 
         for (int fw_col = 0; fw_col < cols; ++fw_col)
         {
-            // Integer cols/2, consistent with origin.y above.
-            const float y = (static_cast<float>(cols / 2) -
+            // Symmetric about the camera axis, consistent with origin.y above.
+            const float y = (static_cast<float>(cols) * 0.5f -
                              static_cast<float>(fw_col) - 0.5f) * cell_size;
             if (std::fabs(y) >= x * tan_half_hfov) continue; // outside FOV
 
             const float theta = std::atan2(y, x);
+            // The FOV mask above guarantees |theta| < half_fov_rad, so bin is
+            // non-negative; min() clamps the +edge (normalized == 1.0) only.
             const int bin = std::min(
-                static_cast<int>((theta + half_fov_rad) / bin_range * static_cast<float>(N_bins)),
+                static_cast<int>((theta + half_fov_rad) / fov_span * static_cast<float>(N_bins)),
                 N_bins - 1);
-            if (bin < 0) continue;
 
             const int i = fw_row * cols + fw_col;
             const uint32_t og_col_idx = width - 1u - static_cast<uint32_t>(fw_row);
@@ -1039,7 +1044,7 @@ void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& 
             if (x_obs <= 2.0f * cell_size)
                 continue;
             const int n_spread = std::max(1, static_cast<int>(std::ceil(
-                cell_size * static_cast<float>(N_bins) / (2.0f * x_obs * bin_range))));
+                cell_size * static_cast<float>(N_bins) / (2.0f * x_obs * fov_span))));
             for (int b = std::max(0, obs_bin - n_spread);
                      b <= std::min(N_bins - 1, obs_bin + n_spread); ++b)
                 bin_occluded[b] = 1;

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -925,6 +925,18 @@ void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& 
 
     ROS_DEBUG("Publishing Occupancy Grid Frame");
 
+    // Horizontal FOV from depth intrinsics: tan(half_hfov) = (width/2) / fx.
+    // The FOV mask and ray binning are meaningless without it - drop the frame
+    // rather than publish a grid built on incomplete information.
+    const auto depth_info_it = _camera_info.find(DEPTH);
+    if (depth_info_it == _camera_info.end() || depth_info_it->second.k.at(0) <= 0.0)
+    {
+        ROS_WARN("Occupancy grid not published: depth stream intrinsics are not available");
+        return;
+    }
+    const float tan_half_hfov = (static_cast<float>(depth_info_it->second.width) * 0.5f)
+                                / static_cast<float>(depth_info_it->second.k.at(0));
+
     auto frame_as_uint8_arr = (uint8_t*)f.get_data();
     auto cols = static_cast<int>(f.get_frame_metadata(RS2_FRAME_METADATA_OCCUPANCY_GRID_COLUMNS));
     auto rows = static_cast<int>(f.get_frame_metadata(RS2_FRAME_METADATA_OCCUPANCY_GRID_ROWS));
@@ -957,27 +969,9 @@ void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& 
     // unknown behind it.
     msg.data.assign(rows * cols, -1);
 
-    // Horizontal FOV from depth intrinsics: tan(half_hfov) = (width/2) / fx
-    float tan_half_hfov = 0.0f;
-    const auto depth_info_it = _camera_info.find(DEPTH);
-    const bool has_fov = (depth_info_it != _camera_info.end() &&
-                          depth_info_it->second.k.at(0) > 0.0);
-    if (has_fov)
-    {
-        tan_half_hfov = (static_cast<float>(depth_info_it->second.width) * 0.5f)
-                        / static_cast<float>(depth_info_it->second.k.at(0));
-    }
-
     const auto width = msg.info.width;
 
-    // Without intrinsics, fall back to the widest in-grid angle (nearest corner)
-    // so every cell is covered. y_max uses (cols - cols/2), the wider half when
-    // cols is odd.
-    const float y_max = (static_cast<float>(cols - cols / 2) - 0.5f) * cell_size;
-    const float x_near = 0.5f * cell_size;
-    const float half_fov_rad = has_fov
-        ? std::atan(tan_half_hfov)
-        : std::atan2(y_max, x_near);
+    const float half_fov_rad = std::atan(tan_half_hfov);
     const float bin_range = 2.0f * half_fov_rad;
 
     // Full grid extent, unless limited by occupancy_max_range.
@@ -1008,7 +1002,7 @@ void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& 
             // Integer cols/2, consistent with origin.y above.
             const float y = (static_cast<float>(cols / 2) -
                              static_cast<float>(fw_col) - 0.5f) * cell_size;
-            if (has_fov && std::fabs(y) >= x * tan_half_hfov) continue; // outside FOV
+            if (std::fabs(y) >= x * tan_half_hfov) continue; // outside FOV
 
             const float theta = std::atan2(y, x);
             const int bin = std::min(

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -928,7 +928,7 @@ void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& 
     auto frame_as_uint8_arr = (uint8_t*)f.get_data();
     auto cols = static_cast<int>(f.get_frame_metadata(RS2_FRAME_METADATA_OCCUPANCY_GRID_COLUMNS));
     auto rows = static_cast<int>(f.get_frame_metadata(RS2_FRAME_METADATA_OCCUPANCY_GRID_ROWS));
-    auto cell_size = static_cast<float>(f.get_frame_metadata(RS2_FRAME_METADATA_OCCUPANCY_CELL_SIZE) / 100.0f); // cm -> m
+    auto cell_size = static_cast<float>(f.get_frame_metadata(RS2_FRAME_METADATA_OCCUPANCY_CELL_SIZE)) / 100.0f; // cm -> m
 
     nav_msgs::msg::OccupancyGrid msg;
     msg.header.stamp = t;
@@ -938,15 +938,18 @@ void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& 
     // Axes follow ROS convention (X: Forward, Y: Left):
     //   width  = cells along X (forward) = rows in firmware
     //   height = cells along Y (left)    = cols in firmware
-    // Origin is the lower-left corner of cell (width-1, 0) in map frame:
-    //   origin.x = 0           (nearest boundary, X direction)
-    //   origin.y = -resolution * height / 2  (rightmost boundary, Y direction)
+    // Origin is the world pose of cell (col=0, row=0), i.e. the nearest-range,
+    // rightmost-side corner of the grid:
+    //   origin.x = 0                                (nearest boundary, X direction)
+    //   origin.y = -resolution * (height - height/2)  (rightmost boundary, Y direction)
+    // Using (height - height/2) instead of height/2 keeps origin.y consistent with
+    // the integer-division used in og_row_idx for all column counts, including odd ones.
     msg.info.map_load_time = t;
     msg.info.resolution = cell_size;
     msg.info.width  = static_cast<uint32_t>(rows);
     msg.info.height = static_cast<uint32_t>(cols);
     msg.info.origin.position.x = 0.0;
-    msg.info.origin.position.y = -cell_size * static_cast<float>(cols) / 2.0f;
+    msg.info.origin.position.y = -cell_size * static_cast<float>(cols - cols / 2);
     msg.info.origin.position.z = 0.0;
     msg.info.origin.orientation.w = 1.0;
 
@@ -977,11 +980,13 @@ void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& 
 
     // Half-FOV in radians. When no intrinsics are available use the widest angle in
     // the grid (nearest corner) so every in-grid cell is covered.
-    const float y_max = (static_cast<float>(cols / 2) - 0.5f) * cell_size;
+    // y_max uses (cols - cols/2) — the larger half for odd cols — to match the
+    // rightmost column's actual |y|, which is (cols - cols/2 - 0.5)*cell_size.
+    const float y_max = (static_cast<float>(cols - cols / 2) - 0.5f) * cell_size;
     const float x_near = 0.5f * cell_size;
     const float half_fov_rad = has_fov
-        ? static_cast<float>(std::atan2(tan_half_hfov, 1.0f))
-        : static_cast<float>(std::atan2(y_max, x_near));
+        ? std::atan(tan_half_hfov)
+        : std::atan2(y_max, x_near);
     const float bin_range = 2.0f * half_fov_rad;
 
     // Effective max range: firmware grid extent unless the user set occupancy_max_range.
@@ -999,8 +1004,11 @@ void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& 
     // each other.  The spread width covers the physical angular footprint of one grid
     // cell at the obstacle's depth, preventing "gap rays" from slipping between two
     // adjacent occupied cells that fall in different bins.
-    std::vector<bool> bin_occluded(N_bins, false);
+    // uint8_t instead of bool: avoids std::vector<bool>'s bit-packing proxy overhead
+    // on every random-access read/write in the hot inner loop.
+    std::vector<uint8_t> bin_occluded(N_bins, 0);
     std::vector<std::pair<int,float>> pending;  // (bin, x_obs) for obstacles in current row
+    pending.reserve(cols);
 
     for (int fw_row = rows - 1; fw_row >= 0; --fw_row)
     {
@@ -1011,11 +1019,12 @@ void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& 
 
         for (int fw_col = 0; fw_col < cols; ++fw_col)
         {
+            // Integer cols/2 is intentional — consistent with og_row_idx and origin.y.
             const float y = (static_cast<float>(cols / 2) -
                              static_cast<float>(fw_col) - 0.5f) * cell_size;
             if (has_fov && std::fabs(y) >= x * tan_half_hfov) continue; // outside FOV
 
-            const float theta = static_cast<float>(std::atan2(y, x));
+            const float theta = std::atan2(y, x);
             const int bin = std::min(
                 static_cast<int>((theta + half_fov_rad) / bin_range * static_cast<float>(N_bins)),
                 N_bins - 1);
@@ -1026,6 +1035,9 @@ void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& 
             const uint32_t og_row_idx = static_cast<uint32_t>(cols) - 1u - static_cast<uint32_t>(fw_col);
             auto& cell_out = msg.data[og_row_idx * width + og_col_idx];
 
+            // AICV firmware packs 8 cells per byte, LSB-first: bit (i%8) of byte (i/8)
+            // corresponds to cell i in row-major order (row 0 = farthest, col 0 = leftmost).
+            // Example: cells [0,0,1,1,0,0,1,0] → byte 0b01001100.
             if ((frame_as_uint8_arr[i / 8U] & (1U << (i % 8U))) != 0)
             {
                 cell_out = 100;
@@ -1041,13 +1053,19 @@ void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& 
         // Spread occlusion from this row's obstacles into neighboring bins.
         // n_spread = angular half-footprint of one cell / bin-width — ensures that a
         // ray passing anywhere through the cell's solid extent is marked as blocked.
+        // Skip spreading for obstacles in the nearest 2 rows (x_obs <= 2*cell_size):
+        // at very close range the formula gives n_spread >> N_bins (the cell subtends
+        // nearly the entire FOV), which would wrongly mark all farther cells as unknown
+        // from a single near glint or housing reflection.
         for (const auto& [obs_bin, x_obs] : pending)
         {
+            if (x_obs <= 2.0f * cell_size)
+                continue;
             const int n_spread = std::max(1, static_cast<int>(std::ceil(
                 cell_size * static_cast<float>(N_bins) / (2.0f * x_obs * bin_range))));
             for (int b = std::max(0, obs_bin - n_spread);
                      b <= std::min(N_bins - 1, obs_bin + n_spread); ++b)
-                bin_occluded[b] = true;
+                bin_occluded[b] = 1;
         }
     }
 

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -104,6 +104,7 @@ BaseRealSenseNode::BaseRealSenseNode(RosNodeBase& node,
     _json_file_path(""),
     _depth_scale_meters(0),
     _clipping_distance(0),
+    _occupancy_max_range(0),
     _linear_accel_cov(0),
     _angular_velocity_cov(0),
     _hold_back_imu_for_frames(false),
@@ -949,22 +950,104 @@ void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& 
     msg.info.origin.position.z = 0.0;
     msg.info.origin.orientation.w = 1.0;
 
-    // data[row_idx * width + col_idx], 0 = free, 100 = occupied.
+    // data[row_idx * width + col_idx], 0 = free, 100 = occupied, -1 = unknown.
     // col_idx increases in +X (forward), row_idx increases in +Y (left).
     // Firmware row 0 = farthest  → col_idx = width-1-fw_row
     // Firmware col 0 = leftmost  → row_idx = height-1-fw_col
-    msg.data.assign(rows * cols, 0);
+    //
+    // True angular raycasting: cells are grouped by ray angle θ = atan2(y, x).
+    // Within each ray, cells are processed nearest→farthest:
+    //   free (0) up to the first obstacle → occupied (100) → unknown (-1) behind.
+    // At far depths a single ray spans multiple depth rows at the same fw_col; at near
+    // depths it can jump across fw_col values, which column-based scanning gets wrong.
+    msg.data.assign(rows * cols, -1);
 
-    for (auto i = 0; i < cols * rows; ++i)
+    // Derive horizontal FOV from depth camera intrinsics: tan(half_hfov) = (w/2) / fx
+    float tan_half_hfov = 0.0f;
+    const auto depth_info_it = _camera_info.find(DEPTH);
+    const bool has_fov = (depth_info_it != _camera_info.end() &&
+                          depth_info_it->second.k.at(0) > 0.0);
+    if (has_fov)
     {
-        // AICV algo packs 8 cells per byte; bit i%8 of byte i/8 = cell i.
-        if ((frame_as_uint8_arr[i / 8U] & (1U << i % 8)) != 0)
+        tan_half_hfov = (static_cast<float>(depth_info_it->second.width) * 0.5f)
+                        / static_cast<float>(depth_info_it->second.k.at(0));
+    }
+
+    const auto width = msg.info.width;
+
+    // Half-FOV in radians. When no intrinsics are available use the widest angle in
+    // the grid (nearest corner) so every in-grid cell is covered.
+    const float y_max = (static_cast<float>(cols / 2) - 0.5f) * cell_size;
+    const float x_near = 0.5f * cell_size;
+    const float half_fov_rad = has_fov
+        ? static_cast<float>(std::atan2(tan_half_hfov, 1.0f))
+        : static_cast<float>(std::atan2(y_max, x_near));
+    const float bin_range = 2.0f * half_fov_rad;
+
+    // Effective max range: firmware grid extent unless the user set occupancy_max_range.
+    const float x_far = (static_cast<float>(rows) - 0.5f) * cell_size;
+    const float max_range = (_occupancy_max_range > 0.0f) ? _occupancy_max_range : x_far;
+
+    // Number of angular bins: enough to give each cell at the farthest depth its own
+    // ray bucket — one cell width at x_far defines the finest angular step needed.
+    const int N_bins = std::max(cols,
+        static_cast<int>(std::ceil(x_far * bin_range / cell_size)) + 1);
+
+    // Per-bin occlusion state. Instead of separate ray lists, we scan row-by-row
+    // (nearest first) and maintain which angular bins are already blocked by a closer
+    // obstacle.  Occlusion is spread AFTER each row so same-depth cells don't shadow
+    // each other.  The spread width covers the physical angular footprint of one grid
+    // cell at the obstacle's depth, preventing "gap rays" from slipping between two
+    // adjacent occupied cells that fall in different bins.
+    std::vector<bool> bin_occluded(N_bins, false);
+    std::vector<std::pair<int,float>> pending;  // (bin, x_obs) for obstacles in current row
+
+    for (int fw_row = rows - 1; fw_row >= 0; --fw_row)
+    {
+        const float x = (static_cast<float>(rows - fw_row) - 0.5f) * cell_size;
+        if (x > max_range) continue; // beyond configured max range — leave as -1
+
+        pending.clear();
+
+        for (int fw_col = 0; fw_col < cols; ++fw_col)
         {
-            uint32_t fw_row = static_cast<uint32_t>(i / cols);
-            uint32_t fw_col = static_cast<uint32_t>(i % cols);
-            uint32_t og_col_idx = static_cast<uint32_t>(rows) - 1u - fw_row;
-            uint32_t og_row_idx = static_cast<uint32_t>(cols) - 1u - fw_col;
-            msg.data[og_row_idx * static_cast<uint32_t>(rows) + og_col_idx] = 100;
+            const float y = (static_cast<float>(cols / 2) -
+                             static_cast<float>(fw_col) - 0.5f) * cell_size;
+            if (has_fov && std::fabs(y) >= x * tan_half_hfov) continue; // outside FOV
+
+            const float theta = static_cast<float>(std::atan2(y, x));
+            const int bin = std::min(
+                static_cast<int>((theta + half_fov_rad) / bin_range * static_cast<float>(N_bins)),
+                N_bins - 1);
+            if (bin < 0) continue;
+
+            const int i = fw_row * cols + fw_col;
+            const uint32_t og_col_idx = width - 1u - static_cast<uint32_t>(fw_row);
+            const uint32_t og_row_idx = static_cast<uint32_t>(cols) - 1u - static_cast<uint32_t>(fw_col);
+            auto& cell_out = msg.data[og_row_idx * width + og_col_idx];
+
+            if ((frame_as_uint8_arr[i / 8U] & (1U << (i % 8U))) != 0)
+            {
+                cell_out = 100;
+                pending.emplace_back(bin, x); // spread shadow after full row is processed
+            }
+            else if (!bin_occluded[bin])
+            {
+                cell_out = 0; // clear line of sight
+            }
+            // else: leave as -1 (ray blocked by a closer obstacle)
+        }
+
+        // Spread occlusion from this row's obstacles into neighboring bins.
+        // n_spread = angular half-footprint of one cell / bin-width — ensures that a
+        // ray passing anywhere through the cell's solid extent is marked as blocked.
+        for (const auto& [obs_bin, x_obs] : pending)
+        {
+            const int n_spread = std::max(1, static_cast<int>(std::ceil(
+                cell_size * static_cast<float>(N_bins) / (2.0f * x_obs * bin_range))));
+            for (int b = std::max(0, obs_bin - n_spread);
+                     b <= std::min(N_bins - 1, obs_bin + n_spread); ++b)
+                bin_occluded[b] = true;
         }
     }
 

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -934,16 +934,12 @@ void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& 
     msg.header.stamp = t;
     msg.header.frame_id = FRAME_ID(OCCUPANCY);
 
-    // Grid metadata — self-describing so subscribers need no out-of-band knowledge.
-    // Axes follow ROS convention (X: Forward, Y: Left):
-    //   width  = cells along X (forward) = rows in firmware
-    //   height = cells along Y (left)    = cols in firmware
-    // Origin is the world pose of cell (col=0, row=0), i.e. the nearest-range,
-    // rightmost-side corner of the grid:
-    //   origin.x = 0                                (nearest boundary, X direction)
-    //   origin.y = -resolution * (height - height/2)  (rightmost boundary, Y direction)
-    // Using (height - height/2) instead of height/2 keeps origin.y consistent with
-    // the integer-division used in og_row_idx for all column counts, including odd ones.
+    // Axes follow ROS convention (X: forward, Y: left):
+    //   width  = cells along X = firmware rows
+    //   height = cells along Y = firmware cols
+    // Origin is the corner of cell (0,0): nearest boundary in X, rightmost in Y.
+    // (cols - cols/2) instead of cols/2 keeps origin.y aligned with the integer
+    // division used in the cell coordinates below when cols is odd.
     msg.info.map_load_time = t;
     msg.info.resolution = cell_size;
     msg.info.width  = static_cast<uint32_t>(rows);
@@ -953,19 +949,15 @@ void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& 
     msg.info.origin.position.z = 0.0;
     msg.info.origin.orientation.w = 1.0;
 
-    // data[row_idx * width + col_idx], 0 = free, 100 = occupied, -1 = unknown.
-    // col_idx increases in +X (forward), row_idx increases in +Y (left).
-    // Firmware row 0 = farthest  → col_idx = width-1-fw_row
-    // Firmware col 0 = leftmost  → row_idx = height-1-fw_col
-    //
-    // True angular raycasting: cells are grouped by ray angle θ = atan2(y, x).
-    // Within each ray, cells are processed nearest→farthest:
-    //   free (0) up to the first obstacle → occupied (100) → unknown (-1) behind.
-    // At far depths a single ray spans multiple depth rows at the same fw_col; at near
-    // depths it can jump across fw_col values, which column-based scanning gets wrong.
+    // data[row_idx * width + col_idx]: 0 = free, 100 = occupied, -1 = unknown.
+    // Firmware row 0 is the farthest row and col 0 the leftmost, so both
+    // indices are flipped when writing into the message.
+    // Cells are traced along rays grouped by angle (theta = atan2(y, x)),
+    // nearest to farthest: free until the first obstacle, occupied at it,
+    // unknown behind it.
     msg.data.assign(rows * cols, -1);
 
-    // Derive horizontal FOV from depth camera intrinsics: tan(half_hfov) = (w/2) / fx
+    // Horizontal FOV from depth intrinsics: tan(half_hfov) = (width/2) / fx
     float tan_half_hfov = 0.0f;
     const auto depth_info_it = _camera_info.find(DEPTH);
     const bool has_fov = (depth_info_it != _camera_info.end() &&
@@ -978,10 +970,9 @@ void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& 
 
     const auto width = msg.info.width;
 
-    // Half-FOV in radians. When no intrinsics are available use the widest angle in
-    // the grid (nearest corner) so every in-grid cell is covered.
-    // y_max uses (cols - cols/2) — the larger half for odd cols — to match the
-    // rightmost column's actual |y|, which is (cols - cols/2 - 0.5)*cell_size.
+    // Without intrinsics, fall back to the widest in-grid angle (nearest corner)
+    // so every cell is covered. y_max uses (cols - cols/2), the wider half when
+    // cols is odd.
     const float y_max = (static_cast<float>(cols - cols / 2) - 0.5f) * cell_size;
     const float x_near = 0.5f * cell_size;
     const float half_fov_rad = has_fov
@@ -989,37 +980,32 @@ void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& 
         : std::atan2(y_max, x_near);
     const float bin_range = 2.0f * half_fov_rad;
 
-    // Effective max range: firmware grid extent unless the user set occupancy_max_range.
+    // Full grid extent, unless limited by occupancy_max_range.
     const float x_far = (static_cast<float>(rows) - 0.5f) * cell_size;
     const float max_range = (_occupancy_max_range > 0.0f) ? _occupancy_max_range : x_far;
 
-    // Number of angular bins: enough to give each cell at the farthest depth its own
-    // ray bucket — one cell width at x_far defines the finest angular step needed.
+    // Enough angular bins to resolve one cell width at the farthest depth.
     const int N_bins = std::max(cols,
         static_cast<int>(std::ceil(x_far * bin_range / cell_size)) + 1);
 
-    // Per-bin occlusion state. Instead of separate ray lists, we scan row-by-row
-    // (nearest first) and maintain which angular bins are already blocked by a closer
-    // obstacle.  Occlusion is spread AFTER each row so same-depth cells don't shadow
-    // each other.  The spread width covers the physical angular footprint of one grid
-    // cell at the obstacle's depth, preventing "gap rays" from slipping between two
-    // adjacent occupied cells that fall in different bins.
-    // uint8_t instead of bool: avoids std::vector<bool>'s bit-packing proxy overhead
-    // on every random-access read/write in the hot inner loop.
+    // Rows are scanned nearest-first while bin_occluded tracks which rays are
+    // already blocked. Occlusion is applied only after a row completes, so cells
+    // at the same depth never shadow each other.
+    // uint8_t rather than bool to avoid vector<bool>'s bit-proxy overhead.
     std::vector<uint8_t> bin_occluded(N_bins, 0);
-    std::vector<std::pair<int,float>> pending;  // (bin, x_obs) for obstacles in current row
+    std::vector<std::pair<int,float>> pending;  // (bin, x) of this row's obstacles
     pending.reserve(cols);
 
     for (int fw_row = rows - 1; fw_row >= 0; --fw_row)
     {
         const float x = (static_cast<float>(rows - fw_row) - 0.5f) * cell_size;
-        if (x > max_range) continue; // beyond configured max range — leave as -1
+        if (x > max_range) continue; // beyond max range: leave unknown
 
         pending.clear();
 
         for (int fw_col = 0; fw_col < cols; ++fw_col)
         {
-            // Integer cols/2 is intentional — consistent with og_row_idx and origin.y.
+            // Integer cols/2, consistent with origin.y above.
             const float y = (static_cast<float>(cols / 2) -
                              static_cast<float>(fw_col) - 0.5f) * cell_size;
             if (has_fov && std::fabs(y) >= x * tan_half_hfov) continue; // outside FOV
@@ -1035,13 +1021,12 @@ void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& 
             const uint32_t og_row_idx = static_cast<uint32_t>(cols) - 1u - static_cast<uint32_t>(fw_col);
             auto& cell_out = msg.data[og_row_idx * width + og_col_idx];
 
-            // AICV firmware packs 8 cells per byte, LSB-first: bit (i%8) of byte (i/8)
-            // corresponds to cell i in row-major order (row 0 = farthest, col 0 = leftmost).
-            // Example: cells [0,0,1,1,0,0,1,0] → byte 0b01001100.
+            // Cells are bit-packed 8 per byte, LSB first: bit (i%8) of byte (i/8)
+            // is cell i in row-major order.
             if ((frame_as_uint8_arr[i / 8U] & (1U << (i % 8U))) != 0)
             {
                 cell_out = 100;
-                pending.emplace_back(bin, x); // spread shadow after full row is processed
+                pending.emplace_back(bin, x); // shadow is spread after the row completes
             }
             else if (!bin_occluded[bin])
             {
@@ -1050,13 +1035,11 @@ void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& 
             // else: leave as -1 (ray blocked by a closer obstacle)
         }
 
-        // Spread occlusion from this row's obstacles into neighboring bins.
-        // n_spread = angular half-footprint of one cell / bin-width — ensures that a
-        // ray passing anywhere through the cell's solid extent is marked as blocked.
-        // Skip spreading for obstacles in the nearest 2 rows (x_obs <= 2*cell_size):
-        // at very close range the formula gives n_spread >> N_bins (the cell subtends
-        // nearly the entire FOV), which would wrongly mark all farther cells as unknown
-        // from a single near glint or housing reflection.
+        // Each obstacle blocks its own bin plus the bins covered by the cell's
+        // physical width at its depth, so no ray can slip between two adjacent
+        // occupied cells. Obstacles in the nearest two rows are skipped: their
+        // footprint spans nearly the whole FOV, and a single noisy near hit
+        // would blank the entire grid.
         for (const auto& [obs_bin, x_obs] : pending)
         {
             if (x_obs <= 2.0f * cell_size)

--- a/realsense2_camera/src/parameters.cpp
+++ b/realsense2_camera/src/parameters.cpp
@@ -67,7 +67,7 @@ void BaseRealSenseNode::getParameters()
     _parameters_names.push_back(param_name);
 
     param_name = std::string("occupancy_max_range");
-    _occupancy_max_range = _parameters->setParam<double>(param_name, 2.5);
+    _occupancy_max_range = static_cast<float>(_parameters->setParam<double>(param_name, 2.5));
     _parameters_names.push_back(param_name);
 
     param_name = std::string("linear_accel_cov");

--- a/realsense2_camera/src/parameters.cpp
+++ b/realsense2_camera/src/parameters.cpp
@@ -66,6 +66,10 @@ void BaseRealSenseNode::getParameters()
     _clipping_distance = _parameters->setParam<double>(param_name, -1.0);
     _parameters_names.push_back(param_name);
 
+    param_name = std::string("occupancy_max_range");
+    _occupancy_max_range = _parameters->setParam<double>(param_name, 2.5);
+    _parameters_names.push_back(param_name);
+
     param_name = std::string("linear_accel_cov");
     _linear_accel_cov = _parameters->setParam<double>(param_name, 0.01);
     _parameters_names.push_back(param_name);

--- a/realsense2_camera/src/rs_node_setup.cpp
+++ b/realsense2_camera/src/rs_node_setup.cpp
@@ -251,9 +251,9 @@ void BaseRealSenseNode::startPublishers(const std::vector<stream_profile>& profi
 
             if (profile.stream_type() == RS2_STREAM_OCCUPANCY)
             {
-                // special handling for occupancy stream, since it is a topic of nav_msgs/msg/GridCells messages
+                // special handling for occupancy stream, since it is a topic of nav_msgs/msg/OccupancyGrid messages
                 // and not a normal image publisher
-                 _occupancy_publisher = _node.create_publisher<nav_msgs::msg::GridCells>("~/occupancy",
+                 _occupancy_publisher = _node.create_publisher<nav_msgs::msg::OccupancyGrid>("~/occupancy",
                     rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos),qos));
             }
             else if(profile.stream_type() == RS2_STREAM_LABELED_POINT_CLOUD)


### PR DESCRIPTION
# Occupancy Grid — How It Works

## 1. Overall Pipeline

```mermaid
flowchart TD
    FW["🔲 D585S Firmware\npacked bitmask — 1 bit per cell\n(1=occupied, 0=not occupied)"]

    subgraph fn["publishOccupancyFrame()"]
        INIT["Init every cell → -1\n(unknown)"]
        FOV{"FOV cone check\n|y| ≥ x · tan(hfov/2) ?"}
        RANGE{"Max range check\nx > occupancy_max_range ?"}
        BIN["Assign to angular bin\nθ = atan2(y, x)"]
        RAY["Scan ray nearest → farthest\nwith per-bin occlusion state"]
        OCC{"Occupied\nbit set?"}
        SHAD{"Ray already\noccluded?"}
        SPREAD["Spread shadow to\n± n_spread neighbour bins\nn_spread = ceil(cell_size·N_bins / 2·x·bin_range)"]
    end

    FREE["0\nconfirmed free"]
    OB["100\noccupied"]
    UNK["-1\nunknown"]
    OUT["📦 nav_msgs/OccupancyGrid"]

    FW --> INIT --> FOV
    FOV -->|outside camera FOV| UNK
    FOV -->|inside FOV| RANGE
    RANGE -->|beyond 2.5 m default| UNK
    RANGE -->|within range| BIN --> RAY --> OCC
    OCC -->|yes| OB --> SPREAD
    OCC -->|no| SHAD
    SHAD -->|yes| UNK
    SHAD -->|no| FREE
    SPREAD -->|"neighbours → -1"| UNK
    FREE --> OUT
    OB  --> OUT
    UNK --> OUT
```

---

## 2. Cell Value Semantics

```mermaid
flowchart LR
    subgraph legend["Cell value in OccupancyGrid.data[]"]
        direction TB
        A["0\n✅ confirmed free\nRay passed through — no obstacle seen"]
        B["100\n🔴 occupied\nFirmware bit = 1"]
        C["-1\n❓ unknown\nOutside FOV, beyond max range,\nor shadowed behind an obstacle"]
    end
```

---

## 3. Live Output

Real grid published by the driver, shown in rviz with the live point cloud overlaid.
White = free (`0`), gray = unknown (`-1`), occupied cells (`100`) sit under the detected boxes —
note the FOV wedge, the shadows fanning out behind each obstacle, and the unknown
region beyond `occupancy_max_range`:

![Occupancy grid live output](../res/occupancy_new_type.gif)
<img width="480" height="529" alt="occupancy_new_type" src="https://github.com/user-attachments/assets/15292566-d6f5-450d-b691-2e27f8420a13" />

---

## 4. Column-Based vs True Angular Raycasting

```
OLD — Column-based (wrong)          NEW — Angular raycasting (correct)
─────────────────────────────       ─────────────────────────────────────
Camera at bottom (x=0)             Camera at bottom (x=0)

      Y=0.5m fixed                        angle θ fixed
         │                                    ╱
x=0.5m  ●                          x=0.5m  ●  (y=0.5m)
         │                                    ╲
x=1.0m  ●                          x=1.0m    ●  (y=1.0m)
         │                                      ╲
x=2.0m  ●                          x=2.0m        ●  (y=2.0m)
         │
x=3.0m  ●                          Shadow FANS outward
                                    y grows with depth: y = x · tan(θ)
Shadow is a vertical stripe         ✔ physically correct
✘ wrong at wide angles
```

---

## 5. Shadow Propagation Along a Ray

```
Ray (single angular bin), scanning nearest → farthest:

  Camera
    │
    ▼
[ free  ]  ← no obstacle yet, clear line of sight  → cell = 0
[ free  ]
[ free  ]
[BLOCKED]  ← firmware bit = 1                       → cell = 100  ← occlusion starts here
[shadow ]  ← ray is occluded                        → cell = -1
[shadow ]
[shadow ]  ← stays unknown all the way to max range → cell = -1
```

---

## 6. Gap-Ray Fix (Shadow Spreading)

Without the fix, a ray can slip through the gap between two adjacent occupied cells
that fall in different angular bins:

```
BEFORE gap-ray fix                    AFTER gap-ray fix
                                      (n_spread bins on each side)

Angular bins:  …23  24  25  26…       Angular bins:  …23  24  25  26…
                    │   │                                  │   │
depth=near          ■   ■  ← 2 occupied cells             ■   ■
depth=mid       0   0   0   0    ← gap ray free!      -1  -1  -1  -1  ← all shadowed
depth=far       0   0   0   0                         -1  -1  -1  -1

■ = occupied   0 = free   -1 = unknown/shadow

n_spread = ceil( cell_size × N_bins / (2 × x_obstacle × bin_range) )
         = large at close range (wide angular footprint)
         = 1    at far range   (narrow angular footprint)
```

---

## 7. FOV Masking

```
Top-down view of the grid (camera at bottom centre):

        ╔═══════════════════════╗   ← far edge (x = max_range)
        ║  -1  -1 │  0   0 │-1 -1║  ← -1 outside FOV cone
        ║  -1  -1 │  0   0 │-1 -1║
        ║  -1   0 │  0   0 │ 0 -1║
        ║   0   0 │100 100 │ 0  0║  ← obstacles
        ║   0   0 │ -1  -1 │ 0  0║  ← shadow behind obstacles
        ║   0   0 │ -1  -1 │ 0  0║
        ╚═══════════════════════╝   ← near edge (x ≈ 0)
                   camera

  FOV cone boundary: |y| = x · tan(hfov/2)
  Anything outside the cone → -1 (unknown)
  Anything beyond max_range → -1 (unknown)
```

---

## 8. Coordinate Mapping: Firmware → OccupancyGrid

```
Firmware layout                    OccupancyGrid layout (ROS convention)
(fw_row=0 = farthest)              (col_idx=0 = nearest, X forward)

fw_row=0   [col 0..cols-1]    →   og_col_idx = width-1-fw_row  (maps far→high X)
fw_row=1   [col 0..cols-1]         og_row_idx = cols-1-fw_col  (maps left→high Y)
...
fw_row=rows-1 [col 0..cols-1] →   data[og_row_idx * width + og_col_idx]

Firmware "cols" = lateral (Y axis) = msg.info.height
Firmware "rows" = depth   (X axis) = msg.info.width
```
