### PR TITLE
Occupancy: publish camera-computed grid + ~/occupancy_certainty; remove host-side raycasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,11 +538,12 @@ User can set the camera name and camera namespace, to distinguish between camera
 - **clip_distance**:
   - Remove from the depth image all values above a given value (meters). Disable by giving negative value (default)
   - For example: `clip_distance:=1.5`
-- **occupancy_max_range**:
-  - Maximum reliable range (meters) for the occupancy grid raycasting. Cells beyond this distance are published as unknown (-1) rather than free, since the absence of a detection there is not evidence of free space.
-  - Defaults to 2.5. Set to 0 or a negative value to use the full grid extent.
-  - For example: `occupancy_max_range:=3.0`
-  - Relevant only when the occupancy stream is enabled (`enable_occupancy:=true`); requires the depth stream for its intrinsics.
+- **occupancy_occupied_threshold**:
+  - Cameras that stream a graded occupancy grid (evidence 1..100 per cell) are binarized for `~/occupancy` at this value: cells at or above it publish as 100, graded cells below it as -1 (unknown). The raw graded grid is always available on `~/occupancy_certainty`.
+  - Default: 100 (the camera's own safety criterion). Range [1, 100].
+  - Has no effect on devices that stream the legacy 1-bit grid.
+  - Read once at startup; a runtime `ros2 param set` does not take effect.
+  - The node auto-detects which of three occupancy grid wire formats an incoming frame carries -- the legacy 1-bit grid, a byte-per-cell graded grid (newer D5xx firmware), or a self-describing MAP1 payload -- with no SDK version requirement beyond occupancy stream support. `~/occupancy_certainty` is published for the byte-per-cell and MAP1 formats; the legacy 1-bit format publishes `~/occupancy` only.
 - **linear_accel_cov**, **angular_velocity_cov**: sets the variance given to the Imu readings.
 - **hold_back_imu_for_frames**: Images processing takes time. Therefor there is a time gap between the moment the image arrives at the wrapper and the moment the image is published to the ROS environment. During this time, Imu messages keep on arriving and a situation is created where an image with earlier timestamp is published after Imu message with later timestamp. If that is a problem, setting *hold_back_imu_for_frames* to *true* will hold the Imu messages back while processing the images and then publish them all in a burst, thus keeping the order of publication as the order of arrival. Note that in either case, the timestamp in each message's header reflects the time of it's origin.
 - **publish_tf**:

--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -450,6 +450,13 @@ if(BUILD_TESTING)
     endforeach()
   endforeach()
 
+  # Unit tests for occupancy grid utilities
+  ament_add_gtest(test_occupancy_grid_utils test/unit/test_occupancy_grid_utils.cpp)
+  target_include_directories(test_occupancy_grid_utils PRIVATE include)
+
+  # Unit tests for the MAP1 self-describing occupancy payload parser
+  ament_add_gtest(test_occupancy_map1 test/unit/test_occupancy_map1.cpp)
+  target_include_directories(test_occupancy_map1 PRIVATE include)
 
   find_package(ament_cmake_pytest REQUIRED)
   set(_pytest_folders

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -17,6 +17,7 @@
 #include <librealsense2/rs.hpp>
 #include <librealsense2/rsutil.h>
 #include "constants.h"
+#include "occupancy_map1.h"
 
 // cv_bridge.h last supported version is humble
 #if defined(CV_BRDIGE_HAS_HPP)
@@ -273,6 +274,7 @@ namespace realsense2_camera
         void publishDynamicTransforms();
         void publishPointCloud(rs2::points f, const rclcpp::Time& t, const rs2::frameset& frameset);
         void publishOccupancyFrame(rs2::frame f, const rclcpp::Time& t);
+        void publishOccupancyFromMap1(const map1::occg_view& view, const rclcpp::Time& t);
         void publishLabeledPointCloud(rs2::labeled_points lpc, const rclcpp::Time& t);
         bool shouldPublishCameraInfo(const stream_index_pair& sip);
         Extrinsics rsExtrinsicsToMsg(const rs2_extrinsics& extrinsics) const;
@@ -350,7 +352,7 @@ namespace realsense2_camera
         std::string _json_file_path;
         float _depth_scale_meters;
         float _clipping_distance;
-        float _occupancy_max_range;
+        int   _occupancy_occupied_threshold;
 
         double _linear_accel_cov;
         double _angular_velocity_cov;
@@ -373,6 +375,7 @@ namespace realsense2_camera
         std::map<stream_index_pair, std::shared_ptr<image_publisher>> _image_publishers;
         rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr _labeled_pointcloud_publisher;
         rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr _occupancy_publisher;
+        rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr _occupancy_certainty_publisher;
         std::map<stream_index_pair, rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr> _imu_publishers;
         std::shared_ptr<SyncedImuPublisher> _synced_imu_publisher;
         std::map<stream_index_pair, rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr> _info_publishers;

--- a/realsense2_camera/include/occupancy_grid_utils.h
+++ b/realsense2_camera/include/occupancy_grid_utils.h
@@ -1,0 +1,45 @@
+// Copyright 2026 RealSense, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <cstdint>
+#include <cstddef>
+#include <vector>
+
+namespace realsense2_camera {
+namespace occupancy {
+
+// MAP1 cell ladder -> the two published data arrays (see file docs in the PR).
+// Values in [1, occupied_threshold) publish as unknown on the binary grid:
+// evidence exists, so "free" would be false, but the bar for "occupied" is not
+// met -- unknown is the only honest value.
+inline void splitCells(const int8_t* cells, size_t n, int8_t occupied_threshold,
+                       std::vector<int8_t>& occupancy_out,
+                       std::vector<int8_t>& certainty_out)
+{
+    occupancy_out.resize(n);
+    certainty_out.resize(n);
+    for (size_t i = 0; i < n; ++i)
+    {
+        const int8_t v = cells[i];
+        certainty_out[i] = v;
+        if (v <= 0)
+            occupancy_out[i] = v;                       // -1 unknown, 0 free
+        else
+            occupancy_out[i] = (v >= occupied_threshold) ? int8_t{100} : int8_t{-1};
+    }
+}
+
+}  // namespace occupancy
+}  // namespace realsense2_camera

--- a/realsense2_camera/include/occupancy_map1.h
+++ b/realsense2_camera/include/occupancy_map1.h
@@ -1,0 +1,143 @@
+// Copyright 2026 RealSense, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Self-contained, header-only parser for the MAP1 self-describing occupancy-grid
+// wire format (librealsense#15557 / device-mgr interface/MappingEp12.h). Ported
+// from the reviewed implementation in librealsense
+// (src/proc/occupancy-map1.h/.cpp, branch niv/occupancy-map1-consume) with the
+// same semantics; this copy has no dependency on librealsense internals
+// (rsutils, synthetic-stream, metadata-parser) -- the ROS node discriminates the
+// MAP1 payload purely by its bytes, not by SDK-side metadata/enums.
+
+#pragma once
+#include <cstdint>
+#include <cstddef>
+#include <cstring>
+
+namespace realsense2_camera {
+namespace map1 {
+
+#pragma pack(push, 1)
+struct frame_header {
+    uint32_t magic;              // 0x3150414D "MAP1"
+    uint16_t version;
+    uint8_t  data_type;          // 2 = occupancy grid
+    uint8_t  flags;              // bit 0: crc32 field is valid
+    uint32_t payload_size;
+    uint16_t profile_id;
+    uint16_t stream_generation;
+    uint32_t crc32;              // CRC-32/ISO-HDLC over payload_size bytes
+};
+struct occg_header {
+    uint16_t width;              // cells along +X (forward)
+    uint16_t height;             // cells along +Y (left); camera at height/2
+    uint16_t resolution_mm;
+    uint16_t cell_stride;
+    int32_t  origin_x_mm;
+    int32_t  origin_y_mm;
+    uint32_t source_frame_id;
+    uint64_t timestamp_us;
+    uint32_t cell_count;
+};
+#pragma pack(pop)
+static_assert(sizeof(frame_header) == 20, "MAP1 frame header ABI");
+static_assert(sizeof(occg_header) == 32, "MAP1 OCCG header ABI");
+
+constexpr uint32_t MAGIC = 0x3150414DU;
+constexpr uint8_t DATA_TYPE_OCCG = 2U;
+constexpr uint8_t FLAG_CRC32 = 1U;
+
+enum class parse_result { ok, not_map1, not_occg, truncated, bad_crc, bad_geometry, bad_version };
+
+struct occg_view {
+    occg_header header;
+    const int8_t* cells;
+};
+
+inline bool is_map1(const uint8_t* data, size_t size)
+{
+    if (data == nullptr || size < sizeof(frame_header)) return false;
+    uint32_t magic;
+    std::memcpy(&magic, data, sizeof(magic));
+    return magic == MAGIC;
+}
+
+// CRC-32/ISO-HDLC (poly 0xEDB88320, reflected, init/xorout 0xFFFFFFFF) -- same
+// algorithm/result as the standard zlib CRC-32. Table-free bit-at-a-time loop
+// (no dependency on librealsense's rsutils table implementation); mathematically
+// identical output for the same input.
+inline uint32_t crc32_iso_hdlc(const void* data, size_t size)
+{
+    uint32_t crc = 0xFFFFFFFFu;
+    const uint8_t* p = static_cast<const uint8_t*>(data);
+    for (size_t i = 0; i < size; ++i)
+    {
+        crc ^= p[i];
+        for (int bit = 0; bit < 8; ++bit)
+        {
+            const uint32_t mask = static_cast<uint32_t>(-static_cast<int32_t>(crc & 1u));
+            crc = (crc >> 1) ^ (0xEDB88320u & mask);
+        }
+    }
+    return ~crc;
+}
+
+inline parse_result parse_occg(const uint8_t* data, size_t size, occg_view* out)
+{
+    if (!is_map1(data, size)) return parse_result::not_map1;
+    frame_header fh;
+    std::memcpy(&fh, data, sizeof(fh));
+    if (fh.data_type != DATA_TYPE_OCCG) return parse_result::not_occg;
+    // Accept any minor revision of major version 1 (0x01xx); reject anything else
+    // (e.g. a future incompatible 0x02xx) rather than silently misinterpreting the
+    // rest of the frame under this struct layout.
+    if ((fh.version >> 8) != 0x01) return parse_result::bad_version;
+    // Widen to uint64_t before adding: fh.payload_size / oh.cell_count are
+    // device-controlled uint32_t values, and on a 32-bit size_t build
+    // `sizeof(...) + <uint32_t>` could wrap around and bypass these checks.
+    if ((uint64_t)size < (uint64_t)sizeof(fh) + fh.payload_size ||
+        fh.payload_size < sizeof(occg_header))
+        return parse_result::truncated;
+    const uint8_t* payload = data + sizeof(fh);
+    // Production occupancy (data_type OCCG) frames are expected to set FLAG_CRC32.
+    // When it is clear the CRC is skipped and the frame is trusted on the geometry/size
+    // checks below alone: a payload bit-flip then goes undetected, but still cannot
+    // overflow a consumer buffer (the cell_count cross-check guarantees that).
+    if ((fh.flags & FLAG_CRC32) &&
+        crc32_iso_hdlc(payload, fh.payload_size) != fh.crc32)
+        return parse_result::bad_crc;
+    occg_header oh;
+    std::memcpy(&oh, payload, sizeof(oh));
+    if ((uint64_t)fh.payload_size < (uint64_t)sizeof(oh) + oh.cell_count)
+        return parse_result::truncated;
+    // A zero-sized grid or an unsupported cell layout (cell_stride is currently
+    // always 1 per the wire spec; any other value means a layout this parser
+    // doesn't know how to interpret) are both malformed geometry.
+    if (oh.width == 0 || oh.height == 0 || oh.cell_stride != 1)
+        return parse_result::bad_geometry;
+    // width/height/cell_count are independently device-controlled fields; without
+    // this check a frame with a small width/height (small allocated destination
+    // buffer) and a large cell_count (large memcpy length) passes every check
+    // above -- especially with FLAG_CRC32 clear, where the CRC never runs -- and
+    // overflows whatever fixed-size buffer a consumer sized from width*height.
+    // width,height <= 0xFFFF so the product fits in uint32_t without overflow.
+    if (oh.cell_count != (uint32_t)oh.width * (uint32_t)oh.height)
+        return parse_result::bad_geometry;
+    out->header = oh;
+    out->cells = reinterpret_cast<const int8_t*>(payload + sizeof(oh));
+    return parse_result::ok;
+}
+
+}  // namespace map1
+}  // namespace realsense2_camera

--- a/realsense2_camera/launch/rs_launch.py
+++ b/realsense2_camera/launch/rs_launch.py
@@ -68,7 +68,7 @@ configurable_parameters = [{'name': 'camera_name',                  'default': '
                            {'name': 'motion_fps',                   'default': '0', 'description': "'motion stream samples per second'"},
                            {'name': 'unite_imu_method',             'default': "0", 'description': '[0-None, 1-copy, 2-linear_interpolation]'},
                            {'name': 'clip_distance',                'default': '-2.', 'description': "''"},
-                           {'name': 'occupancy_max_range',          'default': '2.5', 'description': "'max reliable range for occupancy raycasting in meters; cells beyond this are unknown (-1)'"},
+                           {'name': 'occupancy_occupied_threshold',  'default': '100', 'description': "'binarization threshold [1-100] for graded occupancy cells on ~/occupancy; the raw graded grid is always on ~/occupancy_certainty'"},
                            {'name': 'angular_velocity_cov',         'default': '0.01', 'description': "''"},
                            {'name': 'linear_accel_cov',             'default': '0.01', 'description': "''"},
                            {'name': 'diagnostics_period',           'default': '0.0', 'description': 'Rate of publishing diagnostics. 0=Disabled'},

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -27,6 +27,8 @@
 #include <tf2_ros/qos.hpp>
 #include "pointcloud_filter.h"
 #include "align_depth_filter.h"
+#include "occupancy_grid_utils.h"
+#include "occupancy_map1.h"
 
 using namespace realsense2_camera;
 
@@ -104,7 +106,7 @@ BaseRealSenseNode::BaseRealSenseNode(RosNodeBase& node,
     _json_file_path(""),
     _depth_scale_meters(0),
     _clipping_distance(0),
-    _occupancy_max_range(0),
+    _occupancy_occupied_threshold(100),
     _linear_accel_cov(0),
     _angular_velocity_cov(0),
     _hold_back_imu_for_frames(false),
@@ -920,28 +922,72 @@ bool BaseRealSenseNode::shouldPublishCameraInfo(const stream_index_pair& sip)
 
 void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& t)
 {
-    if(!_occupancy_publisher || 0 == _occupancy_publisher->get_subscription_count())
+    const bool occ_wanted = _occupancy_publisher && 0 != _occupancy_publisher->get_subscription_count();
+    const bool cert_wanted = _occupancy_certainty_publisher &&
+                             0 != _occupancy_certainty_publisher->get_subscription_count();
+    if (!occ_wanted && !cert_wanted)
         return;
 
-    ROS_DEBUG("Publishing Occupancy Grid Frame");
-
-    // Horizontal FOV from depth intrinsics: tan(half_hfov) = (width/2) / fx.
-    // The FOV mask and ray binning are meaningless without it - drop the frame
-    // rather than publish a grid built on incomplete information.
-    const auto depth_info_it = _camera_info.find(DEPTH);
-    if (depth_info_it == _camera_info.end() || depth_info_it->second.k.at(0) <= 0.0
-        || depth_info_it->second.width == 0)
+    // Self-describing MAP1 payloads (D5xx safety-streams FW, librealsense#15557)
+    // are discriminated purely by their own bytes (magic + data_type) - the SDK
+    // no longer exposes origin metadata/enums for this. A frame tagged MAP1 that
+    // fails to parse (bad CRC, truncated, bad geometry/version, ...) must never
+    // fall through to the legacy unpack below: those wire bytes are not a
+    // bit/byte grid and misinterpreting them would feed garbage into a costmap.
+    auto* raw_data = static_cast<const uint8_t*>(f.get_data());
+    const size_t raw_size = static_cast<size_t>(f.get_data_size());
+    if (raw_data == nullptr)
     {
-        ROS_WARN("Occupancy grid not published: depth stream intrinsics are not available");
+        return;   // no payload to read - guards is_map1 and both legacy paths below
+    }
+    if (map1::is_map1(raw_data, raw_size))
+    {
+        map1::occg_view view{};
+        const auto r = map1::parse_occg(raw_data, raw_size, &view);
+        if (r != map1::parse_result::ok)
+        {
+            // Throttled (not _ONCE): a validation failure that begins mid-run must stay
+            // visible, but a persistently bad stream must not spam the log.
+            RCLCPP_WARN_THROTTLE(_logger, *_node.get_clock(), 5000,
+                                 "MAP1 occupancy frame failed validation (parse_result=%d) - dropped",
+                                 static_cast<int>(r));
+            return;
+        }
+        // MAP1 cells arrive already in nav_msgs row-major order (data[y*width+x], +X forward
+        // along width, +Y left), so publishOccupancyFromMap1 copies them straight through --
+        // unlike the legacy paths below, which relayout fw_row/fw_col. The self-describing
+        // wire format owns the axis convention; HW-validated on D555.
+        publishOccupancyFromMap1(view, t);
         return;
     }
-    const float tan_half_hfov = (static_cast<float>(depth_info_it->second.width) * 0.5f)
-                                / static_cast<float>(depth_info_it->second.k.at(0));
 
-    auto frame_as_uint8_arr = (uint8_t*)f.get_data();
+    // Per-frame trace, kept at DEBUG (off by default) but throttled so it does not
+    // log every frame even when debug logging is enabled, matching the MAP1 path.
+    RCLCPP_DEBUG_THROTTLE(_logger, *_node.get_clock(), 5000, "Publishing Occupancy Grid Frame (legacy path)");
+
     auto cols = static_cast<int>(f.get_frame_metadata(RS2_FRAME_METADATA_OCCUPANCY_GRID_COLUMNS));
     auto rows = static_cast<int>(f.get_frame_metadata(RS2_FRAME_METADATA_OCCUPANCY_GRID_ROWS));
     auto cell_size = static_cast<float>(f.get_frame_metadata(RS2_FRAME_METADATA_OCCUPANCY_CELL_SIZE)) / 100.0f; // cm -> m
+    if (rows <= 0 || cols <= 0)
+    {
+        // Guard the geometry before it is used: a zero or negative rows/cols would
+        // otherwise size the grid below (or wrap when cast to size_t) and publish an
+        // empty/garbage grid; drop the frame instead.
+        RCLCPP_WARN_THROTTLE(_logger, *_node.get_clock(), 5000,
+                             "Occupancy frame reported %dx%d cells - dropped", rows, cols);
+        return;
+    }
+    // rows, cols are positive but device-controlled int metadata (the legacy path,
+    // unlike MAP1, does not cap them at 0xFFFF), so on a 32-bit size_t their product
+    // can wrap. Reject that before a wrapped n under-sizes nav_cells / msg.data while
+    // the loops below still index the full rows*cols geometry.
+    if (static_cast<size_t>(rows) > SIZE_MAX / static_cast<size_t>(cols))
+    {
+        RCLCPP_WARN_THROTTLE(_logger, *_node.get_clock(), 5000,
+                             "Occupancy frame geometry %dx%d overflows size_t - dropped", rows, cols);
+        return;
+    }
+    const size_t n = static_cast<size_t>(rows) * static_cast<size_t>(cols);
 
     nav_msgs::msg::OccupancyGrid msg;
     msg.header.stamp = t;
@@ -963,95 +1009,121 @@ void BaseRealSenseNode::publishOccupancyFrame(rs2::frame f, const rclcpp::Time& 
     msg.info.origin.position.z = 0.0;
     msg.info.origin.orientation.w = 1.0;
 
-    // data[row_idx * width + col_idx]: 0 = free, 100 = occupied, -1 = unknown.
-    // Firmware row 0 is the farthest row and col 0 the leftmost, so both
-    // indices are flipped when writing into the message.
-    // Cells are traced along rays grouped by angle (theta = atan2(y, x)),
-    // nearest to farthest: free until the first obstacle, occupied at it,
-    // unknown behind it.
-    msg.data.assign(rows * cols, -1);
-
     const auto width = msg.info.width;
 
-    const float half_fov_rad = std::atan(tan_half_hfov);
-    const float fov_span = 2.0f * half_fov_rad; // total angular window covered by the bins
-
-    // Full grid extent, unless limited by occupancy_max_range.
-    const float x_far = (static_cast<float>(rows) - 0.5f) * cell_size;
-    const float max_range = (_occupancy_max_range > 0.0f) ? _occupancy_max_range : x_far;
-
-    // Enough angular bins to resolve one cell width at the farthest depth.
-    const int N_bins = std::max(cols,
-        static_cast<int>(std::ceil(x_far * fov_span / cell_size)) + 1);
-
-    // Rows are scanned nearest-first while bin_occluded tracks which rays are
-    // already blocked. Occlusion is applied only after a row completes, so cells
-    // at the same depth never shadow each other.
-    // uint8_t rather than bool to avoid vector<bool>'s bit-proxy overhead.
-    std::vector<uint8_t> bin_occluded(N_bins, 0);
-    std::vector<std::pair<int,float>> pending;  // (bin, x) of this row's obstacles
-    pending.reserve(cols);
-
-    for (int fw_row = rows - 1; fw_row >= 0; --fw_row)
+    // Size sniff: new D585S FW streams one signed byte per cell (byte-legacy,
+    // -1/0/1..100 - carries the same certainty ladder as MAP1, just without the
+    // self-describing header); older FW still streams a plain 1-bit grid
+    // (bit-legacy, occupied/free only). Both firmware layouts share the same
+    // fw_row/fw_col double axis flip below; only the source element width differs.
+    // The byte/bit discrimination relies on the transport reporting the exact payload
+    // size: a byte grid is n bytes, a bit grid ceil(n/8) < n. A bit frame delivered in an
+    // over-allocated (>= n) buffer would be misread here as byte-legacy.
+    if (raw_size >= n)
     {
-        const float x = (static_cast<float>(rows - fw_row) - 0.5f) * cell_size;
-        // Rows are scanned nearest-first, so past max_range every remaining row
-        // is also beyond it: stop, leaving them unknown.
-        if (x > max_range) break;
-
-        pending.clear();
-
-        for (int fw_col = 0; fw_col < cols; ++fw_col)
+        // Byte-legacy: certainty is available here too, unlike the bit path.
+        const int8_t* fw_cells = reinterpret_cast<const int8_t*>(raw_data);
+        std::vector<int8_t> nav_cells(n);
+        for (int fw_row = 0; fw_row < rows; ++fw_row)
         {
-            // Symmetric about the camera axis, consistent with origin.y above.
-            const float y = (static_cast<float>(cols) * 0.5f -
-                             static_cast<float>(fw_col) - 0.5f) * cell_size;
-            if (std::fabs(y) >= x * tan_half_hfov) continue; // outside FOV
-
-            const float theta = std::atan2(y, x);
-            // The FOV mask above guarantees |theta| < half_fov_rad, so bin is
-            // non-negative; min() clamps the +edge (normalized == 1.0) only.
-            const int bin = std::min(
-                static_cast<int>((theta + half_fov_rad) / fov_span * static_cast<float>(N_bins)),
-                N_bins - 1);
-
-            const int i = fw_row * cols + fw_col;
-            const uint32_t og_col_idx = width - 1u - static_cast<uint32_t>(fw_row);
-            const uint32_t og_row_idx = static_cast<uint32_t>(cols) - 1u - static_cast<uint32_t>(fw_col);
-            auto& cell_out = msg.data[og_row_idx * width + og_col_idx];
-
-            // Cells are bit-packed 8 per byte, LSB first: bit (i%8) of byte (i/8)
-            // is cell i in row-major order.
-            if ((frame_as_uint8_arr[i / 8U] & (1U << (i % 8U))) != 0)
+            for (int fw_col = 0; fw_col < cols; ++fw_col)
             {
-                cell_out = 100;
-                pending.emplace_back(bin, x); // shadow is spread after the row completes
+                // size_t index math (not int rows*cols) on BOTH source and destination
+                // so device-supplied geometry cannot overflow the product before indexing,
+                // matching the bit-legacy path below.
+                const size_t src_idx = static_cast<size_t>(fw_row) * static_cast<size_t>(cols) + fw_col;
+                const uint32_t og_col_idx = width - 1u - static_cast<uint32_t>(fw_row);
+                const uint32_t og_row_idx = static_cast<uint32_t>(cols) - 1u - static_cast<uint32_t>(fw_col);
+                const size_t dst_idx = static_cast<size_t>(og_row_idx) * width + og_col_idx;
+                nav_cells[dst_idx] = fw_cells[src_idx];
             }
-            else if (!bin_occluded[bin])
-            {
-                cell_out = 0; // clear line of sight
-            }
-            // else: leave as -1 (ray blocked by a closer obstacle)
         }
 
-        // Each obstacle blocks its own bin plus the bins covered by the cell's
-        // physical width at its depth, so no ray can slip between two adjacent
-        // occupied cells. Obstacles in the nearest two rows are skipped: their
-        // footprint spans nearly the whole FOV, and a single noisy near hit
-        // would blank the entire grid.
-        for (const auto& [obs_bin, x_obs] : pending)
+        nav_msgs::msg::OccupancyGrid certainty_msg;
+        certainty_msg.header = msg.header;
+        certainty_msg.info = msg.info;
+        occupancy::splitCells(nav_cells.data(), n,
+                              static_cast<int8_t>(_occupancy_occupied_threshold),
+                              msg.data, certainty_msg.data);
+
+        if (occ_wanted)
+            _occupancy_publisher->publish(msg);
+        if (cert_wanted)
+            _occupancy_certainty_publisher->publish(certainty_msg);
+        return;
+    }
+
+    // Legacy 1-bit grids never publish certainty - nothing to do if only
+    // ~/occupancy_certainty has subscribers.
+    if (!occ_wanted)
+        return;
+
+    // Overflow-safe ceiling division: n + 7 could wrap size_t near its max (n is
+    // bounded by the guard above, but only to <= SIZE_MAX), so compute ceil(n/8)
+    // without ever forming n + 7.
+    const size_t bit_bytes = (n / 8u) + ((n % 8u != 0u) ? 1u : 0u);
+    if (raw_size < bit_bytes)
+    {
+        ROS_WARN("Legacy occupancy frame smaller than its declared grid - dropped");
+        return;
+    }
+
+    // Legacy 1-bit grids carry occupancy only; the unknown/shadow semantics
+    // moved into the camera (MapGridBuilder) and are not reconstructed here.
+    // Index math uses size_t (not int rows*cols) on both source and destination so
+    // device-supplied geometry cannot overflow the product, matching the byte path above.
+    msg.data.assign(n, 0);
+    for (int fw_row = 0; fw_row < rows; ++fw_row)
+    {
+        for (int fw_col = 0; fw_col < cols; ++fw_col)
         {
-            if (x_obs <= 2.0f * cell_size)
-                continue;
-            const int n_spread = std::max(1, static_cast<int>(std::ceil(
-                cell_size * static_cast<float>(N_bins) / (2.0f * x_obs * fov_span))));
-            for (int b = std::max(0, obs_bin - n_spread);
-                     b <= std::min(N_bins - 1, obs_bin + n_spread); ++b)
-                bin_occluded[b] = 1;
+            const size_t i = static_cast<size_t>(fw_row) * static_cast<size_t>(cols) + fw_col;
+            if ((raw_data[i / 8U] & (1U << (i % 8U))) != 0)
+            {
+                const uint32_t og_col_idx = width - 1u - static_cast<uint32_t>(fw_row);
+                const uint32_t og_row_idx = static_cast<uint32_t>(cols) - 1u - static_cast<uint32_t>(fw_col);
+                const size_t dst_idx = static_cast<size_t>(og_row_idx) * width + og_col_idx;
+                msg.data[dst_idx] = 100;
+            }
         }
     }
 
+    // occ_wanted was checked (and returned on) above - always true here.
     _occupancy_publisher->publish(msg);
+}
+
+void BaseRealSenseNode::publishOccupancyFromMap1(const map1::occg_view& view, const rclcpp::Time& t)
+{
+    RCLCPP_DEBUG_THROTTLE(_logger, *_node.get_clock(), 5000, "Publishing Occupancy Grid + Certainty (MAP1 path)");
+
+    const auto& h = view.header;
+
+    nav_msgs::msg::OccupancyGrid msg;
+    msg.header.stamp = t;
+    msg.header.frame_id = FRAME_ID(OCCUPANCY);
+    msg.info.map_load_time = t;
+    msg.info.resolution = static_cast<float>(h.resolution_mm) / 1000.0f;
+    msg.info.width  = h.width;
+    msg.info.height = h.height;
+    msg.info.origin.position.x = static_cast<double>(h.origin_x_mm) / 1000.0;
+    msg.info.origin.position.y = static_cast<double>(h.origin_y_mm) / 1000.0;
+    msg.info.origin.position.z = 0.0;
+    msg.info.origin.orientation.w = 1.0;
+
+    nav_msgs::msg::OccupancyGrid certainty_msg;
+    certainty_msg.header = msg.header;
+    certainty_msg.info = msg.info;
+
+    // FW cells are already in nav_msgs order (data[y*width + x], X forward,
+    // Y left) - no axis flipping, unlike the legacy bit-packed/byte-packed paths.
+    occupancy::splitCells(view.cells, h.cell_count,
+                          static_cast<int8_t>(_occupancy_occupied_threshold),
+                          msg.data, certainty_msg.data);
+
+    if (_occupancy_publisher && 0 != _occupancy_publisher->get_subscription_count())
+        _occupancy_publisher->publish(msg);
+    if (_occupancy_certainty_publisher && 0 != _occupancy_certainty_publisher->get_subscription_count())
+        _occupancy_certainty_publisher->publish(certainty_msg);
 }
 
 void BaseRealSenseNode::publishLabeledPointCloud(rs2::labeled_points lpc, const rclcpp::Time& t)

--- a/realsense2_camera/src/parameters.cpp
+++ b/realsense2_camera/src/parameters.cpp
@@ -66,8 +66,14 @@ void BaseRealSenseNode::getParameters()
     _clipping_distance = _parameters->setParam<double>(param_name, -1.0);
     _parameters_names.push_back(param_name);
 
-    param_name = std::string("occupancy_max_range");
-    _occupancy_max_range = static_cast<float>(_parameters->setParam<double>(param_name, 2.5));
+    param_name = std::string("occupancy_occupied_threshold");
+    _occupancy_occupied_threshold = static_cast<int>(_parameters->setParam<int>(param_name, 100));
+    if (_occupancy_occupied_threshold < 1 || _occupancy_occupied_threshold > 100)
+    {
+        ROS_WARN_STREAM("occupancy_occupied_threshold " << _occupancy_occupied_threshold
+                        << " out of [1,100]; using 100");
+        _occupancy_occupied_threshold = 100;
+    }
     _parameters_names.push_back(param_name);
 
     param_name = std::string("linear_accel_cov");

--- a/realsense2_camera/src/rs_node_setup.cpp
+++ b/realsense2_camera/src/rs_node_setup.cpp
@@ -255,6 +255,9 @@ void BaseRealSenseNode::startPublishers(const std::vector<stream_profile>& profi
                 // and not a normal image publisher
                  _occupancy_publisher = _node.create_publisher<nav_msgs::msg::OccupancyGrid>("~/occupancy",
                     rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos),qos));
+                 _occupancy_certainty_publisher = _node.create_publisher<nav_msgs::msg::OccupancyGrid>(
+                    "~/occupancy_certainty",
+                    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos), qos));
             }
             else if(profile.stream_type() == RS2_STREAM_LABELED_POINT_CLOUD)
             {

--- a/realsense2_camera/test/unit/test_occupancy_grid_utils.cpp
+++ b/realsense2_camera/test/unit/test_occupancy_grid_utils.cpp
@@ -1,0 +1,44 @@
+// Copyright 2026 RealSense, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include "occupancy_grid_utils.h"
+
+using realsense2_camera::occupancy::splitCells;
+
+TEST(SplitCells, LadderWithDefaultThreshold)
+{
+    const int8_t cells[] = {-1, 0, 1, 37, 99, 100};
+    std::vector<int8_t> occ, cert;
+    splitCells(cells, 6, 100, occ, cert);
+    EXPECT_EQ((std::vector<int8_t>{-1, 0, -1, -1, -1, 100}), occ);
+    EXPECT_EQ((std::vector<int8_t>{-1, 0, 1, 37, 99, 100}), cert);
+}
+
+TEST(SplitCells, LowerThresholdMovesTheBar)
+{
+    const int8_t cells[] = {-1, 0, 49, 50, 100};
+    std::vector<int8_t> occ, cert;
+    splitCells(cells, 5, 50, occ, cert);
+    EXPECT_EQ((std::vector<int8_t>{-1, 0, -1, 100, 100}), occ);
+}
+
+TEST(SplitCells, ReusesBuffersWithoutGrowth)
+{
+    const int8_t cells[] = {0, 0, 0};
+    std::vector<int8_t> occ(3), cert(3);
+    auto* occ_ptr = occ.data();
+    splitCells(cells, 3, 100, occ, cert);
+    EXPECT_EQ(occ_ptr, occ.data());   // hot path: no realloc when sized right
+}

--- a/realsense2_camera/test/unit/test_occupancy_map1.cpp
+++ b/realsense2_camera/test/unit/test_occupancy_map1.cpp
@@ -1,0 +1,178 @@
+// Copyright 2026 RealSense, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include "occupancy_map1.h"
+#include <cstring>
+#include <vector>
+
+using namespace realsense2_camera::map1;
+
+namespace {
+std::vector<uint8_t> make_frame(uint16_t w, uint16_t h, bool valid_crc = true,
+                                uint8_t data_type = DATA_TYPE_OCCG,
+                                uint16_t version = 0x0100, uint16_t cell_stride = 1)
+{
+    occg_header oh{};
+    oh.width = w; oh.height = h; oh.resolution_mm = 50; oh.cell_stride = cell_stride;
+    oh.origin_x_mm = 0; oh.origin_y_mm = -(int32_t)(h * 50 / 2);
+    oh.source_frame_id = 7; oh.timestamp_us = 123456789ULL;
+    oh.cell_count = (uint32_t)w * h;
+    std::vector<uint8_t> payload(sizeof(oh) + oh.cell_count);
+    std::memcpy(payload.data(), &oh, sizeof(oh));
+    auto* cells = (int8_t*)(payload.data() + sizeof(oh));
+    std::memset(cells, -1, oh.cell_count);
+    if (oh.cell_count >= 3) { cells[0] = 0; cells[1] = 100; cells[2] = 37; }
+
+    frame_header fh{};
+    fh.magic = MAGIC; fh.version = version; fh.data_type = data_type;
+    fh.flags = FLAG_CRC32; fh.payload_size = (uint32_t)payload.size();
+    fh.profile_id = 0x0201; fh.stream_generation = 1;
+    fh.crc32 = crc32_iso_hdlc(payload.data(), payload.size());
+    if (!valid_crc) fh.crc32 ^= 0xDEADBEEFU;
+
+    std::vector<uint8_t> frame(sizeof(fh) + payload.size());
+    std::memcpy(frame.data(), &fh, sizeof(fh));
+    std::memcpy(frame.data() + sizeof(fh), payload.data(), payload.size());
+    return frame;
+}
+}  // namespace
+
+TEST(OccupancyMap1, GoodOccgFrameParsesToHeaderAndCells)
+{
+    auto f = make_frame(320, 256);
+    occg_view v{};
+    ASSERT_EQ(parse_occg(f.data(), f.size(), &v), parse_result::ok);
+    EXPECT_EQ(v.header.width, 320);
+    EXPECT_EQ(v.header.height, 256);
+    EXPECT_EQ(v.header.resolution_mm, 50);
+    EXPECT_EQ(v.header.origin_y_mm, -6400);
+    EXPECT_EQ(v.header.cell_count, 81920u);
+    EXPECT_EQ(v.cells[0], 0);
+    EXPECT_EQ(v.cells[1], 100);
+    EXPECT_EQ(v.cells[2], 37);
+    EXPECT_EQ(v.cells[3], -1);
+}
+
+TEST(OccupancyMap1, NonMap1BytesAreNotMap1)
+{
+    std::vector<uint8_t> legacy(1063, 0xAB);   // D585S bit-packed grid, no magic
+    occg_view v{};
+    EXPECT_FALSE(is_map1(legacy.data(), legacy.size()));
+    EXPECT_EQ(parse_occg(legacy.data(), legacy.size(), &v), parse_result::not_map1);
+}
+
+TEST(OccupancyMap1, BadCrcIsRejected)
+{
+    auto f = make_frame(320, 256, /*valid_crc=*/false);
+    occg_view v{};
+    EXPECT_EQ(parse_occg(f.data(), f.size(), &v), parse_result::bad_crc);
+}
+
+TEST(OccupancyMap1, TruncatedPayloadIsRejected)
+{
+    auto f = make_frame(320, 256);
+    occg_view v{};
+    EXPECT_EQ(parse_occg(f.data(), f.size() - 100, &v), parse_result::truncated);
+}
+
+TEST(OccupancyMap1, CellCountInconsistentWithWidthHeightIsRejected)
+{
+    // width/height (which size the destination buffer) and cell_count (which sizes
+    // the memcpy out of the parsed view) are independent device-controlled fields.
+    // Craft a frame that is otherwise well-formed -- payload big enough to satisfy
+    // the truncated check, FLAG_CRC32 clear so the mismatch isn't masked by/coupled
+    // to a CRC failure -- purely to isolate the geometry cross-check.
+    const uint16_t w = 4, h = 4;               // declares a 16-cell (4x4) grid...
+    occg_header oh{};
+    oh.width = w; oh.height = h; oh.resolution_mm = 50; oh.cell_stride = 1;
+    oh.origin_x_mm = 0; oh.origin_y_mm = 0;
+    oh.source_frame_id = 1; oh.timestamp_us = 1;
+    oh.cell_count = 1000;                      // ...but claims 1000 cells of payload.
+    std::vector<uint8_t> payload(sizeof(oh) + oh.cell_count, 0);
+    std::memcpy(payload.data(), &oh, sizeof(oh));
+
+    frame_header fh{};
+    fh.magic = MAGIC; fh.version = 0x0100; fh.data_type = DATA_TYPE_OCCG;
+    fh.flags = 0;  // FLAG_CRC32 clear: the CRC path must not be what catches this.
+    fh.payload_size = (uint32_t)payload.size();
+    fh.profile_id = 0x0201; fh.stream_generation = 1;
+    fh.crc32 = 0;
+
+    std::vector<uint8_t> frame(sizeof(fh) + payload.size());
+    std::memcpy(frame.data(), &fh, sizeof(fh));
+    std::memcpy(frame.data() + sizeof(fh), payload.data(), payload.size());
+
+    occg_view v{};
+    EXPECT_EQ(parse_occg(frame.data(), frame.size(), &v), parse_result::bad_geometry);
+}
+
+TEST(OccupancyMap1, CrcReferenceVector)
+{
+    // CRC-32/ISO-HDLC ("123456789") == 0xCBF43926 -- pins the polynomial/reflection.
+    EXPECT_EQ(crc32_iso_hdlc("123456789", 9), 0xCBF43926u);
+}
+
+TEST(OccupancyMap1, GoldenFrameDecodesCellsInRowMajorOrder)
+{
+    // Golden frame: a small 4(forward/width) x 3(lateral/height) grid with a distinct
+    // value at each corner + one interior cell, so the byte<->position contract and the
+    // axis convention (X forward along width, Y lateral, data[cy*width+cx] row-major) are
+    // pinned. A future struct-packing/offset/axis change breaks this loudly, catching the
+    // "valid CRC but mirrored/rotated grid" failure mode CRC/bounds checks cannot.
+    const uint16_t W = 4, H = 3;
+    occg_header oh{};
+    oh.width = W; oh.height = H; oh.resolution_mm = 50; oh.cell_stride = 1;
+    oh.origin_x_mm = 0; oh.origin_y_mm = -(int32_t)(H * 50 / 2);   // lateral-centered = -75
+    oh.source_frame_id = 7; oh.timestamp_us = 42ULL;
+    oh.cell_count = (uint32_t)W * H;                               // 12
+
+    int8_t grid[W * H];
+    std::memset(grid, -1, sizeof(grid));                          // default unknown
+    grid[0 * W + 0] = 0;      // (cx=0, cy=0) free
+    grid[0 * W + 3] = 100;    // (cx=3, cy=0) occupied
+    grid[2 * W + 0] = 42;     // (cx=0, cy=2) graded
+    grid[2 * W + 3] = 7;      // (cx=3, cy=2) graded
+    grid[1 * W + 2] = 0;      // (cx=2, cy=1) interior free
+
+    std::vector<uint8_t> payload(sizeof(oh) + oh.cell_count);
+    std::memcpy(payload.data(), &oh, sizeof(oh));
+    std::memcpy(payload.data() + sizeof(oh), grid, sizeof(grid));
+
+    frame_header fh{};
+    fh.magic = MAGIC; fh.version = 0x0100; fh.data_type = DATA_TYPE_OCCG;
+    fh.flags = FLAG_CRC32; fh.payload_size = (uint32_t)payload.size();
+    fh.profile_id = 0x0201; fh.stream_generation = 1;
+    fh.crc32 = crc32_iso_hdlc(payload.data(), payload.size());
+
+    std::vector<uint8_t> frame(sizeof(fh) + payload.size());
+    std::memcpy(frame.data(), &fh, sizeof(fh));
+    std::memcpy(frame.data() + sizeof(fh), payload.data(), payload.size());
+
+    occg_view v{};
+    ASSERT_EQ(parse_occg(frame.data(), frame.size(), &v), parse_result::ok);
+    // geometry + the frozen wire convention
+    EXPECT_EQ(v.header.width, W);
+    EXPECT_EQ(v.header.height, H);
+    EXPECT_EQ(v.header.origin_x_mm, 0);
+    EXPECT_EQ(v.header.origin_y_mm, -75);
+    EXPECT_EQ(v.header.cell_count, 12u);
+    // cells preserved byte-for-byte in row-major data[cy*width+cx] order
+    EXPECT_EQ(v.cells[0 * W + 0], 0);
+    EXPECT_EQ(v.cells[0 * W + 3], 100);
+    EXPECT_EQ(v.cells[2 * W + 0], 42);
+    EXPECT_EQ(v.cells[2 * W + 3], 7);
+    EXPECT_EQ(v.cells[1 * W + 2], 0);
+    EXPECT_EQ(v.cells[0 * W + 1], -1);   // an untouched cell stays unknown
+}


### PR DESCRIPTION
# Occupancy: parse self-describing MAP1 in-node + `~/occupancy_certainty`

## Summary

Moves occupancy post-processing out of the node and onto the camera. The
realsense2_camera node now **unpacks** what the D5xx firmware produces instead of
re-deriving it: it parses the self-describing **MAP1** occupancy payload in-node
(validated, CRC-checked), publishes the binarized grid on `~/occupancy` and the
graded per-cell confidence on a new `~/occupancy_certainty`. A single publisher
auto-detects three wire formats, so it works across firmware generations with no
SDK-version requirement beyond occupancy-stream support.

This replaces the previous in-node angular raycasting / FOV-masking / max-range
logic (that responsibility now lives in the camera), so the node
is a thin, well-bounded unpacker.

## How it works

```mermaid
flowchart TD
  F["occupancy frame bytes"] --> N{"raw_data null?"}
  N -->|yes| D1["drop"]
  N -->|no| M{"MAP1 magic?"}
  M -->|yes| P["parse_occg:<br/>CRC + geometry + bounds"]
  P -->|ok| S["splitCells"]
  P -->|invalid| D2["drop + throttled warn"]
  M -->|no| B{"size fits a byte grid?"}
  B -->|yes| BY["byte-legacy"] --> S
  B -->|no| BI["bit-legacy -> ~/occupancy only"]
  S --> O1["~/occupancy (binarized)"]
  S --> O2["~/occupancy_certainty (1..100)"]
```

**MAP1 frame** (self-describing, so geometry/origin travel with the data):

```
[ 20B frame_header ] magic "MAP1", version, data_type=OCCG, flags, payload_size,
                     profile_id, stream_generation, crc32
[ 32B occg_header  ] width(=forward X), height(=lateral Y), resolution_mm, cell_stride,
                     origin_x_mm, origin_y_mm, source_frame_id, timestamp_us, cell_count
[ int8 cells ...   ] row-major data[cy*width+cx];  -1 unknown / 0 free / 1..100 occupied
```

`splitCells` produces both outputs from the graded cells:

```
cell value   ~/occupancy (binary)                 ~/occupancy_certainty
  -1          -1 unknown                            -1
   0           0 free                                0
  1..100       100 if >= occupancy_occupied_threshold, else -1     the raw value
```

### Live in rviz

**`~/occupancy` and the new `~/occupancy_certainty` rendered together (D555):**

<img width="860" height="474" alt="rviz_new_certainty_topic" src="https://github.com/user-attachments/assets/0bf82361-d1db-49b8-9c24-f9bfc52ea058" />


## Changes

- **`occupancy_map1.h`** — table-free MAP1 parser: packed structs with size
  `static_assert`s, CRC-32/ISO-HDLC, and ordered bounds checks (frame length →
  payload_size → occg_header → `cell_count == width*height` geometry cross-check)
  that reject a malformed frame before any indexing.
- **`occupancy_grid_utils.h`** — `splitCells` (binarize + certainty split).
- **`base_realsense_node.cpp`** — `publishOccupancyFrame` three-carrier dispatch
  (MAP1 / byte-legacy / bit-legacy) + `publishOccupancyFromMap1`; drops invalid
  frames (never republished raw); removes the old raycasting/`occupancy_max_range`.
- **New topic** `~/occupancy_certainty` (byte-legacy + MAP1 formats); **new param**
  `occupancy_occupied_threshold` (default 100, range [1,100]).
- **Tests** — `test_occupancy_map1.cpp` (CRC reference vector, bad-CRC, truncated,
  geometry mismatch, and a **golden frame** pinning the byte↔position axis contract)
  and `test_occupancy_grid_utils.cpp`.

## Review feedback pre-empted

Concerns raised on the related producer PR (#461) and by the bots here, addressed:

- **Per-ray evidence, not global max** — decoding side has no raycasting; the
  camera owns it, and its FW PR keeps the per-ray bound.
- **Buffer-capacity / geometry validation before indexing** — `cell_count ==
  width*height` cross-check + size-ordered guards.
- **Integer-overflow** in the legacy path — bit-legacy now uses `size_t` for the
  size guard, `assign`, and index (matching the byte path).
- **Null data pointer** — guarded before all paths.
- **CRC-optional frames** — documented that production OCCG frames set `FLAG_CRC32`;
  a clear flag is trusted on geometry alone (still overflow-safe).

## Compatibility / breaking changes

- **Breaking for external subscribers of the old occupancy behavior:** in-node
  raycasting/FOV-masking and `occupancy_max_range` are removed; unknown/shadow
  semantics now come from the camera. `~/occupancy` message type is unchanged
  (`nav_msgs/OccupancyGrid`).
- **New topic** `~/occupancy_certainty` — additive; legacy 1-bit firmware publishes
  `~/occupancy` only.
- No SDK version requirement beyond occupancy-stream support (three-format auto-detect).

## Testing

- [x] `test_occupancy_map1` 7/7, `test_occupancy_grid_utils` 3/3
- [x] `colcon build --packages-select realsense2_camera` clean
- [x] Live on D555: `~/occupancy` + `~/occupancy_certainty` publish at ~18 Hz
      (occupancy stream enabled standalone)
- [x] README updated (new topic, param, three-format auto-detect)