### PR TITLE
Fix image_transport::create_publisher for ROS2 Rolling

### DIFF
--- a/realsense2_camera/src/image_publisher.cpp
+++ b/realsense2_camera/src/image_publisher.cpp
@@ -41,8 +41,17 @@ image_transport_publisher::image_transport_publisher( rclcpp::Node & node,
                                                       const std::string & topic_name,
                                                       const rmw_qos_profile_t & qos )
 {
+#if defined( LYRICAL ) || defined( ROLLING )
+    // On Rolling/Lyrical, image_transport::create_publisher deduces NodeT
+    // from a Node reference (it then calls node.get_node_base_interface()),
+    // and the QoS argument is rclcpp::QoS rather than rmw_qos_profile_t.
+    rclcpp::QoS rclcpp_qos( rclcpp::QoSInitialization::from_rmw( qos ), qos );
+    image_publisher_impl = std::make_shared< image_transport::Publisher >(
+        image_transport::create_publisher( node, topic_name, rclcpp_qos ) );
+#else
     image_publisher_impl = std::make_shared< image_transport::Publisher >(
         image_transport::create_publisher( &node, topic_name, qos ) );
+#endif
 }
 void image_transport_publisher::publish( sensor_msgs::msg::Image::UniquePtr image_ptr )
 {


### PR DESCRIPTION
**Overview:** Fixes the ROS2 Rolling build break on `r/4.58.3` — `image_transport::create_publisher` API changed on Rolling and no longer accepts a raw `rclcpp::Node*` rvalue.

### Problem
Rolling CI fails to compile:
```
image_publisher.cpp:45: image_transport::create_publisher( &node, topic_name, qos )
error: cannot bind non-const lvalue reference of type 'rclcpp::Node*&' to an rvalue of type 'rclcpp::Node*'
```
Rolling's `image_transport::create_publisher` now deduces `NodeT` from a `Node&` (calls `node.get_node_base_interface()`) and takes `rclcpp::QoS` instead of `rmw_qos_profile_t`.

### Fix
Guard the Rolling/Lyrical call path behind `#if defined( LYRICAL ) || defined( ROLLING )`, passing `node` by reference and an `rclcpp::QoS`. Stable distros keep the existing `&node` path. `-DROLLING` is already defined by `CMakeLists.txt` for `ROS_DISTRO=rolling`.

Cherry-pick of the `image_publisher.cpp` hunk from #3525 (the CMake/CI/Lyrical and FastDDS-workaround parts of that PR are intentionally excluded — ROS is not built with DDS).

### Scope
- `realsense2_camera/src/image_publisher.cpp` only.

🤖 Generated by AI
