### PR TITLE
Ashraf/zerocopy nitors v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 .idea/
 .vs/
 *.json
-bench/
+# bench/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .idea/
 .vs/
 *.json
+bench/

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,17 @@
+# bench/ — temporary benchmarking scratch space
+
+Not part of the wrapper and **not meant to ship**: this directory is a holding place for the
+NITROS zero-copy measurement harness while that work is in progress (RSDEV-6254). Move it out or
+delete it once the numbers are settled.
+
+`nitros_zc_bench/` carries a `COLCON_IGNORE` so a workspace that has this repo in its `src/` does
+not try to build it — and so it cannot collide with the copy that is checked out directly as
+`<workspace>/src/nitros_zc_bench` on the Jetson test rig. To use it there, sync the contents
+(minus `COLCON_IGNORE`) into that location:
+
+```bash
+rsync -a --exclude COLCON_IGNORE bench/nitros_zc_bench/ \
+    <workspace>/src/nitros_zc_bench/
+```
+
+See `nitros_zc_bench/README.md` for what it measures and how to run it.

--- a/bench/nitros_zc_bench/CMakeLists.txt
+++ b/bench/nitros_zc_bench/CMakeLists.txt
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 3.22)
+project(nitros_zc_bench LANGUAGES CXX CUDA)
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(CUDA REQUIRED)
+find_package(isaac_ros_nitros REQUIRED)
+find_package(isaac_ros_managed_nitros REQUIRED)
+find_package(isaac_ros_nitros_image_type REQUIRED)
+find_package(rclcpp_components REQUIRED)
+
+include_directories(src ${CUDA_INCLUDE_DIRS})
+
+# The pixel-touching kernel both consumers run, so the GPU work is identical on both paths.
+add_library(bench_kernel STATIC src/bench_kernel.cu src/viz_kernel.cu)
+set_target_properties(bench_kernel PROPERTIES POSITION_INDEPENDENT_CODE ON CUDA_ARCHITECTURES "87")
+
+add_executable(cpu_consumer src/cpu_consumer.cpp)
+target_link_libraries(cpu_consumer bench_kernel ${CUDA_LIBRARIES})
+ament_target_dependencies(cpu_consumer rclcpp sensor_msgs)
+
+add_executable(nitros_consumer src/nitros_consumer.cpp)
+target_link_libraries(nitros_consumer bench_kernel ${CUDA_LIBRARIES})
+ament_target_dependencies(nitros_consumer
+  rclcpp sensor_msgs isaac_ros_nitros isaac_ros_managed_nitros isaac_ros_nitros_image_type)
+
+# Same consumers as loadable components, so they can be composed into the camera node's process.
+# That is the configuration where NITROS actually hands over a pointer: across a process boundary
+# rclcpp has to run the NitrosImage type adapter, which does a device->host copy.
+add_library(nitros_zc_bench_components SHARED
+  src/cpu_consumer.cpp src/nitros_consumer.cpp src/nitros_viewer.cpp)
+target_compile_definitions(nitros_zc_bench_components PRIVATE NITROS_ZC_BENCH_COMPONENT_ONLY)
+target_link_libraries(nitros_zc_bench_components bench_kernel ${CUDA_LIBRARIES})
+ament_target_dependencies(nitros_zc_bench_components
+  rclcpp rclcpp_components sensor_msgs isaac_ros_nitros isaac_ros_managed_nitros
+  isaac_ros_nitros_image_type)
+rclcpp_components_register_nodes(nitros_zc_bench_components
+  "nitros_zc_bench::NitrosConsumer" "nitros_zc_bench::CpuConsumer" "nitros_zc_bench::NitrosViewer")
+
+install(TARGETS nitros_zc_bench_components
+  ARCHIVE DESTINATION lib LIBRARY DESTINATION lib RUNTIME DESTINATION bin)
+install(TARGETS cpu_consumer nitros_consumer DESTINATION lib/${PROJECT_NAME})
+install(DIRECTORY launch rviz DESTINATION share/${PROJECT_NAME})
+install(PROGRAMS scripts/run_bench.sh DESTINATION lib/${PROJECT_NAME})
+
+ament_package()

--- a/bench/nitros_zc_bench/README.md
+++ b/bench/nitros_zc_bench/README.md
@@ -1,0 +1,72 @@
+# nitros_zc_bench
+
+Consumer-side benchmark for the `realsense2_camera` NITROS zero-copy color path (RSDEV-6254).
+
+Both consumers run the **identical** CUDA kernel over every byte of every frame, so the only thing
+being compared is how the frame reaches the GPU:
+
+| Executable | Subscribes to | Getting onto the GPU |
+| --- | --- | --- |
+| `cpu_consumer` | `~/color/image_raw` (`sensor_msgs/Image`) | `cudaMemcpy` host→device, every frame |
+| `nitros_consumer` | `~/color/nitros_image` (negotiated `nitros_image_rgb8`) | nothing — the pixels are already in GPU memory |
+
+Each run reports delivered FPS (against the stream rate), the onto-GPU cost per frame, kernel time,
+transport and end-to-end latency (frame timestamp → GPU work complete), and the consumer's own CPU
+as a percentage of one core. A machine-readable `RESULT {...}` line is printed at the end of a run.
+
+## Running it
+
+`scripts/run_bench.sh` drives the whole comparison inside the Isaac ROS container on the Jetson. It
+runs four phases, each with a fresh camera node, and samples the **camera node's** CPU over the
+measured window too:
+
+| Phase | Publisher | Consumer |
+| --- | --- | --- |
+| `zerocopy` | `enable_color_nitros:=true`, pooled allocator | `nitros_consumer` |
+| `baseline` | `enable_color_nitros:=false` | `cpu_consumer` |
+| `legacy` | `enable_color_nitros:=true`, `RS_NITROS_LEGACY_ALLOC=1` (pre-pool `cudaMalloc` per frame) | `nitros_consumer` |
+| `verify` | debug logging on | short run; counts `ZERO-COPY source` vs `UPLOAD` frames |
+
+```bash
+# inside the container, with the workspace built with -DBUILD_WITH_NITROS=ON
+./src/nitros_zc_bench/scripts/run_bench.sh
+# knobs: OUT=<dir> WARMUP=5.0 DURATION=30.0 PROFILE=1920x1080x30 FPS=30.0
+```
+
+Results land in `$OUT` (default `<workspace>/bench_results/`): one `<phase>.log` per consumer and
+`<phase>.camera.log` per camera node, plus a summary of all `RESULT` / `PUBLISHER_CPU` lines.
+
+## Looking at the GPU frame
+
+`nitros_zc_bench::NitrosViewer` lets you see the pixels the wrapper actually published, without
+undoing the zero-copy it exists to demonstrate.
+
+```bash
+ros2 launch nitros_zc_bench view_gpu_frame.launch.py            # camera + composed viewer
+ros2 run rviz2 rviz2 -d $(ros2 pkg prefix nitros_zc_bench)/share/nitros_zc_bench/rviz/gpu_view.rviz
+```
+
+It subscribes to `~/color/nitros_image` **in the camera's own process**, downscales the frame on the
+GPU, and copies back only a thumbnail — 480x270 (57 KB) at 2 Hz by default, against 6.22 MB at
+30 Hz. It republishes that as a plain `sensor_msgs/Image` on `/nitros_viewer/gpu_view`, which rviz
+(a separate process) can subscribe to harmlessly.
+
+| Parameter | Default | Notes |
+| --- | --- | --- |
+| `rate_hz` | `2.0` | `0` makes the viewer inert |
+| `view_width` / `view_height` | `480` / `270` | thumbnail size |
+| `full_res` | `false` | copy whole frames back: fine for eyeballing, do not benchmark with it |
+| `snapshot_path` | `''` | write one PPM of the GPU frame, for checking content with no display attached |
+
+Measured cost of running it at the defaults: publisher stays at **373-396 us** per frame, versus
+**372-385 us** with no viewer at all — i.e. free.
+
+> **Do not point rviz at `~/color/nitros_image` directly.** A subscriber in another process forces
+> NITROS's type adapter to copy every frame device->host and takes the publisher from ~400 us to
+> ~4400 us per frame. That is the whole reason the viewer is a composed component.
+
+## Requirements
+
+An Isaac ROS workspace (release-3.2 on JetPack 6.x) with `isaac_ros_managed_nitros` and
+`isaac_ros_nitros_image_type` built, `ros-humble-magic-enum` and `ros-humble-negotiated` installed,
+and the GXF extension directories on `LD_LIBRARY_PATH` (the script handles the last part).

--- a/bench/nitros_zc_bench/launch/composed_bench.launch.py
+++ b/bench/nitros_zc_bench/launch/composed_bench.launch.py
@@ -1,0 +1,105 @@
+"""Camera node and one consumer composed into a single process.
+
+This is the configuration where NITROS actually hands over a GPU pointer. Across a process
+boundary rclcpp has to run the NitrosImage type adapter, whose convert_to_ros_message does a
+device->host cudaMemcpy2D (and convert_to_custom copies back host->device on the subscriber
+side) - so a separately launched consumer is not really zero-copy at all.
+
+Note what is deliberately NOT set here: `use_intra_process_comms`. NITROS turns intra-process
+comms on itself, per data publisher and subscriber (IntraProcessSetting::Enable in
+nitros_publisher.cpp / nitros_subscriber.cpp). Setting it at node level instead applies it to the
+`negotiated` package's transient-local negotiation topics too, and rclcpp rejects that combination
+with "intraprocess communication allowed only with volatile durability". NVIDIA's own Isaac ROS
+launch files compose NITROS nodes without the flag for the same reason.
+
+    ros2 launch nitros_zc_bench composed_bench.launch.py consumer:=nitros duration_s:=30.0
+    ros2 launch nitros_zc_bench composed_bench.launch.py consumer:=cpu    duration_s:=30.0
+"""
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
+
+
+def _container(context, *args, **kwargs):
+    consumer = LaunchConfiguration('consumer').perform(context)
+    warmup_s = float(LaunchConfiguration('warmup_s').perform(context))
+    duration_s = float(LaunchConfiguration('duration_s').perform(context))
+    profile = LaunchConfiguration('profile').perform(context)
+    csv_path = LaunchConfiguration('csv_path').perform(context)
+    # Only meaningful with consumer:=cpu. NITROS cannot be combined with node-level intra-process
+    # comms (see the module docstring); this exists to measure the best non-NITROS configuration,
+    # where rclcpp passes the sensor_msgs/Image by pointer instead of serialising it.
+    intra_process = LaunchConfiguration('intra_process').perform(context).lower() == 'true'
+    extra = [{'use_intra_process_comms': True}] if intra_process else []
+
+    consumer_plugin = {
+        'nitros': 'nitros_zc_bench::NitrosConsumer',
+        'cpu': 'nitros_zc_bench::CpuConsumer',
+    }[consumer]
+    consumer_params = {
+        'warmup_s': warmup_s,
+        'duration_s': duration_s,
+        'expected_fps': 30.0,
+        'csv_path': csv_path,
+    }
+    if consumer == 'nitros':
+        # The wrapper's factory instantiates the node as /camera/camera, so its relative
+        # topics land under that, not under /camera.
+        consumer_params['topic'] = '/camera/camera/color/nitros_image'
+    else:
+        consumer_params['topic'] = '/camera/camera/color/image_raw'
+
+    return [
+        ComposableNodeContainer(
+            name='bench_container',
+            namespace='',
+            package='rclcpp_components',
+            executable='component_container_mt',
+            # One line per 100 frames from the publisher's own cost accounting.
+            arguments=['--ros-args', '--log-level', 'NitrosImagePublisher:=debug'],
+            composable_node_descriptions=[
+                ComposableNode(
+                    package='realsense2_camera',
+                    plugin='realsense2_camera::RealSenseNodeFactory',
+                    name='camera',
+                    extra_arguments=extra,
+                    parameters=[{
+                        'rgb_camera.color_profile': profile,
+                        'rgb_camera.color_format': 'RGB8',
+                        # Only turn NITROS publishing on when the NITROS consumer is the one
+                        # running, so the plain-consumer run does not pay for an unused publisher.
+                        'enable_color_nitros': consumer == 'nitros',
+                        'enable_depth': False,
+                        'enable_infra1': False,
+                        'enable_infra2': False,
+                        'enable_gyro': False,
+                        'enable_accel': False,
+                        'pointcloud.enable': False,
+                        'align_depth.enable': False,
+                    }],
+                ),
+                ComposableNode(
+                    package='nitros_zc_bench',
+                    plugin=consumer_plugin,
+                    name=f'{consumer}_consumer',
+                    extra_arguments=extra,
+                    parameters=[consumer_params],
+                ),
+            ],
+            output='screen',
+        ),
+    ]
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        DeclareLaunchArgument('consumer', default_value='nitros', choices=['nitros', 'cpu']),
+        DeclareLaunchArgument('warmup_s', default_value='5.0'),
+        DeclareLaunchArgument('duration_s', default_value='30.0'),
+        DeclareLaunchArgument('profile', default_value='1920x1080x30'),
+        DeclareLaunchArgument('csv_path', default_value=''),
+        DeclareLaunchArgument('intra_process', default_value='false'),
+        OpaqueFunction(function=_container),
+    ])

--- a/bench/nitros_zc_bench/launch/view_gpu_frame.launch.py
+++ b/bench/nitros_zc_bench/launch/view_gpu_frame.launch.py
@@ -1,0 +1,86 @@
+"""Camera + a composed viewer, so you can actually look at the GPU frame.
+
+    ros2 launch nitros_zc_bench view_gpu_frame.launch.py
+    ros2 run rviz2 rviz2   # then add an Image display on /nitros_viewer/gpu_view
+
+The viewer is composed into the camera's container on purpose. rviz itself stays a separate
+process, but it subscribes to the small `sensor_msgs/Image` the viewer republishes - NOT to
+`~/color/nitros_image`. Subscribing to the NITROS topic from another process forces the type
+adapter to copy every frame device->host and takes the publisher from ~400 us to ~4400 us per
+frame, which defeats the whole point.
+
+Cost of the viewer at defaults: one GPU downscale plus a 57 KB device->host copy, twice a second.
+Set rate_hz:=0 to make it inert, or full_res:=true to copy whole frames back (fine for eyeballing,
+useless for benchmarking).
+"""
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
+
+
+def _container(context, *args, **kwargs):
+    profile = LaunchConfiguration('profile').perform(context)
+    rate_hz = float(LaunchConfiguration('rate_hz').perform(context))
+    full_res = LaunchConfiguration('full_res').perform(context).lower() == 'true'
+    snapshot_path = LaunchConfiguration('snapshot_path').perform(context)
+    view_width = int(LaunchConfiguration('view_width').perform(context))
+    view_height = int(LaunchConfiguration('view_height').perform(context))
+
+    return [
+        ComposableNodeContainer(
+            name='view_container',
+            namespace='',
+            package='rclcpp_components',
+            executable='component_container_mt',
+            # One line per 100 frames of the publisher's own cost, so you can confirm the viewer
+            # is not putting the removed copy back (expect ~400 us, not ~4000 us).
+            arguments=['--ros-args', '--log-level', 'NitrosImagePublisher:=debug'],
+            composable_node_descriptions=[
+                ComposableNode(
+                    package='realsense2_camera',
+                    plugin='realsense2_camera::RealSenseNodeFactory',
+                    name='camera',
+                    parameters=[{
+                        'rgb_camera.color_profile': profile,
+                        'rgb_camera.color_format': 'RGB8',
+                        'enable_color_nitros': True,
+                        'enable_depth': False,
+                        'enable_infra1': False,
+                        'enable_infra2': False,
+                        'enable_gyro': False,
+                        'enable_accel': False,
+                        'pointcloud.enable': False,
+                        'align_depth.enable': False,
+                    }],
+                ),
+                ComposableNode(
+                    package='nitros_zc_bench',
+                    plugin='nitros_zc_bench::NitrosViewer',
+                    name='nitros_viewer',
+                    parameters=[{
+                        'topic': '/camera/camera/color/nitros_image',
+                        'rate_hz': rate_hz,
+                        'full_res': full_res,
+                        'view_width': view_width,
+                        'view_height': view_height,
+                        'snapshot_path': snapshot_path,
+                    }],
+                ),
+            ],
+            output='screen',
+        ),
+    ]
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        DeclareLaunchArgument('profile', default_value='1920x1080x30'),
+        DeclareLaunchArgument('rate_hz', default_value='2.0'),
+        DeclareLaunchArgument('full_res', default_value='false'),
+        DeclareLaunchArgument('view_width', default_value='480'),
+        DeclareLaunchArgument('view_height', default_value='270'),
+        DeclareLaunchArgument('snapshot_path', default_value=''),
+        OpaqueFunction(function=_container),
+    ])

--- a/bench/nitros_zc_bench/package.xml
+++ b/bench/nitros_zc_bench/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>nitros_zc_bench</name>
+  <version>0.2.0</version>
+  <description>
+    Consumer-side benchmark for the realsense2_camera NITROS zero-copy color path: compares a
+    plain sensor_msgs/Image consumer (which must copy every frame host-to-device) against a
+    NITROS consumer that reads the frame in place on the GPU. Both run the identical CUDA kernel
+    over every pixel, so the only difference measured is how the frame reaches the GPU.
+  </description>
+  <maintainer email="ashraf.kattoura@realsenseai.com">Ashraf Kattoura</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>rclcpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>isaac_ros_nitros</depend>
+  <depend>isaac_ros_managed_nitros</depend>
+  <depend>isaac_ros_nitros_image_type</depend>
+  <depend>rclcpp_components</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/bench/nitros_zc_bench/rviz/gpu_view.rviz
+++ b/bench/nitros_zc_bench/rviz/gpu_view.rviz
@@ -1,0 +1,24 @@
+Panels:
+  - Class: rviz_common/Displays
+    Name: Displays
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Class: rviz_default_plugins/Image
+      Enabled: true
+      Name: GPU frame (downscaled on the GPU)
+      Topic:
+        Depth: 1
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /nitros_viewer/gpu_view
+      Value: true
+  Global Options:
+    Fixed Frame: camera_link
+  Tools:
+    - Class: rviz_default_plugins/MoveCamera
+  Value: true
+Window Geometry:
+  Height: 600
+  Width: 900

--- a/bench/nitros_zc_bench/scripts/pair_frames.py
+++ b/bench/nitros_zc_bench/scripts/pair_frames.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Compare two consumers that watched the same stream, frame by frame.
+
+Absolute stamp-to-arrival latency is not usable here: the RealSense frame stamp and the consumer's
+clock are different domains, so it can even come out negative. Pairing the two consumers' rows by
+stamp_ns removes the stamp from the comparison entirely -- what is left is how much later one
+transport delivered the same frame than the other, plus each path's delivery jitter.
+"""
+import csv
+import statistics
+import sys
+
+
+def load(path):
+    rows = {}
+    with open(path) as f:
+        for r in csv.DictReader(f):
+            rows[int(r["stamp_ns"])] = (int(r["arrival_ns"]), float(r["prep_us"]), float(r["kernel_us"]))
+    return rows
+
+
+def pct(values, p):
+    values = sorted(values)
+    return values[min(len(values) - 1, int(len(values) * p))]
+
+
+def jitter_ms(rows):
+    arrivals = [a for _, (a, _, _) in sorted(rows.items())]
+    gaps = [(b - a) / 1e6 for a, b in zip(arrivals, arrivals[1:])]
+    return gaps
+
+
+def main(nitros_path, cpu_path):
+    nitros, cpu = load(nitros_path), load(cpu_path)
+    common = sorted(set(nitros) & set(cpu))
+    print(f"PAIRED frames: nitros={len(nitros)} cpu={len(cpu)} common={len(common)}")
+    if not common:
+        print("PAIRED no frames in common -- cannot compare")
+        return
+    deltas = [(nitros[s][0] - cpu[s][0]) / 1e6 for s in common]
+    print(
+        "PAIRED nitros-minus-cpu arrival delta (ms): "
+        f"mean {statistics.mean(deltas):+.2f}  p50 {pct(deltas, 0.5):+.2f}  "
+        f"p99 {pct(deltas, 0.99):+.2f}   (negative = NITROS delivered it first)"
+    )
+    for name, rows in (("nitros", nitros), ("cpu", cpu)):
+        gaps = jitter_ms(rows)
+        if gaps:
+            print(
+                f"PAIRED {name} inter-arrival gap (ms): mean {statistics.mean(gaps):.2f}  "
+                f"p50 {pct(gaps, 0.5):.2f}  p99 {pct(gaps, 0.99):.2f}  max {max(gaps):.2f}"
+            )
+
+
+if __name__ == "__main__":
+    main(sys.argv[1], sys.argv[2])

--- a/bench/nitros_zc_bench/scripts/run_bench.sh
+++ b/bench/nitros_zc_bench/scripts/run_bench.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# NITROS zero-copy benchmark, run inside the Isaac ROS container on the Jetson.
+#
+# Three phases, each a fresh camera node plus one consumer:
+#   zerocopy  : NITROS publishing on (pooled allocator)  + nitros_consumer  (frame stays on the GPU)
+#   baseline  : NITROS publishing off                    + cpu_consumer     (frame copied H2D)
+#   legacy    : NITROS publishing on (cudaMalloc/frame)  + nitros_consumer  (pre-pool publisher)
+#
+# Each phase reports consumer FPS / latency / CPU and the camera node's own CPU over the window.
+# ROS setup scripts reference unbound vars, so no set -u here.
+set -o pipefail
+
+WS=/workspaces/isaac_ros-dev
+OUT=${OUT:-$WS/bench_results}
+WARMUP=${WARMUP:-5.0}
+DURATION=${DURATION:-30.0}
+PROFILE=${PROFILE:-1920x1080x30}
+FPS=${FPS:-30.0}
+
+mkdir -p "$OUT"
+source /opt/ros/humble/setup.bash
+source $WS/install/setup.bash
+for d in $(find $WS/install -name 'libgxf_*.so' -exec dirname {} \; | sort -u); do
+  export LD_LIBRARY_PATH="$d:$LD_LIBRARY_PATH"
+done
+
+CAM_ARGS=(--ros-args
+  -p "rgb_camera.color_profile:=$PROFILE"
+  -p rgb_camera.color_format:=RGB8
+  -p enable_depth:=false -p enable_infra1:=false -p enable_infra2:=false
+  -p enable_gyro:=false -p enable_accel:=false -p pointcloud.enable:=false
+  -p align_depth.enable:=false)
+
+# The camera node's own pid, not the "ros2 run" wrapper that spawned it.
+node_pid() {
+  # Match on the executable itself (field 2), which excludes the python "ros2 run" wrapper and
+  # any shell whose command line merely mentions the node.
+  ps -eo pid,args | awk '$2 ~ /realsense2_camera_node$/ { print $1; exit }'
+}
+
+# CPU seconds consumed by a pid so far (utime+stime from /proc/<pid>/stat).
+cpu_seconds() {
+  local pid=$1
+  [ -r "/proc/$pid/stat" ] || { echo 0; return; }
+  awk '{ n=split($0, a, ") "); split(a[n], f, " "); print (f[12]+f[13])/'"$(getconf CLK_TCK)"' }' "/proc/$pid/stat"
+}
+
+run_phase() {
+  local name=$1 nitros=$2 consumer=$3 legacy=$4
+  local log="$OUT/$name.log"
+  echo "=== phase $name (nitros=$nitros consumer=$consumer legacy_alloc=$legacy) ==="
+
+  pkill -f realsense2_camera_node 2>/dev/null; pkill -f _consumer 2>/dev/null; sleep 3
+
+  if [ "$legacy" = "1" ]; then export RS_NITROS_LEGACY_ALLOC=1; else unset RS_NITROS_LEGACY_ALLOC; fi
+  ros2 run realsense2_camera realsense2_camera_node "${CAM_ARGS[@]}" \
+      -p "enable_color_nitros:=$nitros" > "$OUT/$name.camera.log" 2>&1 &
+  local cam_wrapper=$!
+
+  # Wait for the stream to actually start before timing anything.
+  local waited=0
+  while ! grep -qE "Stream started|Starting Sensor" "$OUT/$name.camera.log" 2>/dev/null; do
+    sleep 1; waited=$((waited+1))
+    if [ $waited -gt 60 ]; then echo "TIMEOUT waiting for camera in phase $name"; cat "$OUT/$name.camera.log"|tail -20; return 1; fi
+  done
+  sleep 3
+  local cam_pid
+  cam_pid=$(node_pid)
+  echo "camera pid $cam_pid (up after ${waited}s)"
+
+  # Consumer runs warmup+duration; sample the camera's CPU over the measured part only.
+  ros2 run nitros_zc_bench "$consumer" --ros-args \
+      -p "warmup_s:=$WARMUP" -p "duration_s:=$DURATION" -p "expected_fps:=$FPS" \
+      -p "csv_path:=$OUT/$name.frames.csv" > "$log" 2>&1 &
+  local cons_wrapper=$!
+  sleep "$WARMUP"
+  local c0 t0
+  c0=$(cpu_seconds "$cam_pid"); t0=$(date +%s.%N)
+  wait $cons_wrapper
+  local c1 t1
+  c1=$(cpu_seconds "$cam_pid"); t1=$(date +%s.%N)
+  local cam_pct
+  cam_pct=$(awk -v c0="$c0" -v c1="$c1" -v t0="$t0" -v t1="$t1" 'BEGIN{ d=t1-t0; if(d>0) printf "%.2f", 100*(c1-c0)/d; else print "0" }')
+  echo "PUBLISHER_CPU {\"phase\":\"$name\",\"camera_cpu_pct\":$cam_pct}" | tee -a "$log"
+  grep -E "^RESULT|^PUBLISHER_CPU" "$log" | sed "s/^/[$name] /"
+  # Did the zero-copy source hold for every frame?
+  grep -c "ZERO-COPY source" "$OUT/$name.camera.log" 2>/dev/null | sed "s/^/[$name] zero-copy-source log lines: /"
+
+  kill $cam_wrapper 2>/dev/null; pkill -f realsense2_camera_node 2>/dev/null; sleep 3
+  return 0
+}
+
+echo "### profile=$PROFILE warmup=${WARMUP}s duration=${DURATION}s"
+run_phase zerocopy true  nitros_consumer 0
+run_phase baseline false cpu_consumer    0
+run_phase legacy   true  nitros_consumer 1
+
+# Both consumers against one camera node, so they see the identical frames and the latency
+# difference between the two transports is measured on the same stream rather than across runs.
+# (They do contend for CPU/GPU here, so treat the FPS/CPU numbers from the single-consumer phases
+# as the authoritative ones and read this phase for the latency delta.)
+both_phase() {
+  local name=both
+  echo "=== phase $name (nitros=true, cpu_consumer + nitros_consumer together) ==="
+  pkill -f realsense2_camera_node 2>/dev/null; pkill -f _consumer 2>/dev/null; sleep 3
+  unset RS_NITROS_LEGACY_ALLOC
+  ros2 run realsense2_camera realsense2_camera_node "${CAM_ARGS[@]}" -p enable_color_nitros:=true \
+      > "$OUT/$name.camera.log" 2>&1 &
+  local wrapper=$!
+  local waited=0
+  while ! grep -qE "Stream started|Starting Sensor" "$OUT/$name.camera.log" 2>/dev/null; do
+    sleep 1; waited=$((waited+1))
+    if [ $waited -gt 60 ]; then echo "TIMEOUT waiting for camera in phase $name"; return 1; fi
+  done
+  sleep 3
+  ros2 run nitros_zc_bench nitros_consumer --ros-args -p "warmup_s:=$WARMUP" \
+      -p "duration_s:=$DURATION" -p "expected_fps:=$FPS" \
+      -p "csv_path:=$OUT/$name.nitros.csv" > "$OUT/$name.nitros.log" 2>&1 &
+  local a=$!
+  ros2 run nitros_zc_bench cpu_consumer --ros-args -p "warmup_s:=$WARMUP" \
+      -p "duration_s:=$DURATION" -p "expected_fps:=$FPS" \
+      -p "csv_path:=$OUT/$name.cpu.csv" > "$OUT/$name.cpu.log" 2>&1 &
+  local b=$!
+  wait $a; wait $b
+  grep -hE "^RESULT" "$OUT/$name.nitros.log" "$OUT/$name.cpu.log" | sed "s/^/[$name] /"
+  python3 "$(dirname "$0")/pair_frames.py" "$OUT/$name.nitros.csv" "$OUT/$name.cpu.csv" || true
+  echo "--- first frames seen by each consumer (pair by stamp_ns) ---"
+  grep -h "STAMP" "$OUT/$name.nitros.log" | sed 's/^/[both:nitros] /' | tail -5
+  grep -h "STAMP" "$OUT/$name.cpu.log" | sed 's/^/[both:cpu]    /' | tail -5
+  kill $wrapper 2>/dev/null; pkill -f realsense2_camera_node 2>/dev/null; sleep 3
+}
+both_phase
+
+# Separate short phase with debug logging on: confirms the SDK really handed us a zero-copy
+# device pointer (copied == false) for every frame, and reports the publisher's own per-frame cost.
+# Kept out of the measured phases because debug logging itself costs CPU.
+verify_phase() {
+  local name=verify log="$OUT/$name.camera.log"
+  echo "=== phase $name (debug logging, 20 s) ==="
+  pkill -f realsense2_camera_node 2>/dev/null; pkill -f _consumer 2>/dev/null; sleep 3
+  unset RS_NITROS_LEGACY_ALLOC
+  ros2 run realsense2_camera realsense2_camera_node "${CAM_ARGS[@]}" -p enable_color_nitros:=true \
+      --log-level camera.camera:=debug --log-level NitrosImagePublisher:=debug > "$log" 2>&1 &
+  local wrapper=$!
+  sleep 12
+  ros2 run nitros_zc_bench nitros_consumer --ros-args -p warmup_s:=1.0 -p duration_s:=8.0 \
+      -p "expected_fps:=$FPS" > "$OUT/$name.log" 2>&1
+  kill $wrapper 2>/dev/null; pkill -f realsense2_camera_node 2>/dev/null; sleep 2
+  echo "VERIFY zero-copy-source frames : $(grep -c 'ZERO-COPY source' "$log")"
+  echo "VERIFY upload (h2d copy) frames: $(grep -c 'UPLOAD (host->device copy)' "$log")"
+  grep -h "publish cost over" "$log" | tail -3
+  grep -hE "^RESULT" "$OUT/$name.log" | sed 's/^/[verify] /'
+}
+verify_phase
+
+echo; echo "########## SUMMARY ##########"
+grep -hE "^RESULT|^PUBLISHER_CPU" "$OUT"/*.log

--- a/bench/nitros_zc_bench/src/bench_kernel.cu
+++ b/bench/nitros_zc_bench/src/bench_kernel.cu
@@ -1,0 +1,29 @@
+// The GPU work both consumers perform, identical on either path: read every byte of the frame.
+#include "bench_kernel.h"
+
+#include <cuda_runtime.h>
+
+namespace
+{
+__global__ void checksum_kernel(const unsigned char * data, size_t n, unsigned long long * out)
+{
+    unsigned long long local = 0;
+    const size_t stride = static_cast<size_t>(blockDim.x) * gridDim.x;
+    for (size_t i = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x; i < n; i += stride) {
+        local += data[i];
+    }
+    atomicAdd(out, local);
+}
+}  // namespace
+
+cudaError_t launch_checksum(
+    const void * gpu_data, size_t n, unsigned long long * d_out, cudaStream_t stream)
+{
+    cudaError_t err = cudaMemsetAsync(d_out, 0, sizeof(unsigned long long), stream);
+    if (err != cudaSuccess) {
+        return err;
+    }
+    checksum_kernel<<<512, 256, 0, stream>>>(
+        static_cast<const unsigned char *>(gpu_data), n, d_out);
+    return cudaGetLastError();
+}

--- a/bench/nitros_zc_bench/src/bench_kernel.h
+++ b/bench/nitros_zc_bench/src/bench_kernel.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <cuda_runtime.h>
+#include <cstddef>
+
+// Sums every byte of the frame into *d_out on the given stream. Nothing about the result matters;
+// it exists so the read of all pixels cannot be optimized away.
+cudaError_t launch_checksum(
+    const void * gpu_data, size_t n, unsigned long long * d_out, cudaStream_t stream);

--- a/bench/nitros_zc_bench/src/bench_stats.h
+++ b/bench/nitros_zc_bench/src/bench_stats.h
@@ -1,0 +1,145 @@
+#pragma once
+// Shared measurement plumbing for the two consumers, so both report exactly the same numbers.
+#include <rclcpp/rclcpp.hpp>
+
+#include <algorithm>
+#include <cstdio>
+#include <fstream>
+#include <numeric>
+#include <string>
+#include <vector>
+
+namespace bench
+{
+// CPU time this process has burned, in seconds (utime + stime from /proc/self/stat).
+inline double processCpuSeconds()
+{
+    std::ifstream f("/proc/self/stat");
+    if (!f) {
+        return 0.0;
+    }
+    std::string ignored;
+    // Fields 14 and 15 are utime and stime, in clock ticks. Field 2 (comm) may contain spaces but
+    // is parenthesised, so skip past the closing paren first.
+    std::string all((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    const size_t close = all.rfind(')');
+    if (close == std::string::npos) {
+        return 0.0;
+    }
+    std::vector<std::string> fields;
+    std::string rest = all.substr(close + 2);   // skip ") "
+    size_t pos = 0;
+    while (pos < rest.size()) {
+        const size_t sp = rest.find(' ', pos);
+        fields.push_back(rest.substr(pos, sp == std::string::npos ? std::string::npos : sp - pos));
+        if (sp == std::string::npos) {
+            break;
+        }
+        pos = sp + 1;
+    }
+    // rest[0] is field 3 (state), so utime is index 11 and stime index 12.
+    if (fields.size() < 13) {
+        return 0.0;
+    }
+    const double ticks = static_cast<double>(sysconf(_SC_CLK_TCK));
+    return (std::stod(fields[11]) + std::stod(fields[12])) / ticks;
+}
+
+inline double percentile(std::vector<double> v, double p)
+{
+    if (v.empty()) {
+        return 0.0;
+    }
+    std::sort(v.begin(), v.end());
+    const size_t idx = std::min(v.size() - 1, static_cast<size_t>(v.size() * p));
+    return v[idx];
+}
+
+inline double mean(const std::vector<double> & v)
+{
+    return v.empty() ? 0.0 : std::accumulate(v.begin(), v.end(), 0.0) / v.size();
+}
+
+// One consumer run: counts, per-frame timings, and CPU usage over the measured window.
+struct Run
+{
+    std::string label;
+    // Optional per-frame record. Absolute stamp-to-arrival latency is not comparable across
+    // transports (the RealSense stamp and the consumer clock are not the same domain), so the
+    // honest comparison is to pair the two consumers' rows by stamp_ns and diff their arrivals.
+    std::ofstream csv;
+    std::vector<double> latency_ms;      // frame timestamp -> GPU work complete
+    std::vector<double> transport_ms;    // frame timestamp -> callback entry
+    std::vector<double> prep_us;         // getting the frame onto the GPU (H2D copy, or nothing)
+    std::vector<double> kernel_us;       // the identical pixel-reading kernel
+    uint64_t frames_seen{0};             // includes warmup
+    double cpu_start{0.0};
+    double wall_start{0.0};
+    double wall_end{0.0};
+    bool measuring{false};
+
+    void openCsv(const std::string & path)
+    {
+        if (path.empty()) {
+            return;
+        }
+        csv.open(path);
+        if (csv) {
+            csv << "stamp_ns,arrival_ns,prep_us,kernel_us\n";
+        }
+    }
+
+    void recordCsv(int64_t stamp_ns, int64_t arrival_ns, double prep_us, double kernel_us)
+    {
+        if (csv) {
+            csv << stamp_ns << ',' << arrival_ns << ',' << prep_us << ',' << kernel_us << '\n';
+        }
+    }
+
+    void beginMeasurement(double now)
+    {
+        measuring = true;
+        cpu_start = processCpuSeconds();
+        wall_start = now;
+    }
+
+    void report(const rclcpp::Logger & logger, double expected_fps) const
+    {
+        const double wall = wall_end - wall_start;
+        const double cpu = processCpuSeconds() - cpu_start;
+        const size_t n = latency_ms.size();
+        const double fps = wall > 0 ? n / wall : 0.0;
+        RCLCPP_INFO(logger, "================ %s ================", label.c_str());
+        RCLCPP_INFO(logger, "measured window      : %.1f s (%zu frames)", wall, n);
+        RCLCPP_INFO(
+            logger, "delivered rate       : %.2f FPS  (%.1f%% of the %.0f FPS stream)",
+            fps, expected_fps > 0 ? 100.0 * fps / expected_fps : 0.0, expected_fps);
+        RCLCPP_INFO(
+            logger, "onto-GPU cost / frame: mean %.1f us  p99 %.1f us",
+            mean(prep_us), percentile(prep_us, 0.99));
+        RCLCPP_INFO(
+            logger, "kernel / frame       : mean %.1f us  p99 %.1f us",
+            mean(kernel_us), percentile(kernel_us, 0.99));
+        RCLCPP_INFO(
+            logger, "transport latency    : mean %.1f ms  p50 %.1f  p99 %.1f",
+            mean(transport_ms), percentile(transport_ms, 0.50), percentile(transport_ms, 0.99));
+        RCLCPP_INFO(
+            logger, "end-to-end latency   : mean %.1f ms  p50 %.1f  p99 %.1f",
+            mean(latency_ms), percentile(latency_ms, 0.50), percentile(latency_ms, 0.99));
+        RCLCPP_INFO(
+            logger, "consumer CPU         : %.1f%% of one core (%.2f s CPU / %.1f s wall)",
+            wall > 0 ? 100.0 * cpu / wall : 0.0, cpu, wall);
+        // Machine-readable line for the runner script.
+        printf(
+            "RESULT {\"label\":\"%s\",\"frames\":%zu,\"wall_s\":%.2f,\"fps\":%.3f,"
+            "\"prep_us_mean\":%.1f,\"prep_us_p99\":%.1f,\"kernel_us_mean\":%.1f,"
+            "\"transport_ms_mean\":%.2f,\"transport_ms_p99\":%.2f,"
+            "\"e2e_ms_mean\":%.2f,\"e2e_ms_p50\":%.2f,\"e2e_ms_p99\":%.2f,\"cpu_pct\":%.2f}\n",
+            label.c_str(), n, wall, fps, mean(prep_us), percentile(prep_us, 0.99),
+            mean(kernel_us), mean(transport_ms), percentile(transport_ms, 0.99),
+            mean(latency_ms), percentile(latency_ms, 0.50), percentile(latency_ms, 0.99),
+            wall > 0 ? 100.0 * cpu / wall : 0.0);
+        fflush(stdout);
+    }
+};
+}  // namespace bench

--- a/bench/nitros_zc_bench/src/cpu_consumer.cpp
+++ b/bench/nitros_zc_bench/src/cpu_consumer.cpp
@@ -1,0 +1,187 @@
+// Baseline consumer: takes the ordinary sensor_msgs/Image topic and copies every frame
+// host-to-device before it can run any GPU work. This is how a GPU perception node consumes
+// RealSense frames today.
+#include "bench_kernel.h"
+#include "bench_stats.h"
+
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/image.hpp>
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+namespace nitros_zc_bench
+{
+using namespace std::chrono_literals;
+
+class CpuConsumer : public rclcpp::Node
+{
+public:
+    explicit CpuConsumer(const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
+    : rclcpp::Node("cpu_consumer", options),
+      _topic(declare_parameter<std::string>("topic", "/camera/camera/color/image_raw")),
+      _warmup_s(declare_parameter<double>("warmup_s", 5.0)),
+      _duration_s(declare_parameter<double>("duration_s", 30.0)),
+      _expected_fps(declare_parameter<double>("expected_fps", 30.0)),
+      _csv_path(declare_parameter<std::string>("csv_path", ""))
+    {
+        _run.label = "CPU baseline (sensor_msgs/Image + host-to-device copy)";
+        cudaSetDevice(0);
+        cudaStreamCreateWithFlags(&_stream, cudaStreamNonBlocking);
+        cudaMalloc(reinterpret_cast<void **>(&_d_out), sizeof(unsigned long long));
+
+        // Best-effort/depth-1 mirrors the NITROS subscriber's default QoS so neither path gets a
+        // deeper queue than the other.
+        rclcpp::QoS qos(1);
+        qos.best_effort();
+        _sub = create_subscription<sensor_msgs::msg::Image>(
+            _topic, qos, [this](sensor_msgs::msg::Image::ConstSharedPtr msg) {onImage(msg);});
+
+        _run.openCsv(_csv_path);
+        _start = now();
+        RCLCPP_INFO(
+            get_logger(), "subscribed to %s; %.0f s warmup then %.0f s measured",
+            _topic.c_str(), _warmup_s, _duration_s);
+        _timer = create_wall_timer(200ms, [this]() {checkDone();});
+    }
+
+    ~CpuConsumer() override
+    {
+        reportIfMeasured();
+        if (_d_buf) {
+            cudaFree(_d_buf);
+        }
+        if (_d_out) {
+            cudaFree(_d_out);
+        }
+        if (_stream) {
+            cudaStreamDestroy(_stream);
+        }
+    }
+
+    // Composed into a container there is no main() to call this, so the destructor does it.
+    void reportIfMeasured()
+    {
+        if (_reported) {
+            return;
+        }
+        _reported = true;
+        if (_run.measuring) {
+            _run.report(get_logger(), _expected_fps);
+        } else {
+            RCLCPP_ERROR(
+                get_logger(), "no frames measured on %s (%llu seen) - is the camera publishing?",
+                _topic.c_str(), static_cast<unsigned long long>(_run.frames_seen));
+        }
+    }
+
+private:
+    void onImage(const sensor_msgs::msg::Image::ConstSharedPtr & msg)
+    {
+        const auto arrival = now();
+        _run.frames_seen++;
+        const double since_start = (arrival - _start).seconds();
+        if (since_start < _warmup_s) {
+            return;
+        }
+        if (!_run.measuring) {
+            _run.beginMeasurement(arrival.seconds());
+        }
+
+        const size_t bytes = msg->data.size();
+        if (bytes == 0) {
+            return;
+        }
+        if (bytes != _buf_bytes) {
+            if (_d_buf) {
+                cudaFree(_d_buf);
+            }
+            if (cudaMalloc(&_d_buf, bytes) != cudaSuccess) {
+                RCLCPP_ERROR(get_logger(), "cudaMalloc(%zu) failed", bytes);
+                _d_buf = nullptr;
+                return;
+            }
+            _buf_bytes = bytes;
+        }
+
+        // The copy this benchmark exists to measure: the frame arrives in host memory, so it has
+        // to be pushed across to the GPU before anything can look at it.
+        const auto t0 = std::chrono::steady_clock::now();
+        cudaError_t err = cudaMemcpyAsync(
+            _d_buf, msg->data.data(), bytes, cudaMemcpyHostToDevice, _stream);
+        if (err == cudaSuccess) {
+            err = cudaStreamSynchronize(_stream);
+        }
+        const auto t1 = std::chrono::steady_clock::now();
+        if (err != cudaSuccess) {
+            RCLCPP_ERROR(get_logger(), "H2D copy failed: %s", cudaGetErrorString(err));
+            return;
+        }
+
+        err = launch_checksum(_d_buf, bytes, _d_out, _stream);
+        if (err == cudaSuccess) {
+            err = cudaStreamSynchronize(_stream);
+        }
+        const auto t2 = std::chrono::steady_clock::now();
+        if (err != cudaSuccess) {
+            RCLCPP_ERROR(get_logger(), "kernel failed: %s", cudaGetErrorString(err));
+            return;
+        }
+
+        const rclcpp::Time stamp(msg->header.stamp);
+        if (_run.latency_ms.size() < 5) {
+            RCLCPP_INFO(
+                get_logger(), "STAMP stamp_ns=%ld arrival_ns=%ld",
+                stamp.nanoseconds(), arrival.nanoseconds());
+        }
+        _run.prep_us.push_back(std::chrono::duration<double, std::micro>(t1 - t0).count());
+        _run.kernel_us.push_back(std::chrono::duration<double, std::micro>(t2 - t1).count());
+        _run.transport_ms.push_back((arrival - stamp).seconds() * 1e3);
+        _run.latency_ms.push_back((now() - stamp).seconds() * 1e3);
+        _run.recordCsv(
+            stamp.nanoseconds(), arrival.nanoseconds(), _run.prep_us.back(), _run.kernel_us.back());
+        _run.wall_end = now().seconds();
+    }
+
+    void checkDone()
+    {
+        if (_run.measuring && (now().seconds() - _run.wall_start) >= _duration_s) {
+            rclcpp::shutdown();
+        } else if (!_run.measuring && (now() - _start).seconds() > _warmup_s + 15.0) {
+            RCLCPP_ERROR(get_logger(), "no frames arrived on %s", _topic.c_str());
+            rclcpp::shutdown();
+        }
+    }
+
+    std::string _topic;
+    double _warmup_s, _duration_s, _expected_fps;
+    std::string _csv_path;
+    bool _reported{false};
+    rclcpp::Time _start;
+    rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr _sub;
+    rclcpp::TimerBase::SharedPtr _timer;
+    bench::Run _run;
+    cudaStream_t _stream{nullptr};
+    void * _d_buf{nullptr};
+    size_t _buf_bytes{0};
+    unsigned long long * _d_out{nullptr};
+};
+}  // namespace nitros_zc_bench
+
+#ifndef NITROS_ZC_BENCH_COMPONENT_ONLY
+int main(int argc, char ** argv)
+{
+    rclcpp::init(argc, argv);
+    auto node = std::make_shared<nitros_zc_bench::CpuConsumer>();
+    rclcpp::spin(node);
+    node->reportIfMeasured();
+    rclcpp::shutdown();
+    return 0;
+}
+#endif  // NITROS_ZC_BENCH_COMPONENT_ONLY
+
+#ifdef NITROS_ZC_BENCH_COMPONENT_ONLY
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(nitros_zc_bench::CpuConsumer)
+#endif

--- a/bench/nitros_zc_bench/src/nitros_consumer.cpp
+++ b/bench/nitros_zc_bench/src/nitros_consumer.cpp
@@ -1,0 +1,163 @@
+// Zero-copy consumer: negotiates NITROS with the wrapper and runs the same kernel straight on the
+// frame's GPU buffer. No host-to-device copy happens anywhere in this process.
+#include "bench_kernel.h"
+#include "bench_stats.h"
+
+#include <isaac_ros_managed_nitros/managed_nitros_subscriber.hpp>
+#include <isaac_ros_nitros_image_type/nitros_image.hpp>
+#include <isaac_ros_nitros_image_type/nitros_image_view.hpp>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+namespace nitros_zc_bench
+{
+using namespace std::chrono_literals;
+using nvidia::isaac_ros::nitros::ManagedNitrosSubscriber;
+using nvidia::isaac_ros::nitros::NitrosImageView;
+
+class NitrosConsumer : public rclcpp::Node
+{
+public:
+    explicit NitrosConsumer(const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
+    : rclcpp::Node("nitros_consumer", options),
+      _topic(declare_parameter<std::string>("topic", "/camera/camera/color/nitros_image")),
+      _format(declare_parameter<std::string>("format", "nitros_image_rgb8")),
+      _warmup_s(declare_parameter<double>("warmup_s", 5.0)),
+      _duration_s(declare_parameter<double>("duration_s", 30.0)),
+      _expected_fps(declare_parameter<double>("expected_fps", 30.0)),
+      _csv_path(declare_parameter<std::string>("csv_path", ""))
+    {
+        _run.label = "NITROS zero-copy (frame already on the GPU)";
+        cudaSetDevice(0);
+        cudaStreamCreateWithFlags(&_stream, cudaStreamNonBlocking);
+        cudaMalloc(reinterpret_cast<void **>(&_d_out), sizeof(unsigned long long));
+
+        _sub = std::make_shared<ManagedNitrosSubscriber<NitrosImageView>>(
+            this, _topic, _format,
+            [this](const NitrosImageView & view) {onImage(view);});
+
+        _run.openCsv(_csv_path);
+        _start = now();
+        RCLCPP_INFO(
+            get_logger(), "negotiating %s on %s; %.0f s warmup then %.0f s measured",
+            _format.c_str(), _topic.c_str(), _warmup_s, _duration_s);
+        _timer = create_wall_timer(200ms, [this]() {checkDone();});
+    }
+
+    ~NitrosConsumer() override
+    {
+        reportIfMeasured();
+        if (_d_out) {
+            cudaFree(_d_out);
+        }
+        if (_stream) {
+            cudaStreamDestroy(_stream);
+        }
+    }
+
+    // Composed into a container there is no main() to call this, so the destructor does it.
+    void reportIfMeasured()
+    {
+        if (_reported) {
+            return;
+        }
+        _reported = true;
+        if (_run.measuring) {
+            _run.report(get_logger(), _expected_fps);
+        } else {
+            RCLCPP_ERROR(
+                get_logger(), "no frames measured on %s (%llu seen) - did negotiation succeed?",
+                _topic.c_str(), static_cast<unsigned long long>(_run.frames_seen));
+        }
+    }
+
+private:
+    void onImage(const NitrosImageView & view)
+    {
+        const auto arrival = now();
+        _run.frames_seen++;
+        const double since_start = (arrival - _start).seconds();
+        if (since_start < _warmup_s) {
+            return;
+        }
+        if (!_run.measuring) {
+            _run.beginMeasurement(arrival.seconds());
+        }
+
+        const void * gpu = view.GetGpuData();
+        const size_t bytes = view.GetSizeInBytes();
+        if (!gpu || bytes == 0) {
+            return;
+        }
+
+        // Nothing to prepare: the pixels are already in GPU memory this process can read.
+        const auto t1 = std::chrono::steady_clock::now();
+        cudaError_t err = launch_checksum(gpu, bytes, _d_out, _stream);
+        if (err == cudaSuccess) {
+            err = cudaStreamSynchronize(_stream);
+        }
+        const auto t2 = std::chrono::steady_clock::now();
+        if (err != cudaSuccess) {
+            RCLCPP_ERROR(get_logger(), "kernel failed: %s", cudaGetErrorString(err));
+            return;
+        }
+
+        const rclcpp::Time stamp(
+            static_cast<int32_t>(view.GetTimestampSeconds()), view.GetTimestampNanoseconds(),
+            arrival.get_clock_type());
+        if (_run.latency_ms.size() < 5) {
+            RCLCPP_INFO(
+                get_logger(), "STAMP stamp_ns=%ld arrival_ns=%ld",
+                stamp.nanoseconds(), arrival.nanoseconds());
+        }
+        _run.prep_us.push_back(0.0);
+        _run.kernel_us.push_back(std::chrono::duration<double, std::micro>(t2 - t1).count());
+        _run.transport_ms.push_back((arrival - stamp).seconds() * 1e3);
+        _run.latency_ms.push_back((now() - stamp).seconds() * 1e3);
+        _run.recordCsv(stamp.nanoseconds(), arrival.nanoseconds(), 0.0, _run.kernel_us.back());
+        _run.wall_end = now().seconds();
+    }
+
+    void checkDone()
+    {
+        if (_run.measuring && (now().seconds() - _run.wall_start) >= _duration_s) {
+            rclcpp::shutdown();
+        } else if (!_run.measuring && (now() - _start).seconds() > _warmup_s + 15.0) {
+            RCLCPP_ERROR(get_logger(), "no frames arrived on %s", _topic.c_str());
+            rclcpp::shutdown();
+        }
+    }
+
+    std::string _topic, _format;
+    double _warmup_s, _duration_s, _expected_fps;
+    std::string _csv_path;
+    bool _reported{false};
+    rclcpp::Time _start;
+    std::shared_ptr<ManagedNitrosSubscriber<NitrosImageView>> _sub;
+    rclcpp::TimerBase::SharedPtr _timer;
+    bench::Run _run;
+    cudaStream_t _stream{nullptr};
+    unsigned long long * _d_out{nullptr};
+};
+}  // namespace nitros_zc_bench
+
+#ifndef NITROS_ZC_BENCH_COMPONENT_ONLY
+int main(int argc, char ** argv)
+{
+    rclcpp::init(argc, argv);
+    auto node = std::make_shared<nitros_zc_bench::NitrosConsumer>();
+    rclcpp::spin(node);
+    node->reportIfMeasured();
+    rclcpp::shutdown();
+    return 0;
+}
+#endif  // NITROS_ZC_BENCH_COMPONENT_ONLY
+
+#ifdef NITROS_ZC_BENCH_COMPONENT_ONLY
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(nitros_zc_bench::NitrosConsumer)
+#endif

--- a/bench/nitros_zc_bench/src/nitros_viewer.cpp
+++ b/bench/nitros_zc_bench/src/nitros_viewer.cpp
@@ -1,0 +1,169 @@
+// Look at the actual GPU frame the wrapper published, without putting the copy we removed back
+// into the pipeline.
+//
+// This node must be COMPOSED into the camera's container. A viewer in another process would force
+// NITROS's type adapter to copy every frame device->host (measured: publisher cost 400 us -> 4400 us
+// per frame), which is precisely what the zero-copy path exists to avoid.
+//
+// Instead it reads the GPU buffer in place, downscales it on the GPU, and copies back only a small
+// thumbnail, at a throttled rate. At the defaults (480x270, 2 Hz) that is 57 KB twice a second
+// against 6.22 MB thirty times a second - about 0.06% of the frame bytes.
+#include "bench_kernel.h"
+#include "viz_kernel.h"
+
+#include <isaac_ros_managed_nitros/managed_nitros_subscriber.hpp>
+#include <isaac_ros_nitros_image_type/nitros_image.hpp>
+#include <isaac_ros_nitros_image_type/nitros_image_view.hpp>
+
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/image.hpp>
+
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace nitros_zc_bench
+{
+using nvidia::isaac_ros::nitros::ManagedNitrosSubscriber;
+using nvidia::isaac_ros::nitros::NitrosImageView;
+
+class NitrosViewer : public rclcpp::Node
+{
+public:
+    explicit NitrosViewer(const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
+    : rclcpp::Node("nitros_viewer", options),
+      _topic(declare_parameter<std::string>("topic", "/camera/camera/color/nitros_image")),
+      _format(declare_parameter<std::string>("format", "nitros_image_rgb8")),
+      _out_topic(declare_parameter<std::string>("out_topic", "~/gpu_view")),
+      _view_width(declare_parameter<int>("view_width", 480)),
+      _view_height(declare_parameter<int>("view_height", 270)),
+      _rate_hz(declare_parameter<double>("rate_hz", 2.0)),
+      _full_res(declare_parameter<bool>("full_res", false)),
+      _snapshot_path(declare_parameter<std::string>("snapshot_path", ""))
+    {
+        cudaSetDevice(0);
+        cudaStreamCreateWithFlags(&_stream, cudaStreamNonBlocking);
+        _pub = create_publisher<sensor_msgs::msg::Image>(_out_topic, rclcpp::QoS(1));
+        _sub = std::make_shared<ManagedNitrosSubscriber<NitrosImageView>>(
+            this, _topic, _format, [this](const NitrosImageView & view) {onImage(view);});
+        RCLCPP_INFO(
+            get_logger(),
+            "viewing %s -> %s at %.1f Hz, %s (this node must be composed in the camera's container)",
+            _topic.c_str(), _pub->get_topic_name(), _rate_hz,
+            _full_res ? "full resolution" : "GPU-downscaled thumbnail");
+    }
+
+    ~NitrosViewer() override
+    {
+        if (_d_thumb) {
+            cudaFree(_d_thumb);
+        }
+        if (_stream) {
+            cudaStreamDestroy(_stream);
+        }
+    }
+
+private:
+    void onImage(const NitrosImageView & view)
+    {
+        const auto now_s = now().seconds();
+        if (_rate_hz <= 0.0 || (now_s - _last_published) < (1.0 / _rate_hz)) {
+            return;   // throttled: most frames are looked at by nobody and cost nothing
+        }
+        _last_published = now_s;
+
+        const void * gpu = view.GetGpuData();
+        const uint32_t src_w = view.GetWidth(), src_h = view.GetHeight();
+        if (!gpu || src_w == 0 || src_h == 0) {
+            return;
+        }
+        const uint32_t out_w = _full_res ? src_w : static_cast<uint32_t>(_view_width);
+        const uint32_t out_h = _full_res ? src_h : static_cast<uint32_t>(_view_height);
+        const size_t out_bytes = static_cast<size_t>(out_w) * out_h * 3;
+
+        sensor_msgs::msg::Image msg;
+        msg.header.frame_id = view.GetFrameId();
+        msg.header.stamp.sec = static_cast<int32_t>(view.GetTimestampSeconds());
+        msg.header.stamp.nanosec = view.GetTimestampNanoseconds();
+        msg.width = out_w;
+        msg.height = out_h;
+        msg.encoding = view.GetEncoding();
+        msg.step = out_w * 3;
+        msg.data.resize(out_bytes);
+
+        cudaError_t err = cudaSuccess;
+        if (_full_res) {
+            // Straight device->host of the whole frame. Only for eyeballing; do not benchmark with it.
+            err = cudaMemcpyAsync(
+                msg.data.data(), gpu, out_bytes, cudaMemcpyDeviceToHost, _stream);
+        } else {
+            if (out_bytes != _thumb_bytes) {
+                if (_d_thumb) {
+                    cudaFree(_d_thumb);
+                }
+                if (cudaMalloc(&_d_thumb, out_bytes) != cudaSuccess) {
+                    RCLCPP_ERROR(get_logger(), "cudaMalloc(%zu) for the thumbnail failed", out_bytes);
+                    _d_thumb = nullptr;
+                    return;
+                }
+                _thumb_bytes = out_bytes;
+            }
+            // Shrink on the GPU first, then copy back only the thumbnail.
+            err = launch_downscale_rgb8(gpu, src_w, src_h, _d_thumb, out_w, out_h, _stream);
+            if (err == cudaSuccess) {
+                err = cudaMemcpyAsync(
+                    msg.data.data(), _d_thumb, out_bytes, cudaMemcpyDeviceToHost, _stream);
+            }
+        }
+        if (err == cudaSuccess) {
+            err = cudaStreamSynchronize(_stream);
+        }
+        if (err != cudaSuccess) {
+            RCLCPP_ERROR(get_logger(), "GPU view failed: %s", cudaGetErrorString(err));
+            return;
+        }
+
+        if (!_snapshot_path.empty() && !_snapshot_written) {
+            writeSnapshot(msg, out_w, out_h);
+            _snapshot_written = true;
+        }
+        _pub->publish(std::move(msg));
+        ++_published;
+    }
+
+    // A one-off PPM of the GPU pixels, for verifying content without a display attached.
+    void writeSnapshot(const sensor_msgs::msg::Image & msg, uint32_t w, uint32_t h)
+    {
+        std::FILE * f = std::fopen(_snapshot_path.c_str(), "wb");
+        if (!f) {
+            RCLCPP_WARN(get_logger(), "cannot write snapshot to %s", _snapshot_path.c_str());
+            return;
+        }
+        std::fprintf(f, "P6\n%u %u\n255\n", w, h);
+        std::fwrite(msg.data.data(), 1, msg.data.size(), f);
+        std::fclose(f);
+        RCLCPP_INFO(
+            get_logger(), "wrote %ux%u snapshot of the GPU frame to %s", w, h, _snapshot_path.c_str());
+    }
+
+    std::string _topic, _format, _out_topic;
+    int _view_width, _view_height;
+    double _rate_hz;
+    bool _full_res;
+    std::string _snapshot_path;
+    bool _snapshot_written{false};
+    double _last_published{0.0};
+    uint64_t _published{0};
+    std::shared_ptr<ManagedNitrosSubscriber<NitrosImageView>> _sub;
+    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr _pub;
+    cudaStream_t _stream{nullptr};
+    void * _d_thumb{nullptr};
+    size_t _thumb_bytes{0};
+};
+}  // namespace nitros_zc_bench
+
+#ifdef NITROS_ZC_BENCH_COMPONENT_ONLY
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(nitros_zc_bench::NitrosViewer)
+#endif

--- a/bench/nitros_zc_bench/src/viz_kernel.cu
+++ b/bench/nitros_zc_bench/src/viz_kernel.cu
@@ -1,0 +1,35 @@
+#include "viz_kernel.h"
+
+namespace
+{
+__global__ void downscale_rgb8_kernel(
+    const unsigned char * src, uint32_t src_w, uint32_t src_h,
+    unsigned char * dst, uint32_t dst_w, uint32_t dst_h)
+{
+    const uint32_t x = blockIdx.x * blockDim.x + threadIdx.x;
+    const uint32_t y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= dst_w || y >= dst_h) {
+        return;
+    }
+    // Map the destination pixel back to the nearest source pixel.
+    const uint32_t sx = static_cast<uint32_t>((static_cast<uint64_t>(x) * src_w) / dst_w);
+    const uint32_t sy = static_cast<uint32_t>((static_cast<uint64_t>(y) * src_h) / dst_h);
+    const size_t s = (static_cast<size_t>(sy) * src_w + sx) * 3;
+    const size_t d = (static_cast<size_t>(y) * dst_w + x) * 3;
+    dst[d + 0] = src[s + 0];
+    dst[d + 1] = src[s + 1];
+    dst[d + 2] = src[s + 2];
+}
+}  // namespace
+
+cudaError_t launch_downscale_rgb8(
+    const void * src, uint32_t src_w, uint32_t src_h,
+    void * dst, uint32_t dst_w, uint32_t dst_h, cudaStream_t stream)
+{
+    const dim3 block(16, 16);
+    const dim3 grid((dst_w + block.x - 1) / block.x, (dst_h + block.y - 1) / block.y);
+    downscale_rgb8_kernel<<<grid, block, 0, stream>>>(
+        static_cast<const unsigned char *>(src), src_w, src_h,
+        static_cast<unsigned char *>(dst), dst_w, dst_h);
+    return cudaGetLastError();
+}

--- a/bench/nitros_zc_bench/src/viz_kernel.h
+++ b/bench/nitros_zc_bench/src/viz_kernel.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <cuda_runtime.h>
+#include <cstdint>
+
+// Nearest-neighbour downscale of an interleaved rgb8 image, GPU -> GPU.
+// The point is to shrink the frame *before* anything crosses to the host: a 480x270 thumbnail is
+// 57 KB against the 6.22 MB of a 1080p frame, so a viewer can look at the real GPU pixels without
+// putting a full-frame device->host copy back into the pipeline.
+cudaError_t launch_downscale_rgb8(
+    const void * src, uint32_t src_w, uint32_t src_h,
+    void * dst, uint32_t dst_w, uint32_t dst_h, cudaStream_t stream);

--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -32,6 +32,10 @@ option(BUILD_WITH_OPENMP "Use OpenMP" OFF)
 option(SET_USER_BREAK_AT_STARTUP "Set user wait point in startup (for debug)" OFF)
 # Define an option to enable or disable lifecycle nodes
 option(USE_LIFECYCLE_NODE "Enable lifecycle nodes (ON/OFF)" OFF)
+# NITROS-native GPU zero-copy publishing (Jetson / Isaac ROS). Requires an Isaac ROS workspace
+# (isaac_ros_nitros, isaac_ros_managed_nitros, isaac_ros_nitros_image_type) and a librealsense
+# built with BUILD_WITH_CUDA_ZEROCOPY. Default OFF so standard builds are unaffected.
+option(BUILD_WITH_NITROS "Enable NITROS-native GPU zero-copy publishing (Jetson / Isaac ROS)" OFF)
 
 # Compiler Defense Flags
 if(UNIX OR APPLE)
@@ -160,6 +164,17 @@ if(NOT realsense2_FOUND)
     message(FATAL_ERROR "\n\n RealSense SDK 2.0 is missing, please install it from https://github.com/realsenseai/librealsense/releases\n\n")
 endif()
 
+if (BUILD_WITH_NITROS)
+  if (USE_LIFECYCLE_NODE)
+    message(FATAL_ERROR "BUILD_WITH_NITROS is incompatible with USE_LIFECYCLE_NODE: ManagedNitrosPublisher requires an rclcpp::Node.")
+  endif()
+  find_package(CUDA REQUIRED)
+  find_package(isaac_ros_nitros REQUIRED)
+  find_package(isaac_ros_managed_nitros REQUIRED)
+  find_package(isaac_ros_nitros_image_type REQUIRED)
+  message(STATUS "🚀 BUILD_WITH_NITROS enabled — NITROS GPU zero-copy color publishing")
+endif()
+
 #set(CMAKE_NO_SYSTEM_FROM_IMPORTED true)
 include_directories(include)
 
@@ -188,6 +203,10 @@ set(SOURCES
 
 if (BUILD_ACCELERATE_GPU_WITH_GLSL)
   list(APPEND SOURCES src/gl_gpu_processing.cpp)
+endif()
+
+if (BUILD_WITH_NITROS)
+  list(APPEND SOURCES src/nitros_image_publisher.cpp)
 endif()
 
 if(NOT DEFINED ENV{ROS_DISTRO})
@@ -240,6 +259,10 @@ if (BUILD_ACCELERATE_GPU_WITH_GLSL)
   add_definitions(-DACCELERATE_GPU_WITH_GLSL)
 endif()
 
+if (BUILD_WITH_NITROS)
+  add_definitions(-DBUILD_WITH_NITROS)
+endif()
+
 set(INCLUDES
     include/context_singleton_wrapper.h
     include/constants.h
@@ -258,6 +281,10 @@ set(INCLUDES
 
 if (BUILD_ACCELERATE_GPU_WITH_GLSL)
   list(APPEND INCLUDES include/gl_window.h)
+endif()
+
+if (BUILD_WITH_NITROS)
+  list(APPEND INCLUDES include/nitros_image_publisher.h)
 endif()
 
 if (BUILD_TOOLS)
@@ -325,6 +352,10 @@ else()
   list(APPEND targets realsense2::realsense2)
 endif()
 
+if (BUILD_WITH_NITROS)
+  list(APPEND dependencies isaac_ros_nitros isaac_ros_managed_nitros isaac_ros_nitros_image_type)
+endif()
+
 # If the flag is enabled, define the macro
 if(USE_LIFECYCLE_NODE)
     find_package(rclcpp_lifecycle REQUIRED)
@@ -350,6 +381,17 @@ install(FILES "${CMAKE_BINARY_DIR}/global_settings.yaml"
 target_link_libraries(${PROJECT_NAME}
   ${targets}
 )
+
+# NITROS packages export their include dirs and libraries the ament way; use
+# ament_target_dependencies so GXF / Isaac ROS transitive deps are picked up.
+if (BUILD_WITH_NITROS)
+  ament_target_dependencies(${PROJECT_NAME}
+    isaac_ros_nitros
+    isaac_ros_managed_nitros
+    isaac_ros_nitros_image_type)
+  target_include_directories(${PROJECT_NAME} PRIVATE ${CUDA_INCLUDE_DIRS})
+  target_link_libraries(${PROJECT_NAME} ${CUDA_LIBRARIES})
+endif()
 
 # Workaround: librealsense built with bundled DDS exports its own fastcdr
 # symbols from librealsense2.so, clashing at runtime with ROS 2's fastdds.

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -17,6 +17,9 @@
 #include <librealsense2/rs.hpp>
 #include <librealsense2/rsutil.h>
 #include "constants.h"
+#ifdef BUILD_WITH_NITROS
+#include "nitros_image_publisher.h"
+#endif
 
 // cv_bridge.h last supported version is humble
 #if defined(CV_BRDIGE_HAS_HPP)
@@ -304,6 +307,16 @@ namespace realsense2_camera
             const std::map<stream_index_pair, std::shared_ptr<image_publisher>>& image_publishers,
             const bool is_publishMetadata = true);
 
+#ifdef BUILD_WITH_NITROS
+        // Map an rs2 pixel format to a NITROS supported-type name + sensor_msgs encoding string +
+        // bytes-per-pixel. Returns false for formats not (yet) supported by the NITROS color path.
+        bool getNitrosImageFormat(const rs2_format& format, std::string& nitros_format,
+                                  std::string& encoding, unsigned int& bpp);
+        // Publish a video frame as a NITROS image using its GPU device pointer (zero-copy).
+        void publishNitrosFrame(rs2::frame f, const rclcpp::Time& t, const stream_index_pair& stream,
+                                unsigned int width, unsigned int height, const rs2_format& stream_format);
+#endif
+
         void publishRGBD(
             const cv::Mat& rgb_cv_matrix,
             const rs2_format& color_format,
@@ -369,8 +382,12 @@ namespace realsense2_camera
         std::vector<geometry_msgs::msg::TransformStamped> _static_tf_msgs;
         std::shared_ptr<std::thread> _tf_t;
 
-        bool _use_intra_process;      
+        bool _use_intra_process;
         std::map<stream_index_pair, std::shared_ptr<image_publisher>> _image_publishers;
+#ifdef BUILD_WITH_NITROS
+        bool _enable_color_nitros = false;
+        std::map<stream_index_pair, std::shared_ptr<NitrosImagePublisher>> _nitros_image_publishers;
+#endif
         rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr _labeled_pointcloud_publisher;
         rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr _occupancy_publisher;
         std::map<stream_index_pair, rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr> _imu_publishers;

--- a/realsense2_camera/include/constants.h
+++ b/realsense2_camera/include/constants.h
@@ -39,6 +39,7 @@
 #define ROS_FATAL_STREAM(msg) RCLCPP_FATAL_STREAM(_logger, msg)
 #define ROS_DEBUG_STREAM_ONCE(msg) RCLCPP_DEBUG_STREAM_ONCE(_logger, msg)
 #define ROS_INFO_STREAM_ONCE(msg) RCLCPP_INFO_STREAM_ONCE(_logger, msg)
+#define ROS_WARN_STREAM_ONCE(msg) RCLCPP_WARN_STREAM_ONCE(_logger, msg)
 #define ROS_WARN_STREAM_COND(cond, msg) RCLCPP_WARN_STREAM_EXPRESSION(_logger, cond, msg)
 
 #define ROS_WARN_ONCE(msg) RCLCPP_WARN_ONCE(_logger, msg)

--- a/realsense2_camera/include/nitros_image_publisher.h
+++ b/realsense2_camera/include/nitros_image_publisher.h
@@ -1,0 +1,70 @@
+// Copyright 2026 RealSense, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#ifdef BUILD_WITH_NITROS
+
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/header.hpp>
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace realsense2_camera
+{
+// Thin, GXF-free wrapper around nvidia::isaac_ros::nitros::ManagedNitrosPublisher<NitrosImage>.
+// The heavy Isaac ROS / GXF / CUDA headers are confined to nitros_image_publisher.cpp, so the
+// rest of the wrapper (base_realsense_node.*) only sees this handle and never pulls in NITROS.
+//
+// NOTE on ownership (Isaac ROS release-3.2): NitrosImageBuilder::WithGpuData() hands the pointer to
+// a GXF VideoBuffer whose release callback calls cudaFree(). GXF therefore OWNS the buffer and frees
+// it once downstream is done. We must NOT pass the librealsense frame-pool pointer directly (GXF
+// would cudaFree memory the SDK owns), so publish() gives GXF its own buffer and device-to-device
+// copies the frame's GPU pixels into it. That still avoids the GPU->CPU->GPU round-trip to the
+// perception graph (the goal); the D2D copy is the cost of release-3.2's owning model. Isaac ROS
+// >=4.0 adds WithReleaseCallback() for a true alias, but 4.x is Jetson Thor / JetPack 7 only, so on
+// Orin the copy is structural.
+//
+// The buffer GXF frees comes from a CUDA stream-ordered memory pool: cudaFree() is legal on memory
+// from cudaMallocFromPoolAsync and returns it to our pool instead of the driver, so GXF's release
+// callback recycles the buffer rather than trashing it. Measured per frame at 1080p rgb8 on AGX
+// Orin: plain cudaMalloc+cudaFree ~718 us, pooled ~2 us. The copy runs on a private non-blocking
+// stream so it does not serialize against librealsense's own CUDA work on the default stream.
+class NitrosImagePublisher
+{
+public:
+    // nitros_format is a NITROS supported-type name (e.g. "nitros_image_rgb8").
+    NitrosImagePublisher(rclcpp::Node * node, const std::string & topic, const std::string & nitros_format);
+    ~NitrosImagePublisher();
+
+    // gpu_src   : CUDA device pointer to the frame pixels (aliases the SDK frame buffer).
+    // size_bytes: number of bytes to copy (width * height * bytes_per_pixel).
+    // encoding  : sensor_msgs::image_encodings string matching nitros_format (e.g. "rgb8").
+    // The frame's pixels are D2D-copied into a GXF-owned buffer and the copy is awaited before the
+    // message is published, so the caller need not keep the frame alive after this returns.
+    void publish(const void * gpu_src,
+                 uint32_t width,
+                 uint32_t height,
+                 size_t size_bytes,
+                 const std::string & encoding,
+                 const std_msgs::msg::Header & header);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> _impl;
+};
+}  // namespace realsense2_camera
+
+#endif  // BUILD_WITH_NITROS

--- a/realsense2_camera/package.xml
+++ b/realsense2_camera/package.xml
@@ -19,6 +19,10 @@
   <depend>cv_bridge</depend>
   <depend>image_transport</depend>
   <depend>librealsense2</depend>
+  <!-- Optional NITROS GPU zero-copy publishing (-DBUILD_WITH_NITROS=ON), like the optional
+       realsense2-gl dep these are not declared here: they are provided by an Isaac ROS
+       workspace (isaac_ros_nitros, isaac_ros_managed_nitros, isaac_ros_nitros_image_type)
+       and only needed for that build. -->
   <depend>rclcpp</depend>
 
   <!-- Lifecycle dependencies are optional -DUSE_LIFECYCLE_NODE -->

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -1252,6 +1252,12 @@ void BaseRealSenseNode::publishFrame(
         return;
     }
 
+#ifdef BUILD_WITH_NITROS
+    // Additive: hand the color frame's GPU device pointer straight to NITROS (no CPU copy).
+    // Independent of the sensor_msgs publishers below, which keep working unchanged.
+    publishNitrosFrame(f, t, stream, width, height, stream_format);
+#endif
+
     // Publish stream image
     if (image_publishers.find(stream) != image_publishers.end())
     {
@@ -1345,6 +1351,62 @@ void BaseRealSenseNode::publishFrame(
         publishMetadata(f, t, OPTICAL_FRAME_ID(stream));
     }
 }
+
+#ifdef BUILD_WITH_NITROS
+bool BaseRealSenseNode::getNitrosImageFormat(
+    const rs2_format& format, std::string& nitros_format, std::string& encoding, unsigned int& bpp)
+{
+    // Only the common color formats for now (color-only first cut). NITROS supported-type
+    // name (used by ManagedNitrosPublisher / negotiation) + matching sensor_msgs encoding + bpp.
+    switch (format)
+    {
+        case RS2_FORMAT_RGB8:  nitros_format = "nitros_image_rgb8";  encoding = sensor_msgs::image_encodings::RGB8;  bpp = 3; return true;
+        case RS2_FORMAT_BGR8:  nitros_format = "nitros_image_bgr8";  encoding = sensor_msgs::image_encodings::BGR8;  bpp = 3; return true;
+        case RS2_FORMAT_RGBA8: nitros_format = "nitros_image_rgba8"; encoding = sensor_msgs::image_encodings::RGBA8; bpp = 4; return true;
+        case RS2_FORMAT_BGRA8: nitros_format = "nitros_image_bgra8"; encoding = sensor_msgs::image_encodings::BGRA8; bpp = 4; return true;
+        default: return false;
+    }
+}
+
+void BaseRealSenseNode::publishNitrosFrame(
+    rs2::frame f, const rclcpp::Time& t, const stream_index_pair& stream,
+    unsigned int width, unsigned int height, const rs2_format& stream_format)
+{
+    auto it = _nitros_image_publishers.find(stream);
+    if (it == _nitros_image_publishers.end())
+        return;
+
+    std::string nitros_format, encoding;
+    unsigned int bpp = 0;
+    if (!getNitrosImageFormat(stream_format, nitros_format, encoding, bpp))
+        return;
+
+    // Get a CUDA device pointer for the frame. On a librealsense built with
+    // BUILD_WITH_CUDA_ZEROCOPY running on an integrated GPU (Jetson), this aliases the
+    // GPU-mapped frame buffer with no host->device copy (copied=false). Otherwise the SDK
+    // uploads (copied=true) so the path still works; either way we get a device pointer.
+    bool copied = false;
+    const void* gpu_ptr = f.get_gpu_data_or_upload(&copied);
+    if (!gpu_ptr)
+    {
+        ROS_WARN_STREAM_ONCE("NITROS: no GPU pointer available for " << STREAM_NAME(stream)
+                             << " (librealsense not built with CUDA?). Skipping NITROS publish.");
+        return;
+    }
+
+    std_msgs::msg::Header header;
+    header.stamp = t;
+    header.frame_id = OPTICAL_FRAME_ID(stream);
+
+    // The publisher D2D-copies the pixels into a GXF-owned buffer synchronously, so `f` (and the
+    // frame-pool buffer gpu_ptr aliases) only needs to stay alive for the duration of this call.
+    const size_t size_bytes = static_cast<size_t>(width) * height * bpp;
+    it->second->publish(gpu_ptr, width, height, size_bytes, encoding, header);
+
+    ROS_DEBUG_STREAM("NITROS " << STREAM_NAME(stream) << " published ("
+                     << (copied ? "UPLOAD (host->device copy)" : "ZERO-COPY source") << ")");
+}
+#endif
 
 
 void BaseRealSenseNode::publishRGBD(

--- a/realsense2_camera/src/nitros_image_publisher.cpp
+++ b/realsense2_camera/src/nitros_image_publisher.cpp
@@ -1,0 +1,308 @@
+// Copyright 2026 RealSense, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef BUILD_WITH_NITROS
+
+#include "nitros_image_publisher.h"
+
+#include <isaac_ros_managed_nitros/managed_nitros_publisher.hpp>
+#include <isaac_ros_nitros_image_type/nitros_image.hpp>
+#include <isaac_ros_nitros_image_type/nitros_image_builder.hpp>
+
+#include <cuda_runtime.h>
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <optional>
+#include <utility>
+
+// cudaMemPool_t / cudaMallocFromPoolAsync (the stream-ordered allocator) need CUDA 11.2.
+#if defined(CUDART_VERSION) && CUDART_VERSION >= 11020
+#define RS_NITROS_HAS_MEMPOOL 1
+#else
+#define RS_NITROS_HAS_MEMPOOL 0
+#endif
+
+namespace realsense2_camera
+{
+using nvidia::isaac_ros::nitros::ManagedNitrosPublisher;
+using nvidia::isaac_ros::nitros::NitrosImage;
+using nvidia::isaac_ros::nitros::NitrosImageBuilder;
+
+namespace
+{
+rclcpp::Logger logger()
+{
+    return rclcpp::get_logger("NitrosImagePublisher");
+}
+
+// Set RS_NITROS_LEGACY_ALLOC=1 to get a plain cudaMalloc + synchronous cudaMemcpy per frame instead
+// of the pooled + async path. Only useful for A/B benchmarking the two allocation strategies.
+bool legacyAllocRequested()
+{
+    const char * env = std::getenv("RS_NITROS_LEGACY_ALLOC");
+    return env != nullptr && env[0] == '1';
+}
+
+// How often the accumulated per-frame publish cost is reported (at DEBUG).
+constexpr uint64_t STATS_LOG_INTERVAL = 100;
+}  // namespace
+
+struct NitrosImagePublisher::Impl
+{
+    std::shared_ptr<ManagedNitrosPublisher<NitrosImage>> pub;
+
+    // Stream-ordered pool the GXF-owned buffers are carved from; null when pooling is unavailable
+    // or RS_NITROS_LEGACY_ALLOC=1, in which case publish() falls back to cudaMalloc.
+#if RS_NITROS_HAS_MEMPOOL
+    cudaMemPool_t pool{nullptr};
+#endif
+    cudaStream_t stream{nullptr};
+    cudaEvent_t copy_done{nullptr};
+
+    // Per-frame publish cost, reported every STATS_LOG_INTERVAL frames.
+    uint64_t frames{0};
+    double us_sum{0.0};
+    double us_max{0.0};
+    double alloc_us_sum{0.0};
+    double wait_us_sum{0.0};
+    double build_us_sum{0.0};
+
+    bool pooled() const
+    {
+#if RS_NITROS_HAS_MEMPOOL
+        return pool != nullptr;
+#else
+        return false;
+#endif
+    }
+
+    // Frees a buffer publish() allocated but never handed to GXF. cudaFree is correct for both
+    // allocation strategies: it is legal on stream-ordered pool memory and returns it to the pool.
+    void freeUnpublished(void * dev) const
+    {
+        if (dev) {
+            cudaFree(dev);
+        }
+    }
+};
+
+NitrosImagePublisher::NitrosImagePublisher(
+    rclcpp::Node * node, const std::string & topic, const std::string & nitros_format)
+: _impl(std::make_unique<Impl>())
+{
+    // ManagedNitrosPublisher performs REP-2007/2009 type negotiation internally; we only
+    // choose the compatible data format (e.g. "nitros_image_rgb8").
+    _impl->pub = std::make_shared<ManagedNitrosPublisher<NitrosImage>>(node, topic, nitros_format);
+
+    // A non-blocking stream keeps our copy out of the legacy default stream, which librealsense's
+    // own CUDA work (alignment, colorizer) uses. It is created at the highest priority the device
+    // offers: the frame cannot be published until this copy lands, so a short copy waiting behind a
+    // consumer's long-running kernels directly delays the whole graph.
+    int lowest_priority = 0, highest_priority = 0;
+    cudaError_t err = cudaDeviceGetStreamPriorityRange(&lowest_priority, &highest_priority);
+    if (err != cudaSuccess) {
+        highest_priority = 0;
+    }
+    err = cudaStreamCreateWithPriority(&_impl->stream, cudaStreamNonBlocking, highest_priority);
+    if (err != cudaSuccess) {
+        RCLCPP_WARN(
+            logger(), "cudaStreamCreateWithPriority failed: %s; falling back to the default stream",
+            cudaGetErrorString(err));
+        _impl->stream = nullptr;
+    }
+    err = cudaEventCreateWithFlags(&_impl->copy_done, cudaEventDisableTiming);
+    if (err != cudaSuccess) {
+        RCLCPP_WARN(
+            logger(), "cudaEventCreateWithFlags failed: %s; will synchronize on the stream instead",
+            cudaGetErrorString(err));
+        _impl->copy_done = nullptr;
+    }
+
+#if RS_NITROS_HAS_MEMPOOL
+    if (legacyAllocRequested()) {
+        RCLCPP_INFO(logger(), "RS_NITROS_LEGACY_ALLOC=1: using cudaMalloc/cudaFree per frame");
+    } else {
+        cudaMemPoolProps props{};
+        props.allocType = cudaMemAllocationTypePinned;
+        props.handleTypes = cudaMemHandleTypeNone;
+        props.location.type = cudaMemLocationTypeDevice;
+        props.location.id = 0;
+        err = cudaMemPoolCreate(&_impl->pool, &props);
+        if (err != cudaSuccess) {
+            RCLCPP_WARN(
+                logger(), "cudaMemPoolCreate failed: %s; falling back to cudaMalloc per frame",
+                cudaGetErrorString(err));
+            _impl->pool = nullptr;
+        } else {
+            // Never hand pages back to the driver: the pool should keep serving the same few
+            // frame-sized blocks for the lifetime of the stream.
+            uint64_t release_threshold = UINT64_MAX;
+            err = cudaMemPoolSetAttribute(
+                _impl->pool, cudaMemPoolAttrReleaseThreshold, &release_threshold);
+            if (err != cudaSuccess) {
+                RCLCPP_WARN(
+                    logger(), "cudaMemPoolSetAttribute(ReleaseThreshold) failed: %s",
+                    cudaGetErrorString(err));
+            }
+        }
+    }
+#else
+    RCLCPP_INFO(logger(), "CUDA < 11.2: using cudaMalloc/cudaFree per frame");
+#endif
+}
+
+NitrosImagePublisher::~NitrosImagePublisher()
+{
+    if (_impl->stream) {
+        cudaStreamSynchronize(_impl->stream);
+    }
+    if (_impl->copy_done) {
+        cudaEventDestroy(_impl->copy_done);
+    }
+    if (_impl->stream) {
+        cudaStreamDestroy(_impl->stream);
+    }
+#if RS_NITROS_HAS_MEMPOOL
+    if (_impl->pool) {
+        // Safe with buffers still in flight: the pool's resources are released once the last
+        // outstanding allocation is freed.
+        cudaMemPoolDestroy(_impl->pool);
+    }
+#endif
+}
+
+void NitrosImagePublisher::publish(
+    const void * gpu_src,
+    uint32_t width,
+    uint32_t height,
+    size_t size_bytes,
+    const std::string & encoding,
+    const std_msgs::msg::Header & header)
+{
+    const auto t_start = std::chrono::steady_clock::now();
+    auto t_alloc = t_start, t_wait = t_start;
+
+    // GXF will cudaFree() this buffer once downstream is done with it, so it must be a buffer we
+    // own rather than the SDK's frame-pool memory.
+    void * dev = nullptr;
+    cudaError_t err = cudaSuccess;
+#if RS_NITROS_HAS_MEMPOOL
+    if (_impl->pooled()) {
+        err = cudaMallocFromPoolAsync(&dev, size_bytes, _impl->pool, _impl->stream);
+    } else {
+        err = cudaMalloc(&dev, size_bytes);
+    }
+#else
+    err = cudaMalloc(&dev, size_bytes);
+#endif
+    if (err != cudaSuccess) {
+        RCLCPP_WARN(
+            logger(), "device allocation of %zu bytes failed: %s; dropping NITROS frame",
+            size_bytes, cudaGetErrorString(err));
+        return;
+    }
+
+    t_alloc = std::chrono::steady_clock::now();
+
+    // Device-to-device copy from the frame's GPU pixels (cudaMemcpyDefault lets UVA resolve the
+    // source, which is device-mapped pinned host memory on a zero-copy build).
+    err = cudaMemcpyAsync(dev, gpu_src, size_bytes, cudaMemcpyDefault, _impl->stream);
+    if (err != cudaSuccess) {
+        RCLCPP_WARN(
+            logger(), "cudaMemcpyAsync(%zu) failed: %s; dropping NITROS frame",
+            size_bytes, cudaGetErrorString(err));
+        _impl->freeUnpublished(dev);
+        return;
+    }
+
+    // release-3.2's NitrosImage carries no CUDA event, so a downstream process has no way to order
+    // its kernels after our copy: the copy has to be complete before the message goes out.
+    if (_impl->copy_done) {
+        err = cudaEventRecord(_impl->copy_done, _impl->stream);
+        if (err == cudaSuccess) {
+            err = cudaEventSynchronize(_impl->copy_done);
+        }
+    } else {
+        err = cudaStreamSynchronize(_impl->stream);
+    }
+    if (err != cudaSuccess) {
+        RCLCPP_WARN(
+            logger(), "waiting for the D2D copy failed: %s; dropping NITROS frame",
+            cudaGetErrorString(err));
+        _impl->freeUnpublished(dev);
+        return;
+    }
+
+    t_wait = std::chrono::steady_clock::now();
+
+    std::optional<NitrosImage> img;
+    try {
+        img.emplace(
+            NitrosImageBuilder()
+            .WithHeader(header)
+            .WithEncoding(encoding)
+            .WithDimensions(height, width)
+            .WithGpuData(dev)   // ownership transfers to GXF (frees via cudaFree on release)
+            .Build());
+    } catch (const std::exception & e) {
+        // Build() throws (e.g. odd dimensions / unsupported encoding) before taking ownership, so
+        // the buffer is still ours to free. Note the catch deliberately covers Build() only: once
+        // Build() has returned, GXF owns the buffer and freeing it here would be a double free.
+        _impl->freeUnpublished(dev);
+        RCLCPP_WARN(logger(), "NitrosImage Build failed: %s", e.what());
+        return;
+    }
+    _impl->pub->publish(std::move(*img));
+
+    const auto t_end = std::chrono::steady_clock::now();
+    const double us = std::chrono::duration<double, std::micro>(t_end - t_start).count();
+    _impl->us_sum += us;
+    _impl->us_max = std::max(_impl->us_max, us);
+    _impl->alloc_us_sum += std::chrono::duration<double, std::micro>(t_alloc - t_start).count();
+    _impl->wait_us_sum += std::chrono::duration<double, std::micro>(t_wait - t_alloc).count();
+    _impl->build_us_sum += std::chrono::duration<double, std::micro>(t_end - t_wait).count();
+    if (++_impl->frames % STATS_LOG_INTERVAL == 0) {
+        const double n = static_cast<double>(STATS_LOG_INTERVAL);
+        // How much memory the pool is holding tells us whether GXF is releasing our buffers
+        // promptly: reserved should settle at a few frames' worth, not keep climbing.
+        double reserved_mb = 0.0, used_mb = 0.0;
+#if RS_NITROS_HAS_MEMPOOL
+        if (_impl->pool) {
+            uint64_t reserved = 0, used = 0;
+            cudaMemPoolGetAttribute(_impl->pool, cudaMemPoolAttrReservedMemCurrent, &reserved);
+            cudaMemPoolGetAttribute(_impl->pool, cudaMemPoolAttrUsedMemCurrent, &used);
+            reserved_mb = static_cast<double>(reserved) / (1024.0 * 1024.0);
+            used_mb = static_cast<double>(used) / (1024.0 * 1024.0);
+        }
+#endif
+        RCLCPP_DEBUG(
+            logger(),
+            "%s publish cost over %.0f frames: mean %.1f us (alloc %.1f, copy-wait %.1f, build %.1f), "
+            "max %.1f us; pool reserved %.1f MB, in use %.1f MB",
+            _impl->pooled() ? "pooled" : "cudaMalloc", n, _impl->us_sum / n,
+            _impl->alloc_us_sum / n, _impl->wait_us_sum / n, _impl->build_us_sum / n,
+            _impl->us_max, reserved_mb, used_mb);
+        _impl->us_sum = 0.0;
+        _impl->us_max = 0.0;
+        _impl->alloc_us_sum = 0.0;
+        _impl->wait_us_sum = 0.0;
+        _impl->build_us_sum = 0.0;
+    }
+}
+}  // namespace realsense2_camera
+
+#endif  // BUILD_WITH_NITROS

--- a/realsense2_camera/src/parameters.cpp
+++ b/realsense2_camera/src/parameters.cpp
@@ -91,6 +91,14 @@ void BaseRealSenseNode::getParameters()
     _tf_prefix = _parameters->setParam<std::string>(param_name, "");
     _parameters_names.push_back(param_name);
 
+#ifdef BUILD_WITH_NITROS
+    // Enable NITROS-native GPU zero-copy publishing of the color stream (Jetson / Isaac ROS).
+    // Read once at construction (publisher creation happens in rs_node_setup); default off.
+    param_name = std::string("enable_color_nitros");
+    _enable_color_nitros = _parameters->setParam<bool>(param_name, false);
+    _parameters_names.push_back(param_name);
+#endif
+
 #if defined (ACCELERATE_GPU_WITH_GLSL)
     param_name = std::string("accelerate_gpu_with_glsl");
      _parameters->setParam<bool>(param_name, false, 

--- a/realsense2_camera/src/rs_node_setup.cpp
+++ b/realsense2_camera/src/rs_node_setup.cpp
@@ -300,6 +300,30 @@ void BaseRealSenseNode::startPublishers(const std::vector<stream_profile>& profi
                 }
                 #endif
 
+#ifdef BUILD_WITH_NITROS
+                // Additive NITROS-native GPU zero-copy publisher for the color stream.
+                if (_enable_color_nitros && profile.stream_type() == RS2_STREAM_COLOR)
+                {
+                    std::string nitros_format, encoding;
+                    unsigned int bpp = 0;
+                    if (getNitrosImageFormat(profile.format(), nitros_format, encoding, bpp))
+                    {
+                        std::stringstream nitros_topic;
+                        nitros_topic << "~/" << stream_name << "/nitros_image";
+                        _nitros_image_publishers[sip] =
+                            std::make_shared<NitrosImagePublisher>(&_node, nitros_topic.str(), nitros_format);
+                        ROS_INFO_STREAM("NITROS color publisher created on topic " << nitros_topic.str()
+                                        << " (format " << nitros_format << ")");
+                    }
+                    else
+                    {
+                        ROS_WARN_STREAM("NITROS color publishing requested but format "
+                                        << rs2_format_to_string(profile.format())
+                                        << " is not supported; skipping NITROS for this stream.");
+                    }
+                }
+#endif
+
                 // create cameraInfo publishers only for non-SC streams
                 if(shouldPublishCameraInfo(sip))
                 {


### PR DESCRIPTION
Add optional NITROS (GPU zero-copy) color publishing
Opt-in path to publish the color stream to an Isaac ROS / NITROS graph on the GPU, skipping the sensor_msgs/Image → DDS → cudaMemcpy round-trip. Additive and gated — default builds and ~/color/image_raw are unchanged. (RSDEV-6254)

What's new
nitros_image_publisher.{h,cpp} — wraps ManagedNitrosPublisher<NitrosImage>; publishes on ~/color/nitros_image.
publishNitrosFrame() hooked into publishFrame(); enable_color_nitros param (default off).
CMake BUILD_WITH_NITROS option (default OFF) → finds/links CUDA + isaac_ros_nitros packages.
Enable
colcon build --packages-select realsense2_camera_msgs realsense2_camera \
  --cmake-args -DBUILD_WITH_NITROS=ON
ros2 run realsense2_camera realsense2_camera_node --ros-args -p enable_color_nitros:=true
Needs an Isaac ROS workspace + librealsense built with BUILD_WITH_CUDA_ZEROCOPY.

