### PR TITLE
turn the FATAL_ERROR for ROS distro check into a WARNING

### DIFF
--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -328,7 +328,7 @@ if(USE_LIFECYCLE_NODE)
         rclcpp_lifecycle::rclcpp_lifecycle
         lifecycle_msgs::lifecycle_msgs__rosidl_typesupport_cpp)
     add_definitions(-DUSE_LIFECYCLE_NODE)
-    message("🚀 USE_LIFECYCLE_NODE is ENABLED")
+    message(STATUS "USE_LIFECYCLE_NODE is ENABLED")
 
     # Create a configuration file for the launch file
     file(WRITE "${CMAKE_BINARY_DIR}/global_settings.yaml"

--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -184,6 +184,7 @@ set(SOURCES
     src/tfs.cpp
     src/actions.cpp
     src/safety.cpp
+    src/ros_param_backend.cpp
   )
 
 if (BUILD_ACCELERATE_GPU_WITH_GLSL)
@@ -196,34 +197,26 @@ endif()
 if("$ENV{ROS_DISTRO}" STREQUAL "foxy")
   message(STATUS "Build for ROS2 Foxy")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DFOXY")
-  set(SOURCES "${SOURCES}" src/ros_param_backend.cpp)
 elseif("$ENV{ROS_DISTRO}" STREQUAL "humble")
   message(STATUS "Build for ROS2 Humble")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHUMBLE")
-  set(SOURCES "${SOURCES}" src/ros_param_backend.cpp)
 elseif("$ENV{ROS_DISTRO}" STREQUAL "iron")
   message(STATUS "Build for ROS2 Iron")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DIRON")
-  set(SOURCES "${SOURCES}" src/ros_param_backend.cpp)
 elseif("$ENV{ROS_DISTRO}" STREQUAL "rolling")
   message(STATUS "Build for ROS2 Rolling")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DROLLING")
-  set(SOURCES "${SOURCES}" src/ros_param_backend.cpp)
 elseif("$ENV{ROS_DISTRO}" STREQUAL "jazzy")
   message(STATUS "Build for ROS2 Jazzy")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DJAZZY")
-  set(SOURCES "${SOURCES}" src/ros_param_backend.cpp)
 elseif("$ENV{ROS_DISTRO}" STREQUAL "kilted")
   message(STATUS "Build for ROS2 Kilted")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DKILTED")
-  set(SOURCES "${SOURCES}" src/ros_param_backend.cpp)
 elseif("$ENV{ROS_DISTRO}" STREQUAL "lyrical")
   message(STATUS "Build for ROS2 Lyrical")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DLYRICAL")
-  set(SOURCES "${SOURCES}" src/ros_param_backend.cpp)
 else()
   message(WARNING "Unsupported ROS Distribution: " "$ENV{ROS_DISTRO}")
-  set(SOURCES "${SOURCES}" src/ros_param_backend.cpp)
 endif()
 
 # The header 'cv_bridge/cv_bridge.hpp' was added in version 3.3.0. For older

--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -324,7 +324,7 @@ if(USE_LIFECYCLE_NODE)
     find_package(rclcpp_lifecycle REQUIRED)
     find_package(lifecycle_msgs REQUIRED)
     list(APPEND dependencies rclcpp_lifecycle lifecycle_msgs)
-    list(APPEND targets 
+    list(APPEND targets
         rclcpp_lifecycle::rclcpp_lifecycle
         lifecycle_msgs::lifecycle_msgs__rosidl_typesupport_cpp)
     add_definitions(-DUSE_LIFECYCLE_NODE)
@@ -416,13 +416,13 @@ install(
 )
 
 # Install launch files
-install(DIRECTORY 
+install(DIRECTORY
     launch
     DESTINATION share/${PROJECT_NAME}
     )
 
 # Install example files
-install(DIRECTORY 
+install(DIRECTORY
     examples
     DESTINATION share/${PROJECT_NAME}
 )

--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -222,7 +222,8 @@ elseif("$ENV{ROS_DISTRO}" STREQUAL "lyrical")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DLYRICAL")
   set(SOURCES "${SOURCES}" src/ros_param_backend.cpp)
 else()
-  message(FATAL_ERROR "Unsupported ROS Distribution: " "$ENV{ROS_DISTRO}")
+  message(WARNING "Unsupported ROS Distribution: " "$ENV{ROS_DISTRO}")
+  set(SOURCES "${SOURCES}" src/ros_param_backend.cpp)
 endif()
 
 # The header 'cv_bridge/cv_bridge.hpp' was added in version 3.3.0. For older


### PR DESCRIPTION
I would like to suggest replacing the `FATAL_ERROR` for the distro check with a `WARNING`, so this can continue to built if there are no API breakages etc.

Fixes #3549 .