### PR TITLE
Fix realsense driver deadlock when quickly toggling stream parameters

### DIFF
--- a/realsense2_camera/src/rs_node_setup.cpp
+++ b/realsense2_camera/src/rs_node_setup.cpp
@@ -62,6 +62,14 @@ void BaseRealSenseNode::monitoringProfileChanges()
                                 ))
             {
                 ROS_DEBUG("Profile has changed");
+                _is_profile_changed = false;
+                _is_align_depth_changed = false;
+
+                #if defined (ACCELERATE_GPU_WITH_GLSL)
+                    _is_accelerate_gpu_with_glsl_changed = false;
+                #endif
+
+                lock.unlock();
                 try
                 {
                     updateSensors();
@@ -70,12 +78,7 @@ void BaseRealSenseNode::monitoringProfileChanges()
                 {
                     ROS_ERROR_STREAM("Error updating the sensors: " << e.what());
                 }
-                _is_profile_changed = false;
-                _is_align_depth_changed = false;
-
-                #if defined (ACCELERATE_GPU_WITH_GLSL)
-                    _is_accelerate_gpu_with_glsl_changed = false;
-                #endif
+                lock.lock();
             }
         }
     };


### PR DESCRIPTION
**Context**

We want to be able to toggle the camera stream off and on to save system resources. In the ROS 2 version of the realsense driver, this is done by toggling the associated ROS parameters.
Issue
I found that if you toggle ROS parameters for different streams within a certain time of each other the driver will hang and never recover.

**Root Cause**

This appears to be because each parameter change triggers a "profile changed update". There is a mutex protected boolean flag and a condition variable that triggers the update in a separate thread.
When the "monitoring profile change" thread update, it makes a call to updateSensors(). This updates the underlying sensor configuration using via librealsense. This has it's own lock that is acquired. This update can take hundreds to milliseconds to over a second. While this is happening the profile change mutex is still being held. So another parameter change coming along can't acquire the lock.
Admittedly I'm not entirely sure why it never recovers but that is the observed behaviour. In the mix here there is also the built in parameter service waiting for the lock and the ROS 2 api doesn't really give you a good/clear timeout callback/return. In addition to this the realsense driver parameter are dynamic and base on different camera models. So it's hard to trace the exact flow of callbacks.

**Solution**

The solution here is to reset the profile change flags once entering the if branch. Then unlock/lock around the call to updateSensors. This unblocks incoming parameter updates while the sensor profile is updating. These are just boolean flags, so there's no queuing required. It'll just see an update required and update the sensors.