### PR TITLE
add `inter_cam_sync_mode` setting support to ros1

### DIFF
--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -100,6 +100,7 @@
   <arg name="stereo_module/exposure/2" default="1"/>
   <arg name="stereo_module/gain/2"     default="16"/>
 
+  <arg name="inter_cam_sync_mode"      default="0"/>
   <arg name="filters"                  default=""/>
   <arg name="clip_distance"            default="-1"/>
   <arg name="linear_accel_cov"         default="0.01"/>
@@ -205,6 +206,7 @@
     <param name="stereo_module/gain/1"     type="int"  value="$(arg stereo_module/gain/1)"/>
     <param name="stereo_module/exposure/2" type="int"  value="$(arg stereo_module/exposure/2)"/>
     <param name="stereo_module/gain/2"     type="int"  value="$(arg stereo_module/gain/2)"/>
+    <param name="inter_cam_sync_mode"      type="int"  value="$(arg inter_cam_sync_mode)"/>
 
     <param name="filters"                  type="str"    value="$(arg filters)"/>
     <param name="clip_distance"            type="double" value="$(arg clip_distance)"/>

--- a/realsense2_camera/launch/rs_camera.launch
+++ b/realsense2_camera/launch/rs_camera.launch
@@ -70,6 +70,8 @@
   <arg name="stereo_module/gain/1"      default="16"/>
   <arg name="stereo_module/exposure/2"  default="1"/>
   <arg name="stereo_module/gain/2"      default="16"/>
+
+  <arg name="inter_cam_sync_mode"       default="0" />
   
   
 
@@ -144,6 +146,8 @@
 
       <arg name="allow_no_texture_points"  value="$(arg allow_no_texture_points)"/>
       <arg name="ordered_pc"               value="$(arg ordered_pc)"/>
+
+      <arg name="inter_cam_sync_mode"      value="$(arg inter_cam_sync_mode)"/>
       
     </include>
   </group>

--- a/realsense2_camera/launch/rs_multiple_devices.launch
+++ b/realsense2_camera/launch/rs_multiple_devices.launch
@@ -10,6 +10,7 @@
   <arg name="tf_prefix_camera3"         default="$(arg camera3)"/>
   <arg name="initial_reset"             default="false"/>
   <arg name="reconnect_timeout"         default="6.0"/>
+  <arg name="inter_cam_sync_mode"       default="0"/>
 
   <group ns="$(arg camera1)">
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
@@ -17,6 +18,7 @@
       <arg name="tf_prefix"         		value="$(arg tf_prefix_camera1)"/>
       <arg name="initial_reset"         value="$(arg initial_reset)"/>
       <arg name="reconnect_timeout"     value="$(arg reconnect_timeout)"/>
+      <arg name="inter_cam_sync_mode"   value="$(arg inter_cam_sync_mode)"/>
     </include>
   </group>
 
@@ -26,6 +28,7 @@
       <arg name="tf_prefix"		          value="$(arg tf_prefix_camera2)"/>
       <arg name="initial_reset"         value="$(arg initial_reset)"/>
       <arg name="reconnect_timeout"     value="$(arg reconnect_timeout)"/>
+      <arg name="inter_cam_sync_mode"   value="$(arg inter_cam_sync_mode)"/>
     </include>
   </group>
 
@@ -35,6 +38,7 @@
       <arg name="tf_prefix"		          value="$(arg tf_prefix_camera3)"/>
       <arg name="initial_reset"         value="$(arg initial_reset)"/>
       <arg name="reconnect_timeout"     value="$(arg reconnect_timeout)"/>
+      <arg name="inter_cam_sync_mode"   value="$(arg inter_cam_sync_mode)"/>
     </include>
   </group>
 </launch>

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -1869,6 +1869,23 @@ void BaseRealSenseNode::setupStreams()
         {
             std::string module_name = sensor_profile.first;
             rs2::sensor sensor = active_sensors[module_name];
+            if (sensor.supports(RS2_OPTION_INTER_CAM_SYNC_MODE))
+            {
+                int sync_mode = 0;
+                _pnh.param("inter_cam_sync_mode", sync_mode, 0);
+                try
+                {
+                    sensor.set_option(RS2_OPTION_INTER_CAM_SYNC_MODE,
+                                      static_cast<float>(sync_mode));
+                    ROS_INFO_STREAM("Set inter_cam_sync_mode = " << sync_mode
+                                    << " on sensor " << module_name);
+                }
+                catch (const rs2::error& e)
+                {
+                    ROS_WARN_STREAM("Failed to set inter_cam_sync_mode on "
+                                    << module_name << ": " << e.what());
+                }
+            }
             sensor.open(sensor_profile.second);
             sensor.start(_sensors_callback[module_name]);
             if (sensor.is<rs2::depth_sensor>())


### PR DESCRIPTION
`inter_cam_sync_mode` setting was only supported in ros2 code, but many people may still use ros1, this pull request add support for this.